### PR TITLE
fix: Move DB migrations and seed to startCommand

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -5,5 +5,3 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate
-bundle exec rails db:seed

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
     name: vkdby
     runtime: ruby
     buildCommand: "./bin/render-build.sh"
-    startCommand: "bundle exec rails server"
+    startCommand: "bundle exec rails db:migrate && bundle exec rails db:seed && bundle exec rails server"
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
Renderのビルドプロセスではデータベース接続が確立されていない可能性があるため、`db:migrate` と `db:seed` を `render.yaml` の `startCommand` に移動しました。