### PR TITLE
feat: Person編集ページにPerson Logs一覧へのリンクを追加

### DIFF
--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -21,7 +21,10 @@
   <div class="mt-6">
     <div class="sm:flex sm:items-center justify-between mb-4">
       <h2 class="text-xl font-bold dark:text-white">Career Logs</h2>
-      <%= link_to "Add Person Log", new_admin_person_person_log_path(@person), class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto" %>
+      <div class="flex gap-2">
+        <%= link_to "View All Logs", admin_person_person_logs_path(@person), class: "inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-600" %>
+        <%= link_to "Add Person Log", new_admin_person_person_log_path(@person), class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto" %>
+      </div>
     </div>
     <%= render "admin/person_logs/list", person: @person, person_logs: @person_logs %>
   </div>


### PR DESCRIPTION
## 概要
Person編集ページのCareer Logsセクションに「View All Logs」ボタンを追加し、Person Logs一覧ページへの導線を改善しました。

## 変更内容
- Career Logsセクションのヘッダーに「View All Logs」リンクを追加
- 既存の「Add Person Log」ボタンと並べて配置
- 「View All Logs」はセカンダリボタン、「Add Person Log」はプライマリボタンとして表示

## 効果
Person編集画面から、Wiki経歴のパース機能がある Person Logs 一覧ページに簡単に移動できるようになります。