### PR TITLE
feat(import): Automatically detect and flag support members

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -258,7 +258,10 @@ class WikipageImporter
   # rubocop:disable Metrics/ParameterLists
   def register_member(unit, part_str, name_str, old_member_key, sns_account, inline_history, member_status)
     # rubocop:enable Metrics/ParameterLists
-    part_key = case part_str.downcase
+    is_support = part_str.to_s.match?(/support|サポート/i)
+    cleaned_part_str = part_str.to_s.gsub(/support|サポート/i, '').strip
+
+    part_key = case cleaned_part_str.downcase
                when 'vocal' then :vocal
                when 'guitar' then :guitar
                when 'bass' then :bass
@@ -266,7 +269,7 @@ class WikipageImporter
                when 'keyboard' then :keyboard
                when 'dj' then :dj
                else
-                 puts "[UNKNOWN_PART] '#{part_str}' in Unit: #{unit.name} (WikiID: #{@wikipage.id})"
+                 puts "[UNKNOWN_PART] '#{cleaned_part_str}' in Unit: #{unit.name} (WikiID: #{@wikipage.id})" unless cleaned_part_str.blank?
                  :unknown
                end
 
@@ -303,6 +306,7 @@ class WikipageImporter
     up.person_key = person_key unless person.present?
     up.part = part_key
     up.status = member_status
+    up.support = is_support
     up.old_person_key = old_member_key
     up.inline_history = inline_history
     up.sns = [sns_account.strip] if sns_account.present?

--- a/db/migrate/20260131020042_add_support_to_unit_people.rb
+++ b/db/migrate/20260131020042_add_support_to_unit_people.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSupportToUnitPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_column :unit_people, :support, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_30_130433) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_31_020042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -130,6 +130,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_30_130433) do
     t.string "person_name"
     t.json "sns"
     t.integer "status", default: 1, null: false
+    t.boolean "support", default: false, null: false
     t.bigint "unit_id", null: false
     t.datetime "updated_at", null: false
     t.index ["old_person_key"], name: "index_unit_people_on_old_person_key"

--- a/script/verify_support_member_import.rb
+++ b/script/verify_support_member_import.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+
+puts '== Starting Support Member Import Verification =='
+
+# 1. Create Test Data
+puts "\n[1] Creating test Wikipage..."
+wiki_content = <<~WIKI
+  SupportUnitTest(SupportUnitTest)
+  {{category Band}}
+  !Support Drums… [[SupportDrummer]]
+  !サポート Guitar… [[SupportGuitarist]]
+  !Vocal… [[RegularVocalist]]
+WIKI
+
+wp = Wikipage.create!(name: "SupportUnitTest_#{Time.now.to_i}", title: 'SupportUnitTest', wiki: wiki_content)
+
+# 2. Run Import
+puts "\n[2] Running WikipageImporter..."
+WikipageImporter.import(wp)
+
+# 3. Verify Results
+puts "\n[3] Verifying results..."
+
+puts "Debug: Units: #{Unit.where('name LIKE ?', 'SupportUnitTest%').pluck(:id, :name, :key)}"
+unit = Unit.find_by(old_wiki_id: wp.id)
+if unit
+  puts "Debug: UnitPeople: #{unit.unit_people.pluck(:person_name, :part, :support)}"
+else
+  puts 'Debug: Unit not found'
+end
+
+unless unit
+  puts 'ERROR: Unit not found!'
+  exit 1
+end
+
+# Check Support Drummer
+drummer = unit.unit_people.find_by(person_name: 'SupportDrummer')
+if drummer
+  puts "Drummer: part=#{drummer.part}, support=#{drummer.support}"
+  if drummer.part == 'drums' && drummer.support == true
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: SupportDrummer not found'
+end
+
+# Check Support Guitarist
+guitarist = unit.unit_people.find_by(person_name: 'SupportGuitarist')
+if guitarist
+  puts "Guitarist: part=#{guitarist.part}, support=#{guitarist.support}"
+  if guitarist.part == 'guitar' && guitarist.support == true
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: SupportGuitarist not found'
+end
+
+# Check Regular Vocalist
+vocalist = unit.unit_people.find_by(person_name: 'RegularVocalist')
+if vocalist
+  puts "Vocalist: part=#{vocalist.part}, support=#{vocalist.support}"
+  if vocalist.part == 'vocal' && vocalist.support == false
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: RegularVocalist not found'
+end


### PR DESCRIPTION
## 概要
Issue #108 に基づき、ユニットメンバーの「サポート」区分をインポート時に自動判定する機能を追加しました。

## 変更内容
1. **DB Schema**: `unit_people` テーブルに `support` カラム (boolean, default: false) を追加。
2. **Importer Logic**: `WikipageImporter` において、メンバーのパート表記に「Support」または「サポート」が含まれる場合、以下の処理を行うように修正：
   - `UnitPerson` の `support` フラグを `true` に設定。
   - パート表記から「Support/サポート」を除去し、正規化されたパート名（例: "Support Drums" -> "drums"）として登録。

## 検証
- 検証用スクリプト `script/verify_support_member_import.rb` を作成し、以下の動作を確認済み：
  - "Support Drums" -> `part: :drums`, `support: true`
  - "サポート Guitar" -> `part: :guitar`, `support: true`
  - "Vocal" -> `part: :vocal`, `support: false`
