### PR TITLE
feat(import): Suppress skip logs for cross-import candidates

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -31,7 +31,8 @@ namespace :import do
         count += 1
       else
         skipped += 1
-        puts "[SKIPPED] #{wp.title} (ID: #{wp.id})" if wp.title.present?
+        # 個人候補の場合はログ出力しない
+        puts "[SKIPPED] #{wp.title} (ID: #{wp.id})" if wp.title.present? && !PersonImporter.valid_person?(wp)
       end
     end
 
@@ -70,7 +71,8 @@ namespace :import do
         count += 1
       else
         skipped += 1
-        puts "[SKIPPED] #{wp.title} (ID: #{wp.id})" if wp.title.present?
+        # ユニット候補の場合はログ出力しない
+        puts "[SKIPPED] #{wp.title} (ID: #{wp.id})" if wp.title.present? && !WikipageImporter.valid_unit?(wp)
       end
     end
 


### PR DESCRIPTION
## 概要
ユニットインポートと個人インポートで、互いの有効条件に該当するスキップ対象のログ出力を抑制しました。

## 背景
現在、`import:units` と `import:people` タスクでは、それぞれのインポーター条件に合わないページを `[SKIPPED]` としてログ出力しています。しかし、ユニット候補として有効なページが個人インポートでスキップされる場合（またはその逆）、これらは意図的な分類であり、ログ出力は不要です。

## 変更内容
- **ユニットインポート (`import:units`)**:
  - スキップ対象が `PersonImporter.valid_person?` に該当する場合、ログ出力を抑制
- **個人インポート (`import:people`)**:
  - スキップ対象が `WikipageImporter.valid_unit?` に該当する場合、ログ出力を抑制

## 実装
```ruby
# ユニットインポート
else
  skipped += 1
  # 個人候補の場合はログ出力しない
  puts "[SKIPPED] #{wp.title} (ID: #{wp.id})" if wp.title.present? && !PersonImporter.valid_person?(wp)
end

# 個人インポート
else
  skipped += 1
  # ユニット候補の場合はログ出力しない
  puts "[SKIPPED] #{wp.title} (ID: #{wp.id})" if wp.title.present? && !WikipageImporter.valid_unit?(wp)
end
```

## 検証
手動でインポートタスクを実行し、ログ出力が適切に抑制されることを確認予定です。
