### PR TITLE
feat: PersonLogにunit_urlカラムを追加

### DIFF
--- a/app/controllers/admin/person_logs_controller.rb
+++ b/app/controllers/admin/person_logs_controller.rb
@@ -61,7 +61,7 @@ module Admin
 
     def person_log_params
       params.require(:person_log).permit(:log_date, :phenomenon, :phenomenon_alias, :unit_id, :unit_name, :unit_key,
-                                         :name, :part, :text, :source_url, :quote_text)
+                                         :name, :part, :text, :source_url, :quote_text, :unit_url)
     end
   end
 end

--- a/app/views/admin/person_logs/_form.html.erb
+++ b/app/views/admin/person_logs/_form.html.erb
@@ -86,6 +86,12 @@
     <%= form.text_field :source_url, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
   </div>
 
+  <div>
+    <%= form.label :unit_url, "Unit URL (External Link)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <%= form.text_field :unit_url, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">URL to external site (e.g., official website, social media) if the unit is not managed in vkdby.</p>
+  </div>
+
   <div class="flex justify-end gap-x-4">
     <%= link_to "Cancel", admin_person_person_logs_path(person), class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
     <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>

--- a/db/migrate/20260125155202_add_unit_url_to_person_logs.rb
+++ b/db/migrate/20260125155202_add_unit_url_to_person_logs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUnitUrlToPersonLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :person_logs, :unit_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_25_135338) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_25_155202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -64,6 +64,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_25_135338) do
     t.bigint "unit_id"
     t.string "unit_key"
     t.string "unit_name"
+    t.string "unit_url"
     t.datetime "updated_at", null: false
     t.index ["person_id", "sort_order"], name: "index_person_logs_on_person_id_and_sort_order"
     t.index ["person_id"], name: "index_person_logs_on_person_id"


### PR DESCRIPTION
## 概要
外部サイトへのリンクを保存するため、`person_logs`テーブルに`unit_url`カラムを追加しました。

## 変更内容
- `person_logs`テーブルに`unit_url` (string)カラムを追加
- コントローラーのストロングパラメータに`unit_url`を追加
- Person Logフォームに「Unit URL (External Link)」フィールドを追加

## 用途
vkdbyで管理していないユニットの場合、外部サイト（公式サイト、SNSなど）へのリンクを保存できるようになります。

## 備考
- `source_url`は情報源（ニュース記事など）用
- `unit_url`は関連リンク（公式サイトなど）用として使い分けます