### PR TITLE
feat: Link existing UnitPerson records on Person import

### DIFF
--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -139,6 +139,9 @@ class PersonImporter
     # Save Person
     person.save!
 
+    # 2.5 Link existing UnitPerson records
+    link_existing_unit_people(person)
+
     # 3. Associate TagIndex (Categories)
     update_tag_indices(person, categories_data[:raw_categories])
 
@@ -147,6 +150,12 @@ class PersonImporter
 
     # 5. Parse Career History
     parse_career_history(person)
+  end
+
+  def link_existing_unit_people(person)
+    return if person.old_key.blank?
+
+    UnitPerson.where(old_person_key: person.old_key).update_all(person_id: person.id, person_key: person.key)
   end
 
   def parse_categories_data

--- a/script/verify_unit_person_linking.rb
+++ b/script/verify_unit_person_linking.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+
+puts '== Starting UnitPerson Linking Verification =='
+
+# 1. Setup Test Data
+puts "\n[1] Setting up test data..."
+unit_name = "TestUnit_#{Time.now.to_i}"
+unit = Unit.create!(name: unit_name, key: unit_name.downcase)
+
+person_name = "TestPerson_#{Time.now.to_i}"
+old_key_raw = "テスト個人_#{Time.now.to_i}"
+encoded_old_key = URI.encode_www_form_component(old_key_raw.encode('EUC-JP'))
+
+# Create UnitPerson with matching old_person_key but NO link
+up = UnitPerson.create!(
+  unit: unit,
+  person_name: person_name,
+  old_person_key: encoded_old_key,
+  part: :vocal,
+  status: :active
+)
+
+puts "Created UnitPerson (ID: #{up.id})"
+puts "  - old_person_key: #{up.old_person_key}"
+puts "  - person_id: #{up.person_id.inspect}"
+puts "  - person_key: #{up.person_key.inspect}"
+
+# Create Wikipage for the Person
+wiki_content = <<~WIKI
+  #{old_key_raw}（#{old_key_raw}）
+  {{category 個人}}
+  {{category 誕生日/1/1}}
+WIKI
+
+wikipage = Wikipage.create!(
+  name: old_key_raw, # old_key matches here
+  title: old_key_raw,
+  wiki: wiki_content
+)
+
+puts "Created Wikipage (ID: #{wikipage.id}, Name: #{wikipage.name})"
+
+# 2. Run Import
+puts "\n[2] Running PersonImporter..."
+begin
+  PersonImporter.import(wikipage)
+rescue StandardError => e
+  puts "Import failed: #{e.message}"
+  puts e.backtrace.join("\n")
+end
+
+# 3. Verify Result
+puts "\n[3] Verifying results..."
+up.reload
+person = Person.find_by(old_key: encoded_old_key)
+
+if person
+  puts "Created Person (ID: #{person.id}, Key: #{person.key})"
+else
+  puts 'ERROR: Person not found!'
+  exit 1
+end
+
+puts 'Updated UnitPerson:'
+puts "  - person_id: #{up.person_id.inspect} (Expected: #{person.id})"
+puts "  - person_key: #{up.person_key.inspect} (Expected: #{person.key})"
+
+if up.person_id == person.id && up.person_key == person.key
+  puts "\nSUCCESS: UnitPerson was correctly linked to the imported Person!"
+else
+  puts "\nFAILURE: UnitPerson was NOT correctly linked."
+  exit 1
+end


### PR DESCRIPTION
## 概要
- 個人データ (`Person`) のインポート時に、既に存在する `UnitPerson` レコードとの紐付けを行う機能を追加しました。
- `old_key` (EUC-JP エンコードされた文字列) をキーとしてマッチングを行います。
- 一部のユニット（Psycho le Cemu等）で採用されている `![[Name]]…Part` 形式のメンバー定義が取り込まれない問題を修正しました。

## 詳細
- `PersonImporter` に `link_existing_unit_people` メソッドを追加し、インポート後の紐付けを実現。
- `WikipageImporter` の `valid_unit?` および `parse_members` を更新し、メンバー定義の順序が逆転している形式にも対応。
- 全体的な Lint エラー（RuboCop）を解消。

## 検証
- `script/verify_unit_person_linking.rb` による動作確認済み。
- `WikipageImporter.valid_unit?` が Psycho le Cemu (ID: 6446) に対して `true` を返すことを確認済み。
