### PR TITLE
fix: handle escape sequences in trend import

### DIFF
--- a/lib/tasks/import_old_trends.rake
+++ b/lib/tasks/import_old_trends.rake
@@ -33,8 +33,14 @@ namespace :import do
 
       until scanner.eos?
         if scanner.scan(/'((?:[^']|'')*)'/)
-          # Quoted string: unescape '' to '
-          values << scanner[1].gsub("''", "'")
+          # Quoted string: unescape '' to ' and handle escape sequences
+          unescaped = scanner[1].gsub("''", "'")
+                                .gsub('\\r\\n', "\r\n")
+                                .gsub('\\n', "\n")
+                                .gsub('\\r', "\r")
+                                .gsub('\\t', "\t")
+                                .gsub('\\\\', '\\')
+          values << unescaped
         elsif scanner.scan(/NULL/)
           values << nil
         elsif scanner.scan(/([^,]+)/)


### PR DESCRIPTION
MySQLダンプからのインポート時に `\r\n` などのエスケープシーケンスが実際の改行文字に変換されていなかった問題を修正。

## 修正内容
- `import_old_trends.rake` でエスケープシーケンスを実際の文字に変換
  - `\r\n` → 改行
  - `\n` → 改行
  - `\r` → 復帰
  - `\t` → タブ
  - `\\` → バックスラッシュ

## 検証結果
- OldTrend 7037: content が正しく9行に分割
- Trend 36916: title が content の1行目のみを含む