### PR TITLE
fix: Order active members by order_in_period

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
       # person_logsが無く、old_historyがある場合はパースして使用
       @old_history_items = @resource.parse_old_history if @logs.empty? && @resource.old_history.present?
     elsif @resource.is_a?(Unit)
-      members = @resource.unit_people.includes(person: { person_logs: :unit })
+      members = @resource.unit_people.includes(person: { person_logs: :unit }).order(:order_in_period)
       @active_members = members.select { |m| m.pre? || m.active? }
       @past_members = members.reject { |m| m.pre? || m.active? }
 


### PR DESCRIPTION
## 概要
ユニットページのアクティブメンバー表示順序が正しくない（`order_in_period` 順になっていない）問題を修正しました。

## 変更内容
`ProfilesController` で `UnitPerson` を取得するクエリに `.order(:order_in_period)` を追加しました。

これにより、データベース上の `order_in_period` カラムの値（Wikiの記載順）に従ってメンバーが並びます。

## 検証
ローカルで検証用スクリプトを実行し、`order_in_period` 順（1, 2, 3...）にメンバーが取得されることを確認しました。
