### PR TITLE
feat: Import past members as status: left

### DIFF
--- a/lib/tasks/import_wikipage.rb
+++ b/lib/tasks/import_wikipage.rb
@@ -223,7 +223,7 @@ ActiveRecord::Base.transaction do
   wiki_content.scan(member_regex) do |match|
     match_data = Regexp.last_match
     current_pos = match_data.begin(0)
-    
+
     # Check if this member is after the separator
     member_status = current_pos > separator_index ? :left : :active
 


### PR DESCRIPTION
## 概要

Wiki内

## 実装の詳細

- `import_wikipage.rb` で
- メンバーの出現位置がその行より後ろであれば、ステータスを `:left` に設定します。
- それより前のメンバーはデフォルトの `:active` です。

## 検証結果

DEXCORE (ID: 15542) で確認。
- 3名が `:active`
- 5名が `:left`
として正しくインポートされました。