### PR TITLE
fix: Use DATABASE_URL in database.yml for production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -78,10 +78,10 @@ test:
 #
 production:
   primary: &primary_production
-    <<: *default
-    database: vkdby_production
-    username: vkdby
-    password: <%= ENV["VKDBY_DATABASE_PASSWORD"] %>
+    adapter: postgresql
+    encoding: unicode
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+    url: <%= ENV["DATABASE_URL"] %>
   cache:
     <<: *primary_production
     database: vkdby_production_cache


### PR DESCRIPTION
Renderデプロイ時に接続エラーが発生するため、production環境では明示的に `DATABASE_URL` を使用し、ローカル設定（localhostなど）を継承しないように修正しました。