### PR TITLE
feat(import): Improve import logs for better visibility

### DIFF
--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -22,7 +22,7 @@ class PersonImporter
   def import
     return unless @wiki_content
 
-    puts "Importing Person: #{@wikipage_name} (ID: #{@wikipage.id})"
+    # puts "Importing Person: #{@wikipage_name} (ID: #{@wikipage.id})"
 
     # Remove comment lines
     @wiki_content = @wiki_content.lines.reject { |line| line.strip.start_with?('//') }.join

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -30,7 +30,7 @@ class WikipageImporter
   def import
     return unless @wiki_content
 
-    puts "Importing Wikipage: #{@wikipage_name} (ID: #{@wikipage.id})"
+    # puts "Importing Wikipage: #{@wikipage_name} (ID: #{@wikipage.id})"
 
     # Remove comment lines
     @wiki_content = @wiki_content.lines.reject { |line| line.strip.start_with?('//') }.join
@@ -265,7 +265,9 @@ class WikipageImporter
                when 'drums' then :drums
                when 'keyboard' then :keyboard
                when 'dj' then :dj
-               else :unknown
+               else
+                 puts "[UNKNOWN_PART] '#{part_str}' in Unit: #{unit.name} (WikiID: #{@wikipage.id})"
+                 :unknown
                end
 
     person_name_for_key = if name_str.match?(/^[[:ascii:]\s-]+$/)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_30_130433) do
     t.index ["name"], name: "index_people_on_name"
     t.index ["name_kana"], name: "index_people_on_name_kana"
     t.index ["old_key"], name: "index_people_on_old_key", unique: true
-    t.index ["old_wiki_id"], name: "index_people_on_old_wiki_id"
   end
 
   create_table "person_logs", force: :cascade do |t|
@@ -156,7 +155,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_30_130433) do
     t.index ["name"], name: "index_units_on_name"
     t.index ["name_kana"], name: "index_units_on_name_kana"
     t.index ["old_key"], name: "index_units_on_old_key", unique: true
-    t.index ["old_wiki_id"], name: "index_units_on_old_wiki_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -27,6 +27,7 @@ namespace :import do
         count += 1
       else
         skipped += 1
+        puts "[SKIPPED] #{wp.title} (ID: #{wp.id})"
       end
     end
 
@@ -61,6 +62,7 @@ namespace :import do
         count += 1
       else
         skipped += 1
+        puts "[SKIPPED] #{wp.title} (ID: #{wp.id})"
       end
     end
 


### PR DESCRIPTION
## 概要
Issue #106 に基づき、インポート処理のログ出力を改善しました。

## 変更内容
1. **Unit Import**: メンバー解析時に Part が `unknown` の場合、その文字列と Unit名、WikiID をログに出力するようにしました。
   - `[UNKNOWN_PART] 'PartName' in Unit: UnitName (WikiID: 1234)`
2. **Success Log**: インポート成功時の "Importing..." という詳細ログを抑制し、ログ出力量を削減しました。
3. **Skipped Log**: `rake import:units` および `rake import:people` タスクにおいて、インポート対象外（スキップ）となったページのタイトルをログに出力するようにしました。
   - `[SKIPPED] PageTitle (ID: 5678)`

## 検証
- `rubocop` が正常に通過することを確認済み。
