### PR TITLE
feat(import): Improve part parsing and save unknown aliases

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -258,8 +258,10 @@ class WikipageImporter
   # rubocop:disable Metrics/ParameterLists
   def register_member(unit, part_str, name_str, old_member_key, sns_account, inline_history, member_status)
     # rubocop:enable Metrics/ParameterLists
-    is_support = part_str.to_s.match?(/support|サポート/i)
-    cleaned_part_str = part_str.to_s.gsub(/support|サポート/i, '').strip
+    # Clean up part string: remove leading '!' and support keywords
+    cleaned_part_str = part_str.to_s.sub(/^!/, '')
+    is_support = cleaned_part_str.match?(/support|サポート/i)
+    cleaned_part_str = cleaned_part_str.gsub(/support|サポート/i, '').strip
 
     part_key = case cleaned_part_str.downcase
                when 'vocal' then :vocal
@@ -272,6 +274,8 @@ class WikipageImporter
                  puts "[UNKNOWN_PART] '#{cleaned_part_str}' in Unit: #{unit.name} (WikiID: #{@wikipage.id})" unless cleaned_part_str.blank?
                  :unknown
                end
+
+    part_alias = part_key == :unknown && cleaned_part_str.present? ? cleaned_part_str : nil
 
     person_name_for_key = if name_str.match?(/^[[:ascii:]\s-]+$/)
                             name_str
@@ -307,6 +311,7 @@ class WikipageImporter
     up.part = part_key
     up.status = member_status
     up.support = is_support
+    up.part_alias = part_alias if part_alias
     up.old_person_key = old_member_key
     up.inline_history = inline_history
     up.sns = [sns_account.strip] if sns_account.present?

--- a/db/migrate/20260131022340_add_part_alias_to_unit_people.rb
+++ b/db/migrate/20260131022340_add_part_alias_to_unit_people.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPartAliasToUnitPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_column :unit_people, :part_alias, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_31_020042) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_31_022340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -124,6 +124,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_020042) do
     t.string "old_person_key"
     t.integer "order_in_period", default: 1, null: false
     t.integer "part", default: 0, null: false
+    t.string "part_alias"
     t.integer "period", default: 1, null: false
     t.bigint "person_id"
     t.string "person_key"

--- a/script/verify_part_improvements.rb
+++ b/script/verify_part_improvements.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative '../config/environment'
+
+puts '== Starting Part Import Improvements Verification =='
+
+# 1. Create Test Data
+puts "\n[1] Creating test Wikipage..."
+wiki_content = <<~WIKI
+  PartTestUnit(PartTestUnit)
+  {{category Band}}
+  !Vocal… [[BangVocal]]
+  !UnknownPart… [[BangUnknown]]
+  !MyUnknownPart… [[PlainUnknown]]
+  !Support Unknown… [[BangSupportUnknown]]
+WIKI
+
+wp = Wikipage.create!(name: "PartTestUnit_#{Time.now.to_i}", title: 'PartTestUnit', wiki: wiki_content)
+
+# 2. Run Import
+puts "\n[2] Running WikipageImporter..."
+WikipageImporter.import(wp)
+
+# 3. Verify Results
+puts "\n[3] Verifying results..."
+unit = Unit.find_by(old_wiki_id: wp.id)
+
+unless unit
+  puts "Debug: All Units: #{Unit.where('name LIKE ?', 'PartTestUnit%').pluck(:id, :name, :old_wiki_id)}"
+  puts 'ERROR: Unit not found!'
+  exit 1
+end
+
+puts "Debug: UnitPeople: #{unit.unit_people.pluck(:person_name, :part, :part_alias, :support)}"
+
+# Check !Vocal -> part: :vocal, alias: nil
+bang_vocal = unit.unit_people.find_by(person_name: 'BangVocal')
+if bang_vocal
+  puts "BangVocal: part=#{bang_vocal.part}, alias=#{bang_vocal.part_alias.inspect}"
+  if bang_vocal.part == 'vocal' && bang_vocal.part_alias.nil?
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: BangVocal not found'
+end
+
+# Check !UnknownPart -> part: :unknown, alias: "UnknownPart" (bang removed)
+bang_unknown = unit.unit_people.find_by(person_name: 'BangUnknown')
+if bang_unknown
+  puts "BangUnknown: part=#{bang_unknown.part}, alias=#{bang_unknown.part_alias.inspect}"
+  if bang_unknown.part == 'unknown' && bang_unknown.part_alias == 'UnknownPart'
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: BangUnknown not found'
+end
+
+# Check MyUnknownPart -> part: :unknown, alias: "MyUnknownPart"
+plain_unknown = unit.unit_people.find_by(person_name: 'PlainUnknown')
+if plain_unknown
+  puts "PlainUnknown: part=#{plain_unknown.part}, alias=#{plain_unknown.part_alias.inspect}"
+  if plain_unknown.part == 'unknown' && plain_unknown.part_alias == 'MyUnknownPart'
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: PlainUnknown not found'
+end
+
+# Check !Support Unknown -> part: :unknown, alias: "Unknown" (bang and support removed), support: true
+bang_support_unknown = unit.unit_people.find_by(person_name: 'BangSupportUnknown')
+if bang_support_unknown
+  puts "BangSupportUnknown: part=#{bang_support_unknown.part}, alias=#{bang_support_unknown.part_alias.inspect}, support=#{bang_support_unknown.support}"
+  if bang_support_unknown.part == 'unknown' && bang_support_unknown.part_alias == 'Unknown' && bang_support_unknown.support == true
+    puts '  -> OK'
+  else
+    puts '  -> FAIL'
+  end
+else
+  puts 'ERROR: BangSupportUnknown not found'
+end


### PR DESCRIPTION
## 概要
Issue #111 に基づき、ユニットメンバーのパート取り込みロジックを改善しました。

## 変更内容
1. **DB Schema**: `unit_people` テーブルに `part_alias` カラム (string, nullable) を追加。
2. **Importer Logic**: `WikipageImporter` において以下の修正を実施：
   - パート文字列の先頭にある `!` を除去。
   - 解析結果が `unknown` だった場合、元の（クリーニング済みの）パート文字列を `part_alias` に保存。

## 検証
- 検証用スクリプト `script/verify_part_improvements.rb` を作成し、以下の動作を確認済み：
  - `!Vocal` -> `part: :vocal`, `part_alias: nil`
  - `!UnknownPart` -> `part: :unknown`, `part_alias: "UnknownPart"`
  - `!MyUnknownPart` -> `part: :unknown`, `part_alias: "MyUnknownPart"`
  - `!Support Unknown` -> `part: :unknown`, `part_alias: "Unknown"`, `support: true`
