### PR TITLE
Fix NameError in Profile View

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,7 +22,7 @@
             <section>
               <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
                 <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">History</h2>
-                <% if @resource.is_a?(Person) && helpers.respond_to?(:logged_in?) && helpers.logged_in? %>
+                <% if @resource.is_a?(Person) && defined?(logged_in?) && logged_in? %>
                   <%= link_to "Edit", admin_person_person_logs_path(@resource), class: "text-xs font-medium text-slate-400 hover:text-indigo-500 transition-colors" %>
                 <% end %>
               </div>


### PR DESCRIPTION
Fixes a `NameError` in `profiles/show.html.erb` where `helpers.logged_in?` was called incorrectly.

Replaces `helpers.logged_in?` with `defined?(logged_in?) && logged_in?` to correctly check for the helper method availability in the view context.