### PR TITLE
fix: Guard against empty person key in MemberRowComponent

### DIFF
--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -6,9 +6,11 @@
           <%= (@member.support? ? "サポート " : "") + (@member.part_alias.presence || @member.part.upcase) %>
         </span>
         <h3 class="text-base md:text-lg font-black text-slate-800 dark:text-slate-100">
-          <% if @member.person %>
+
+          <% if @member.person && @member.person.key.present? %>
             <%= link_to @member.name, profile_path(@member.person.key), class: "hover:text-person transition-colors" %>
           <% else %>
+
             <%= @member.name %>
           <% end %>
         </h3>


### PR DESCRIPTION
## 概要\n特定のPersonデータでkeyが空の場合にUrlGenerationErrorが発生する問題を修正しました。\n\n## 対応内容\nMemberRowComponentでPersonのkeyが存在しない場合はリンクを生成せず、名前のみを表示するように変更しました。