### PR TITLE
fix: Limit automatic db:prepare in docker-entrypoint

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 
-# If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
-  ./bin/rails db:prepare
-fi
+# if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+#   ./bin/rails db:prepare
+# fi
 
 exec "${@}"


### PR DESCRIPTION
> デプロイエラーの根本原因は bin/docker-entrypoint が自動的に db:prepare を実行しようとしていたことでした。 Renderの環境（特にDockerデプロイ時）では、このタイミングでデータベース接続が確立できない場合があり、また startCommand 側でもDB操作を行っているため競合していました。
>
> 修正: bin/docker-entrypoint 内の自動 db:prepare 実行処理をコメントアウトしました。 これにより、render.yaml の startCommand で指定した順序（db:migrate -> db:seed -> server）でのみDB操作が行われるようになります。