### PR TITLE
fix: Force tailwind build in render-build.sh

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,5 +3,6 @@
 set -o errexit
 
 bundle install
+bundle exec rails tailwindcss:build
 bundle exec rails assets:precompile
 bundle exec rails assets:clean


### PR DESCRIPTION
Render環境で assets:precompile 時に Tailwind のビルドが正しく行われていない可能性があるため、明示的に tailwindcss:build を実行するようにしました。