### PR TITLE
fix: Explicitly specify adapter in database.yml production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -75,5 +75,8 @@ test:
 #
 # Production configuration
 production:
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   url: <%= ENV["DATABASE_URL"] %>
 


### PR DESCRIPTION
Railsがadapterを認識できないエラーを修正するため、production環境の設定に `adapter: postgresql` を明示的に追加しました。