### PR TITLE
feat: add trends display to unit profile page

### DIFF
--- a/app/components/unit_trends_component.html.erb
+++ b/app/components/unit_trends_component.html.erb
@@ -1,0 +1,20 @@
+<section class="mt-8">
+  <div class="flex items-center justify-between mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
+    <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Trends</h2>
+  </div>
+  
+  <div class="space-y-3">
+    <% @trends.each do |trend| %>
+      <div class="flex items-start gap-3 text-sm">
+        <div class="shrink-0 w-24 text-slate-400 dark:text-slate-500 font-mono text-xs pt-0.5">
+          <%= trend.date %>
+        </div>
+        <div class="grow">
+          <p class="font-bold text-slate-700 dark:text-slate-200">
+            <%= format_title(trend.title) %>
+          </p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/components/unit_trends_component.rb
+++ b/app/components/unit_trends_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class UnitTrendsComponent < ViewComponent::Base
+  def initialize(trends:)
+    super()
+    @trends = trends
+  end
+
+  def render?
+    @trends.present?
+  end
+
+  private
+
+  def format_title(title)
+    # [[Display|Link]] -> Internal EUC-JP link
+    formatted = title.gsub(/\[\[(.*?)\|(.*?)\]\]/) do
+      display = Regexp.last_match(1)
+      target = Regexp.last_match(2)
+      create_internal_link(display, target)
+    end
+
+    # [[Link]] -> Internal EUC-JP link (Display == Target)
+    formatted = formatted.gsub(/\[\[([^|]+?)\]\]/) do
+      target = Regexp.last_match(1)
+      create_internal_link(target, target)
+    end
+
+    # [Display|URL] -> External link
+    formatted = formatted.gsub(%r{\[(.*?)\|(https?://.*?)\]}) do
+      display = Regexp.last_match(1)
+      url = Regexp.last_match(2)
+      link_to(display, url, target: '_blank', rel: 'noopener noreferrer')
+    end
+
+    sanitize(formatted, tags: %w[a], attributes: %w[href target rel])
+  end
+
+  def create_internal_link(display, target)
+    encoded = URI.encode_www_form_component(target.encode('EUC-JP'))
+    link_to(display, "/#{encoded}.html")
+  rescue Encoding::UndefinedConversionError
+    link_to(display, '#')
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -21,6 +21,10 @@ class ProfilesController < ApplicationController
       unit_logs = @resource.unit_logs
       person_logs = @resource.person_logs.includes(:person)
       @history = (unit_logs + person_logs).sort_by { |l| [l.log_date.to_s, l.is_a?(PersonLog) ? 1 : 0] }
+
+      @trends = Trend.where('units @> ?', [{ unit_id: @resource.id }].to_json)
+                     .order(date: :desc)
+                     .limit(10)
     end
 
     respond_to do |format|

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,6 +17,7 @@
               active_members: @active_members,
               past_members: @past_members
             ) %>
+            <%= render UnitTrendsComponent.new(trends: @trends) if @trends %>
           <% end %>
 
           <% if (@resource.is_a?(Person) && (@logs.present? || @old_history_items.present?)) || (@resource.is_a?(Unit) && @history.present?) %>


### PR DESCRIPTION
Issue #141: ユニットページへのトレンド表示対応

## 変更内容
- **ProfilesController**: ユニットに関連するトレンドを取得 (最大10件)
- **UnitTrendsComponent**: トレンド表示用コンポーネント作成
  - Wiki記法パース対応:
    - `[[Link]]` → 内部リンク
    - `[[Display|Link]]` → 内部リンク (EUC-JPエンコード)
    - `[Display|URL]` → 外部リンク
- **View**: `profiles/show.html.erb` にコンポーネント追加