### PR TITLE
feat: convert old trends to new table

### DIFF
--- a/db/migrate/20260201103239_add_unknown_flags_to_trends.rb
+++ b/db/migrate/20260201103239_add_unknown_flags_to_trends.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUnknownFlagsToTrends < ActiveRecord::Migration[8.1]
+  def change
+    add_column :trends, :day_unknown, :boolean, default: false, null: false
+    add_column :trends, :month_unknown, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260201103646_add_indexes_to_trends.rb
+++ b/db/migrate/20260201103646_add_indexes_to_trends.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexesToTrends < ActiveRecord::Migration[8.1]
+  def change
+    add_index :trends, :date
+    add_index :trends, :units, using: :gin
+  end
+end

--- a/db/migrate/20260201103943_add_title_and_people_index_to_trends.rb
+++ b/db/migrate/20260201103943_add_title_and_people_index_to_trends.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddTitleAndPeopleIndexToTrends < ActiveRecord::Migration[8.1]
+  def change
+    add_column :trends, :title, :string
+    add_index :trends, :people, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_01_101546) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_01_103943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -128,7 +128,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_01_101546) do
     t.text "content"
     t.datetime "created_at", null: false
     t.date "date", null: false
+    t.boolean "day_unknown", default: false, null: false
     t.integer "etc_phenomenon"
+    t.boolean "month_unknown", default: false, null: false
     t.integer "old_trend_id"
     t.integer "old_wiki_id"
     t.jsonb "people"
@@ -137,11 +139,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_01_101546) do
     t.text "quote"
     t.string "quote_title"
     t.string "quote_url"
+    t.string "title"
     t.integer "unit_phenomenon"
     t.jsonb "units"
     t.datetime "updated_at", null: false
     t.string "via_name"
     t.string "via_url"
+    t.index ["date"], name: "index_trends_on_date"
+    t.index ["people"], name: "index_trends_on_people", using: :gin
+    t.index ["units"], name: "index_trends_on_units", using: :gin
   end
 
   create_table "unit_logs", force: :cascade do |t|

--- a/lib/tasks/README.md
+++ b/lib/tasks/README.md
@@ -10,6 +10,8 @@
 PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:reset
 PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:units
 PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:people
+PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:old_trends
+PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails convert:old_trends
 ```
 
 ## スクリプト一覧
@@ -94,6 +96,29 @@ PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:reset
 - ユニットタイプ（バンド、セッションなど）
 - カテゴリ（TagIndex）
 
+## トレンドデータの移行
+
+### 4. import:old_trends - 旧トレンドデータのインポート
+MySQLのダンプファイル (`trends_all_YYYYMMDD.sql`) から、中間テーブル `old_trends` へデータをインポートします。
+
+```bash
+# プロジェクトルートにSQLファイルを配置した状態で実行
+bin/rails import:old_trends
+```
+
+### 5. convert:old_trends - 新トレンドテーブルへのコンバート
+`old_trends` テーブルのデータを解析・変換し、正規の `trends` テーブルへ移行します。
+この処理では以下が行われます：
+- `wikipage_id` を元にした `Unit` / `Person` との関連付け
+- `content` の解析による `phenomenon` (現象タイプ) の判定
+- 日付文字列のパースと補正 (`day_unknown`, `month_unknown` フラグの設定)
+- `content` の1行目を `title` として抽出
+
+```bash
+bin/rails convert:old_trends
+```
+
+**注意**: このタスクを実行すると、既存の `trends` テーブルのデータは全て削除 (`delete_all`) された上で再作成されます。
 
 ## 対応リンクサービス
 
@@ -126,4 +151,3 @@ PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:reset
 ### 新しいカテゴリの追加
 
 各Importerサービスの `parse_categories` メソッドに追加してください。
-

--- a/lib/tasks/convert_old_trends.rake
+++ b/lib/tasks/convert_old_trends.rake
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+namespace :convert do
+  desc 'Convert old_trends to trends'
+  task old_trends: :environment do
+    puts 'Start converting OldTrend to Trend...'
+    Trend.delete_all
+
+    count = 0
+    skipped_count = 0
+
+    OldTrend.find_each do |old|
+      # Handle date parsing
+      target_date = old.target_date
+      day_unknown = false
+      month_unknown = false
+      clean_date = target_date.dup
+
+      case target_date
+      when /^\d{4}$/
+        # Format "YYYY"
+        month_unknown = true
+        day_unknown = true
+        clean_date = "#{target_date}/01/01"
+      when %r{/00/00$}
+        # Format "YYYY/00/00" or "YYYY/MM/00/00" (though unlikely)
+        month_unknown = true
+        day_unknown = true
+        clean_date = target_date.sub(%r{/00/00$}, '/01/01')
+      when %r{/00$}
+        # Format "YYYY/MM/00"
+        day_unknown = true
+        clean_date = target_date.sub(%r{/00$}, '/01')
+      when %r{/\d{2}/00}
+        # Catch other cases where day is 00 but maybe not at end? unlikely given strict format but good to be safe
+        day_unknown = true
+        clean_date = clean_date.gsub('/00', '/01')
+      end
+
+      begin
+        date_obj = Date.parse(clean_date)
+      rescue Date::Error
+        date_obj = Date.new(1970, 1, 1) # Fallback
+        puts "Invalid date found: #{old.target_date}, defaulted to 1970-01-01"
+      end
+
+      # Base attributes
+      trend = Trend.new(
+        date: date_obj,
+        day_unknown: day_unknown,
+        month_unknown: month_unknown,
+        title: old.content&.lines&.first&.chomp || old.target_name,
+        content: old.content,
+        quote: old.quote,
+        quote_url: old.quote_url,
+        via_name: old.via,
+        via_url: old.via_url,
+        active: old.publish,
+        old_trend_id: old.id,
+        old_wiki_id: old.wikipage_id
+      )
+
+      # Publish start date
+      trend.publish_start_at = old.publish_plan_date || old.created_at || Time.current
+
+      # Find associations
+      unit = Unit.find_by(old_wiki_id: old.wikipage_id)
+      person = Person.find_by(old_wiki_id: old.wikipage_id)
+
+      if unit
+        trend.units = [{ unit_id: unit.id, unit_name: unit.name }]
+      elsif person
+        trend.people = [{ person_id: person.id, person_name: person.name }]
+      end
+
+      # Map Phenomenon
+      apply_phenomenon(trend, old)
+
+      if trend.save
+        count += 1
+        print '.' if (count % 100).zero?
+      else
+        puts "\nFailed to save Trend (OldTrend ID: #{old.id}): #{trend.errors.full_messages.join(', ')}"
+        skipped_count += 1
+      end
+    end
+
+    puts "\nConversion completed. Imported: #{count}, Skipped: #{skipped_count}"
+  end
+
+  # rubocop:disable Metrics/PerceivedComplexity
+  def apply_phenomenon(trend, old)
+    case old.trend_class
+    when 1
+      trend.unit_phenomenon = if old.content&.include?('結成')
+                                :formation
+                              elsif old.content&.include?('始動') || old.content&.include?('1st.LIVE')
+                                :first_live
+                              elsif old.content&.include?('解禁')
+                                :announcement
+                              else
+                                :formation
+                              end
+    when 2
+      trend.unit_phenomenon = if old.content&.match?(/活動休止|活動停止|無期限活動休止/)
+                                :suspend
+                              else
+                                :finish
+                              end
+    when 3
+      trend.unit_phenomenon = :restart
+    when 4
+      trend.unit_phenomenon = :limited
+    when 8
+      trend.unit_phenomenon = :other
+    when 9
+      trend.unit_phenomenon = :limited
+    when 11
+      trend.person_phenomenon = :join_member
+    when 12
+      trend.person_phenomenon = :leave_member
+    when 19
+      trend.person_phenomenon = :other
+    else
+      trend.etc_phenomenon = :other
+    end
+  end
+  # rubocop:enable Metrics/PerceivedComplexity
+end


### PR DESCRIPTION
Issue #138: 新トレンドテーブルへのコンバート

## 変更内容
- `trends` テーブルのカラム追加
  - `day_unknown`, `month_unknown` (日付不明フラグ)
  - `title`
  - インデックス追加 (`date`, `units`, `people`)
- Rakeタスク `convert:old_trends` 作成
  - `old_trends` からデータを移行
  - 日付解析とフラグ設定
  - `wikipage_id` に基づく `Unit`/`Person` 紐付け
  - `content` 1行目を `title` に設定
- ドキュメント更新 (`lib/tasks/README.md`)