### PR TITLE
fix: Move tailwindcss-rails to global Gemfile group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,8 @@ gem 'bootsnap', require: false
 gem 'kamal', require: false
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
-gem 'thruster', require: false
 gem 'tailwindcss-rails'
+gem 'thruster', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 1.2'


### PR DESCRIPTION
Renderの本番環境でも `tailwindcss:build` コマンドを実行できるようにするため、`tailwindcss-rails` gem をdevelopmentグループからグローバルグループに移動しました。