### PR TITLE
feat: create trend table and model

### DIFF
--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Trend < ApplicationRecord
+  # Enums
+  enum :unit_phenomenon, {
+    announcement: 1,
+    formation: 2,
+    first_live: 3,
+    finish: 4,
+    pending: 5,
+    rename: 6,
+    suspend: 7,
+    restart: 8,
+    limited: 9,
+    etc: 98,
+    unknown: 99,
+    other: 100
+  }, prefix: true
+
+  enum :person_phenomenon, {
+    original_member: 0,
+    join_member: 1,
+    leave_member: 2,
+    suspend_member: 3,
+    rename_member: 4,
+    convert: 5,
+    stay: 6,
+    dismissal: 7,
+    rejoin: 8,
+    retirement: 90,
+    passed_away: 98,
+    unknown: 99,
+    other: 100
+  }, prefix: true
+
+  enum :etc_phenomenon, {
+    unknown: 99,
+    other: 100
+  }, prefix: true
+
+  # Validations
+  validates :date, presence: true
+  validates :active, inclusion: { in: [true, false] }
+  validates :publish_start_at, presence: true
+  validate :must_have_at_least_one_phenomenon
+
+  private
+
+  def must_have_at_least_one_phenomenon
+    return if unit_phenomenon.present? || person_phenomenon.present? || etc_phenomenon.present?
+
+    errors.add(:base, 'At least one phenomenon (unit, person, or etc) must be present')
+  end
+end

--- a/db/migrate/20260201101546_create_trends.rb
+++ b/db/migrate/20260201101546_create_trends.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class CreateTrends < ActiveRecord::Migration[8.1]
+  def change
+    create_table :trends do |t|
+      t.date :date, null: false
+      t.jsonb :units
+      t.jsonb :people
+      t.text :content
+      t.text :quote
+      t.string :quote_url
+      t.string :quote_title
+      t.string :via_url
+      t.string :via_name
+      t.boolean :active, default: true, null: false
+      t.datetime :publish_start_at, null: false
+      t.integer :unit_phenomenon
+      t.integer :person_phenomenon
+      t.integer :etc_phenomenon
+      t.integer :old_trend_id
+      t.integer :old_wiki_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_01_071545) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_01_101546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -121,6 +121,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_01_071545) do
     t.index ["index_group_id", "order_in_group"], name: "index_tag_indices_on_index_group_id_and_order_in_group"
     t.index ["index_group_id"], name: "index_tag_indices_on_index_group_id"
     t.index ["name"], name: "index_tag_indices_on_name", unique: true
+  end
+
+  create_table "trends", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.date "date", null: false
+    t.integer "etc_phenomenon"
+    t.integer "old_trend_id"
+    t.integer "old_wiki_id"
+    t.jsonb "people"
+    t.integer "person_phenomenon"
+    t.datetime "publish_start_at", null: false
+    t.text "quote"
+    t.string "quote_title"
+    t.string "quote_url"
+    t.integer "unit_phenomenon"
+    t.jsonb "units"
+    t.datetime "updated_at", null: false
+    t.string "via_name"
+    t.string "via_url"
   end
 
   create_table "unit_logs", force: :cascade do |t|

--- a/test/fixtures/trends.yml
+++ b/test/fixtures/trends.yml
@@ -1,0 +1,37 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  date: 2026-02-01
+  units: 
+  people: 
+  content: MyText
+  quote: MyText
+  quote_url: MyString
+  quote_title: MyString
+  via_url: MyString
+  via_name: MyString
+  active: false
+  publish_start_at: 2026-02-01 19:15:46
+  unit_phenomenon: 1
+  person_phenomenon: 1
+  etc_phenomenon: 1
+  old_trend_id: 1
+  old_wiki_id: 1
+
+two:
+  date: 2026-02-01
+  units: 
+  people: 
+  content: MyText
+  quote: MyText
+  quote_url: MyString
+  quote_title: MyString
+  via_url: MyString
+  via_name: MyString
+  active: false
+  publish_start_at: 2026-02-01 19:15:46
+  unit_phenomenon: 1
+  person_phenomenon: 1
+  etc_phenomenon: 1
+  old_trend_id: 1
+  old_wiki_id: 1

--- a/test/models/trend_test.rb
+++ b/test/models/trend_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TrendTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Issue #137: 新トレンドテーブル作成

## 変更内容
- Trendモデル作成
-  テーブルマイグレーション
- Enumsとバリデーション定義
  - 100 は other に統一
  - unit_phenomenon: restart対応