### PR TITLE
Refactor history components and add status alias

### DIFF
--- a/app/models/person_log.rb
+++ b/app/models/person_log.rb
@@ -51,6 +51,6 @@ class PersonLog < ApplicationRecord
   }
 
   def status_text
-    STATUS_TRANSLATIONS[status] || status&.humanize
+    status_alias || STATUS_TRANSLATIONS[status] || status&.humanize
   end
 end

--- a/app/models/unit_log.rb
+++ b/app/models/unit_log.rb
@@ -35,6 +35,6 @@ class UnitLog < ApplicationRecord
   }
 
   def phenomenon_text
-    PHENOMENON_TRANSLATIONS[phenomenon] || phenomenon.humanize
+    status_alias || PHENOMENON_TRANSLATIONS[phenomenon] || phenomenon&.humanize
   end
 end

--- a/db/migrate/20260118135216_add_status_alias_to_person_logs_and_unit_logs.rb
+++ b/db/migrate/20260118135216_add_status_alias_to_person_logs_and_unit_logs.rb
@@ -1,0 +1,6 @@
+class AddStatusAliasToPersonLogsAndUnitLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :person_logs, :status_alias, :string
+    add_column :unit_logs, :status_alias, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_18_041805) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_18_135216) do
   create_table "links", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.boolean "active", default: true
     t.datetime "created_at", null: false
@@ -50,6 +50,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_18_041805) do
     t.bigint "person_id", null: false
     t.integer "sort_order"
     t.integer "status", null: false
+    t.string "status_alias"
     t.text "text"
     t.bigint "unit_id"
     t.string "unit_key"
@@ -64,6 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_18_041805) do
     t.datetime "created_at", null: false
     t.date "log_date"
     t.integer "phenomenon"
+    t.string "status_alias"
     t.text "text"
     t.bigint "unit_id", null: false
     t.datetime "updated_at", null: false

--- a/test/components/previews/person_history_item_component_preview.rb
+++ b/test/components/previews/person_history_item_component_preview.rb
@@ -24,4 +24,12 @@ class PersonHistoryItemComponentPreview < ViewComponent::Preview
 
     render(PersonHistoryItemComponent.new(log: log))
   end
+
+  def with_alias
+    person = Person.new(name: "Person Name", key: "person_key")
+    unit = Unit.new(name: "Unit Name", key: "unit_key")
+    log = PersonLog.new(log_date: Date.today, status: "leave", status_alias: "卒業", person: person, unit: unit)
+
+    render(PersonHistoryItemComponent.new(log: log))
+  end
 end

--- a/test/components/previews/unit_history_item_component_preview.rb
+++ b/test/components/previews/unit_history_item_component_preview.rb
@@ -23,4 +23,10 @@ class UnitHistoryItemComponentPreview < ViewComponent::Preview
 
     render(UnitHistoryItemComponent.new(log: log))
   end
+  def with_alias
+    unit = Unit.new(name: "Unit Name", key: "unit_key")
+    log = UnitLog.new(log_date: Date.today, phenomenon: "finish", status_alias: "集結")
+
+    render(UnitHistoryItemComponent.new(log: log))
+  end
 end


### PR DESCRIPTION
Refactors the history components by extracting individual items into `PersonHistoryItemComponent` and `UnitHistoryItemComponent`. This simplifies the structure and allows for cleaner iteration in the view.

Also implements a `status_alias` feature:
- Adds a `status_alias` column to `person_logs` and `unit_logs`.
- Updates models to prioritize `status_alias` when displaying status text.
- This allows custom text (e.g., "卒業" instead of "脱退") for specific logs.

Resolves lookbook preview errors and improves component modularity.