### PR TITLE
fix: 日本語ユニット名のキー生成ロジックを修正

### DIFF
--- a/lib/tasks/import_wikipage.rb
+++ b/lib/tasks/import_wikipage.rb
@@ -168,11 +168,9 @@ ActiveRecord::Base.transaction do
     # Convert Kana to Romaji
     source_for_key = Romaji.kana2romaji(unit_name_kana)
   else
-    # Fallback: Can't convert safely without kana. Use encoded? Or try to convert name?
-    # Romaji gem might handle Kanji? No, usually expect Kana.
-    # Just use encoded old key as fallback? No readability.
-    # Let's try name as is (Rails param handling might percent encode it)
-    source_for_key = wikipage_name
+    # Fallback: Can't convert safely without kana. Use encoded old_key
+    # Use encoded old_key (without percent signs for readability/safety)
+    source_for_key = encoded_old_key.gsub(/%/, "")
   end
 
   unit_key = source_for_key.downcase.gsub(/\s+/, "-")

--- a/lib/tasks/wikipage_parser.rb
+++ b/lib/tasks/wikipage_parser.rb
@@ -229,8 +229,8 @@ module WikipageParser
         # Convert Kana to Romaji
         source_for_key = Romaji.kana2romaji(unit_name_kana)
       else
-        # Fallback to original name
-        source_for_key = wikipage_name
+        # Fallback to encoded old_key (without percent signs) to ensure ASCII
+        source_for_key = encode_euc_jp_url(wikipage_name).gsub(/%/, "")
       end
 
       source_for_key.downcase.gsub(/\s+/, "-")


### PR DESCRIPTION
## 概要
日本語を含むユニット名のインポート時に、キーが正しくASCII化されない問題を修正しました。フリガナがない場合、old_key（EUC-JPエンコード）を利用してASCIIキーを生成するように変更しました。

## 変更点
- import_wikipage.rb: 日本語のwikipage_nameをそのままキーとして使用しないように修正
- wikipage_parser.rb: generate_unit_keyメソッドも同様に修正