### PR TITLE
HistoryComponentの枠組みのリファクタリング（続き）

### DIFF
--- a/app/components/person_history_component.html.erb
+++ b/app/components/person_history_component.html.erb
@@ -1,6 +1,3 @@
-<section>
-  <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">History</h2>
-  <div class="grid gap-6 relative before:absolute before:left-3 before:top-0 before:bottom-0 before:w-0.5 before:bg-slate-200 dark:before:bg-slate-700">
     <% @logs.each do |log| %>
       <div class="bg-slate-50 dark:bg-slate-900/50 rounded-2xl p-5 pl-10 relative border border-slate-100 dark:border-slate-700 hover:translate-x-1 transition-transform group">
         <div class="absolute left-[0.45rem] top-6 w-2.5 h-2.5 bg-person border-2 border-white dark:border-slate-800 rounded-full z-10 shadow-[0_0_0_2px_rgba(226,232,240,1)] dark:shadow-[0_0_0_2px_rgba(51,65,85,1)]"></div>
@@ -30,5 +27,3 @@
         </div>
       </div>
     <% end %>
-  </div>
-</section>

--- a/app/components/unit_history_component.html.erb
+++ b/app/components/unit_history_component.html.erb
@@ -1,6 +1,3 @@
-<section>
-  <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">History</h2>
-  <div class="grid gap-6 relative before:absolute before:left-3 before:top-0 before:bottom-0 before:w-0.5 before:bg-slate-200 dark:before:bg-slate-700">
     <% @logs.each do |log| %>
       <div class="bg-slate-50 dark:bg-slate-900/50 rounded-2xl p-5 pl-10 relative border border-slate-100 dark:border-slate-700 hover:translate-x-1 transition-transform group">
         <div class="absolute left-[0.45rem] top-6 w-2.5 h-2.5 bg-person border-2 border-white dark:border-slate-800 rounded-full z-10 shadow-[0_0_0_2px_rgba(226,232,240,1)] dark:shadow-[0_0_0_2px_rgba(51,65,85,1)]"></div>
@@ -25,5 +22,3 @@
         </div>
       </div>
     <% end %>
-  </div>
-</section>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -18,10 +18,17 @@
             ) %>
           <% end %>
 
-          <% if @resource.is_a?(Person) && @logs.present? %>
-            <%= render PersonHistoryComponent.new(person: @resource, logs: @logs) %>
-          <% elsif @resource.is_a?(Unit) && @history.present? %>
-            <%= render UnitHistoryComponent.new(unit: @resource, logs: @history) %>
+          <% if (@resource.is_a?(Person) && @logs.present?) || (@resource.is_a?(Unit) && @history.present?) %>
+            <section>
+              <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">History</h2>
+              <div class="grid gap-6 relative before:absolute before:left-3 before:top-0 before:bottom-0 before:w-0.5 before:bg-slate-200 dark:before:bg-slate-700">
+                <% if @resource.is_a?(Person) %>
+                  <%= render PersonHistoryComponent.new(person: @resource, logs: @logs) %>
+                <% elsif @resource.is_a?(Unit) %>
+                  <%= render UnitHistoryComponent.new(unit: @resource, logs: @history) %>
+                <% end %>
+              </div>
+            </section>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
## 概要
先のPRでマージ漏れしていた、ヒストリーコンポーネントの枠組みをView側に移動する変更です。

## 変更点
- `PersonHistoryComponent`, `UnitHistoryComponent` から枠（section, h2, div）を削除
- `profiles/show.html.erb` に共通の枠を追加

これにより、コンポーネントの責務がより明確になり、コードの重複が排除されました。