### PR TITLE
chore: Add conditional data import to render build script

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,3 +6,10 @@ bundle install
 bundle exec rails tailwindcss:build
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
+
+if [ "$IMPORT_DATA" = "true" ]; then
+  echo "Running data import..."
+  bundle exec rails db:migrate # Ensure DB is migrated before import
+  bundle exec rails import:units
+  bundle exec rails import:people
+fi


### PR DESCRIPTION
## 概要
Render へのデプロイ時にデータインポートを実行できるように、`bin/render-build.sh` を更新しました。

## 変更内容
環境変数 `IMPORT_DATA` が `true` に設定されている場合のみ、以下の Rake タスクを実行するように条件分岐を追加しました：
- `db:migrate`
- `import:units`
- `import:people`

## 目的
Render の無料プランなどでシェル（コンソール）アクセスが制限されている環境でも、デプロイプロセスを通じてデータインポートを行えるようにするため。

## 使用方法
1. Render の Environment Variables に `IMPORT_DATA` = `true` を設定
2. デプロイを実行
3. デプロイ完了後、`IMPORT_DATA` を削除または `false` に変更
