### PR TITLE
feat: Add search to admin index groups & adjust importers

### DIFF
--- a/app/controllers/admin/index_groups_controller.rb
+++ b/app/controllers/admin/index_groups_controller.rb
@@ -23,10 +23,14 @@ module Admin
 
     def show
       if @index_group.id.zero?
-        @indices = TagIndex.where(index_group_id: nil).order(:name)
+        base_scope = TagIndex.where(index_group_id: nil)
+        base_scope = base_scope.where('name LIKE ?', "%#{params[:q]}%") if params[:q].present?
+        @indices = base_scope.order(:name)
         @groups = IndexGroup.ordered
       else
-        @indices = @index_group.tag_indices.ordered
+        indices_scope = @index_group.tag_indices
+        indices_scope = indices_scope.where('name LIKE ?', "%#{params[:q]}%") if params[:q].present?
+        @indices = indices_scope.ordered
       end
     end
 

--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -222,7 +222,7 @@ class PersonImporter
       # Normalize category name
       index_name = cat_raw.strip
 
-      tag_index = TagIndex.create_with(index_group_id: 2).find_or_create_by(name: index_name)
+      tag_index = TagIndex.find_or_create_by(name: index_name)
       TagIndexItem.create!(
         tag_index: tag_index,
         indexable: person

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -162,7 +162,7 @@ class WikipageImporter
 
     categories.each do |cat_raw|
       index_name = cat_raw.strip
-      tag_index = TagIndex.create_with(index_group_id: 1).find_or_create_by(name: index_name)
+      tag_index = TagIndex.find_or_create_by(name: index_name)
       TagIndexItem.create!(
         tag_index: tag_index,
         indexable: unit

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -28,6 +28,16 @@
 
   <div class="bg-white shadow rounded-lg p-6">
     <% if @index_group.id == 0 %>
+      <div class="mb-4">
+        <%= form_with url: admin_index_group_path(@index_group), method: :get, local: true, class: "flex gap-2" do |f| %>
+          <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
+          <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
+          <% if params[:q].present? %>
+            <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
+          <% end %>
+        <% end %>
+      </div>
+
       <%= form_with url: move_indices_admin_index_group_path(@index_group), method: :post, local: true, html: { id: "move_indices_form" } do |f| %>
         <div class="flex items-center mb-4 p-4 bg-gray-50 rounded-md border border-gray-200">
           <span class="mr-2 text-sm font-medium text-gray-700">Move selected to:</span>
@@ -58,6 +68,16 @@
         <% end %>
       </ul>
     <% else %>
+      <div class="mb-4">
+        <%= form_with url: admin_index_group_path(@index_group), method: :get, local: true, class: "flex gap-2" do |f| %>
+          <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
+          <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
+          <% if params[:q].present? %>
+            <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
+          <% end %>
+        <% end %>
+      </div>
+
       <%= form_with url: detach_indices_admin_index_group_path(@index_group), method: :post, local: true, html: { id: "detach_indices_form" } do |f| %>
         <div class="flex items-center justify-between mb-4">
           <h2 class="text-lg font-medium text-gray-900">Indices (Drag to reorder)</h2>

--- a/db/migrate/20260129131500_create_index_groups.rb
+++ b/db/migrate/20260129131500_create_index_groups.rb
@@ -10,12 +10,12 @@ class CreateIndexGroups < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    reversible do |dir|
-      dir.up do
-        execute "INSERT INTO index_groups (id, name, sort_order, created_at, updated_at) VALUES (1, 'カナ索引', 1, NOW(), NOW())"
-        execute "INSERT INTO index_groups (id, name, sort_order, created_at, updated_at) VALUES (2, '個人カナ索引', 2, NOW(), NOW())"
-      end
-    end
+    # reversible do |dir|
+    #   dir.up do
+    #     execute "INSERT INTO index_groups (id, name, sort_order, created_at, updated_at) VALUES (1, 'カナ索引', 1, NOW(), NOW())"
+    #     execute "INSERT INTO index_groups (id, name, sort_order, created_at, updated_at) VALUES (2, '個人カナ索引', 2, NOW(), NOW())"
+    #   end
+    # end
 
     rename_column :tag_indices, :index_group, :index_group_id
     add_foreign_key :tag_indices, :index_groups


### PR DESCRIPTION
## 概要
管理画面のインデックスグループ詳細ページに検索機能を追加しました。また、インポーターにおけるデフォルトのインデックスグループ設定（1, 2）を削除し、未設定（nil）となるように変更しました。

## 変更点
- **検索機能**: `Admin::IndexGroupsController` とビューに検索ロジックとフォームを追加。
- **インポーター**: `WikipageImporter`, `PersonImporter` から `index_group_id` の指定を削除。