### PR TITLE
fix/importer: preserve full category path in tag_indices

### DIFF
--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -205,7 +205,7 @@ class PersonImporter
       next if cat_raw.match?(%r{^(誕生日|誕生年)/})
 
       # Normalize category name
-      index_name = cat_raw.split('/').last.strip
+      index_name = cat_raw.strip
 
       tag_index = TagIndex.find_or_create_by(name: index_name)
       TagIndexItem.create!(

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -154,7 +154,7 @@ class WikipageImporter
     unit.tag_index_items.destroy_all
 
     categories.each do |cat_raw|
-      index_name = cat_raw.split('/').last.strip
+      index_name = cat_raw.strip
       tag_index = TagIndex.find_or_create_by(name: index_name)
       TagIndexItem.create!(
         tag_index: tag_index,


### PR DESCRIPTION
Retain the full category name (e.g., 'Parent/Child') instead of using only the last segment.