### PR TITLE
feat: Add note column to people and units

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -53,7 +53,7 @@ module Admin
 
     def person_params
       params.require(:person).permit(
-        :name, :name_kana, :birthday, :birth_year, :blood, :hometown, :status, :old_history,
+        :name, :name_kana, :birthday, :birth_year, :blood, :hometown, :status, :old_history, :note,
         parts: [],
         links_attributes: %i[id text url active _destroy],
         name_logs_attributes: %i[name name_kana]

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -58,7 +58,7 @@ module Admin
     end
 
     def unit_params
-      params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key,
+      params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key, :note,
                                    links_attributes: %i[id text url active sort_order _destroy],
                                    name_logs_attributes: %i[name name_kana])
     end

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -124,6 +124,12 @@
     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Wiki形式の経歴テキスト</p>
   </div>
 
+  <div>
+    <%= form.label :note, "Note", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <%= form.text_area :note, rows: 5, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">管理用メモ</p>
+  </div>
+
   <div class="flex justify-end gap-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
     <%= link_to "Cancel", admin_people_path, class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
     <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -77,6 +77,12 @@
     </div>
   </div>
 
+  <div>
+    <%= form.label :note, "Note", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <%= form.text_area :note, rows: 5, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">管理用メモ</p>
+  </div>
+
 
 
   <div class="flex justify-end gap-x-4">

--- a/db/migrate/20260126152355_add_note_to_people_and_units.rb
+++ b/db/migrate/20260126152355_add_note_to_people_and_units.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddNoteToPeopleAndUnits < ActiveRecord::Migration[8.1]
+  def change
+    add_column :people, :note, :text
+    add_column :units, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_25_155202) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_26_152355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -37,6 +37,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_25_155202) do
     t.string "name"
     t.string "name_kana"
     t.jsonb "name_log"
+    t.text "note"
     t.text "old_history"
     t.string "old_key"
     t.text "old_wiki_text"
@@ -110,6 +111,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_25_155202) do
     t.string "name"
     t.string "name_kana"
     t.jsonb "name_log"
+    t.text "note"
     t.string "old_key"
     t.text "old_wiki_text"
     t.integer "status", default: 1, null: false


### PR DESCRIPTION
Overview:
Adds a `note` column to both `people` and `units` tables to store administrative notes.
Enables editing of these notes in the admin interface.

Changes:
- DB Migration: Add `note` (text) column to `people` and `units`
- Controller: Update strong parameters in `Admin::PeopleController` and `Admin::UnitsController`
- View: Add note text area to `admin/people/_form.html.erb` and `admin/units/_form.html.erb`