### PR TITLE
docs: Add RuboCop execution requirement before push

### DIFF
--- a/.agent/GIT_WORKFLOW.md
+++ b/.agent/GIT_WORKFLOW.md
@@ -66,6 +66,16 @@ type: 簡潔な説明
 ### 3. リモートへのpush
 
 ```bash
+# **重要: push前に必ずRuboCopを実行**
+PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rubocop
+
+# エラーがある場合は自動修正
+PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rubocop -A
+
+# 修正があった場合は再度コミット
+git add -A
+git commit -m "style: Fix RuboCop offenses"
+
 # フィーチャーブランチをリモートにpush
 git push origin feat/feature-name
 ```
@@ -137,8 +147,8 @@ git push origin main --force
 push前に以下を確認:
 
 - [ ] **現在のブランチがmainではない**ことを確認（`git branch`）
+- [ ] **RuboCopを実行してエラーがない**（`bin/rubocop`）
 - [ ] ローカルでテストが通る
-- [ ] RuboCopエラーがない（`bin/rubocop`）
 
 ---
 


### PR DESCRIPTION
## 概要

push前にRuboCopを必ず実行することをGIT_WORKFLOW.mdに明記しました。

## 変更内容

### リモートへのpushセクション
- RuboCop実行手順を追加
- 自動修正（`-A`）の手順を追加
- 修正があった場合の再コミット手順を追加

### チェックリスト
- RuboCopチェックを最優先項目として強調
- 順序を変更してRuboCopを2番目に配置

## 目的

- コード品質の維持
- CIでのlintエラーを事前に防止
- レビュー時間の短縮

これにより、push前に必ずRuboCopを実行する習慣が身につきます。