### PR TITLE
feat: トレンドページの実装 (Issue #144)

### DIFF
--- a/app/components/unit_trends_component.html.erb
+++ b/app/components/unit_trends_component.html.erb
@@ -7,11 +7,11 @@
     <% @trends.each do |trend| %>
       <div class="flex items-start gap-3 text-sm">
         <div class="shrink-0 w-24 text-slate-400 dark:text-slate-500 font-mono text-xs pt-0.5">
-          <%= trend.date %>
+          <%= link_to trend.date, trend_path(trend), class: "hover:underline hover:text-indigo-500 transition-colors" %>
         </div>
         <div class="grow">
           <p class="font-bold text-slate-700 dark:text-slate-200">
-            <%= format_title(trend.title) %>
+            <%= format_wiki_title(trend.title) %>
           </p>
         </div>
       </div>

--- a/app/components/unit_trends_component.rb
+++ b/app/components/unit_trends_component.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class UnitTrendsComponent < ViewComponent::Base
+  include WikiLinkHelper
+  include Rails.application.routes.url_helpers
+
   def initialize(trends:)
     super()
     @trends = trends
@@ -8,38 +11,5 @@ class UnitTrendsComponent < ViewComponent::Base
 
   def render?
     @trends.present?
-  end
-
-  private
-
-  def format_title(title)
-    # [[Display|Link]] -> Internal EUC-JP link
-    formatted = title.gsub(/\[\[(.*?)\|(.*?)\]\]/) do
-      display = Regexp.last_match(1)
-      target = Regexp.last_match(2)
-      create_internal_link(display, target)
-    end
-
-    # [[Link]] -> Internal EUC-JP link (Display == Target)
-    formatted = formatted.gsub(/\[\[([^|]+?)\]\]/) do
-      target = Regexp.last_match(1)
-      create_internal_link(target, target)
-    end
-
-    # [Display|URL] -> External link
-    formatted = formatted.gsub(%r{\[(.*?)\|(https?://.*?)\]}) do
-      display = Regexp.last_match(1)
-      url = Regexp.last_match(2)
-      link_to(display, url, target: '_blank', rel: 'noopener noreferrer')
-    end
-
-    sanitize(formatted, tags: %w[a], attributes: %w[href target rel])
-  end
-
-  def create_internal_link(display, target)
-    encoded = URI.encode_www_form_component(target.encode('EUC-JP'))
-    link_to(display, "/#{encoded}.html")
-  rescue Encoding::UndefinedConversionError
-    link_to(display, '#')
   end
 end

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class TrendsController < ApplicationController
+  def index
+    scope = Trend.all.order(date: :desc)
+
+    if params[:year].present?
+      year = params[:year].to_i
+      month = params[:month].presence&.to_i
+
+      start_date = Date.new(year, month || 1, 1)
+      end_date = month ? start_date.end_of_month : start_date.end_of_year
+
+      scope = scope.where(date: start_date..end_date)
+    end
+
+    @pagy, @trends = pagy(scope)
+
+    all_unit_ids = @trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
+    @related_units = Unit.where(id: all_unit_ids).index_by(&:id)
+  end
+
+  def show
+    @trend = Trend.find(params[:id])
+    return unless @trend.units.present?
+
+    unit_ids = @trend.units.map { |u| u['unit_id'] }
+    @related_units = Unit.where(id: unit_ids).index_by(&:id)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,46 @@
 module ApplicationHelper
   include Pagy::Frontend
 
+  def pagy_tailwind_nav(pagy)
+    html = +'<nav class="flex justify-center gap-1" aria-label="Pagination">'
+
+    # Common classes
+    base_class = 'relative inline-flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors duration-200'
+    inactive_class = "#{base_class} text-slate-500 hover:bg-slate-100 hover:text-slate-700 " \
+                     'dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200'
+    active_class = "#{base_class} bg-indigo-600 text-white hover:bg-indigo-700 shadow-sm " \
+                   'focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500'
+    disabled_class = "#{base_class} text-slate-300 dark:text-slate-600 cursor-not-allowed"
+
+    # Prev
+    html << if pagy.prev
+              link_to('Prev', pagy_url_for(pagy, pagy.prev), class: inactive_class)
+            else
+              content_tag(:span, 'Prev', class: disabled_class)
+            end
+
+    # Series
+    pagy.series.each do |item|
+      case item
+      when Integer
+        html << link_to(item, pagy_url_for(pagy, item), class: inactive_class)
+      when String # current page
+        html << content_tag(:span, item, class: active_class)
+      when :gap
+        html << content_tag(:span, '...', class: "#{base_class} text-slate-400 dark:text-slate-500")
+      end
+    end
+
+    # Next
+    html << if pagy.next
+              link_to('Next', pagy_url_for(pagy, pagy.next), class: inactive_class)
+            else
+              content_tag(:span, 'Next', class: disabled_class)
+            end
+
+    html << '</nav>'
+  end
+
   def logged_in?
     false
   end

--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module WikiLinkHelper
+  def format_wiki_content(text)
+    return '' if text.blank?
+
+    # Handle newlines and escaping
+    # simple_format escapes the text
+    formatted = simple_format(text, {}, wrapper_tag: 'div')
+
+    parse_wiki_links(formatted)
+  end
+
+  def format_wiki_title(text)
+    return '' if text.blank?
+
+    # Just escape, no wrapping
+    formatted = h(text)
+
+    parse_wiki_links(formatted)
+  end
+
+  private
+
+  def parse_wiki_links(text)
+    # [[Display|Link]] -> Internal EUC-JP link
+    formatted = text.gsub(/\[\[(.*?)\|(.*?)\]\]/) do
+      display = Regexp.last_match(1)
+      target = Regexp.last_match(2)
+      create_internal_link(display, target)
+    end
+
+    # [[Link]] -> Internal EUC-JP link (Display == Target)
+    formatted = formatted.gsub(/\[\[([^|]+?)\]\]/) do
+      target = Regexp.last_match(1)
+      create_internal_link(target, target)
+    end
+
+    # [Display|URL] -> External link
+    formatted = formatted.gsub(%r{\[(.*?)\|(https?://.*?)\]}) do
+      display = Regexp.last_match(1)
+      url = Regexp.last_match(2)
+      link_to(display, url, target: '_blank', rel: 'noopener noreferrer')
+    end
+
+    sanitize(formatted, tags: %w[a div p br], attributes: %w[href target rel class])
+  end
+
+  def create_internal_link(display, target)
+    encoded = URI.encode_www_form_component(target.encode('EUC-JP'))
+    link_to(display, "/#{encoded}.html")
+  rescue Encoding::UndefinedConversionError
+    link_to(display, '#')
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,7 @@
             <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
               <%= link_to "Units", units_path, class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" %>
               <%= link_to "People", people_path, class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" %>
+              <%= link_to "Trends", trends_path, class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" %>
               <% if logged_in? %>
                 <%= link_to "Admin: Users", admin_users_path, class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" %>
                 <%= link_to "Admin: Units", admin_units_path, class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,0 +1,31 @@
+<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+    <div class="p-5 md:p-8">
+      <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-8">Trends</h1>
+
+      <div class="space-y-4">
+        <% @trends.each do |trend| %>
+          <div class="flex items-start gap-4 p-4 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors border border-slate-100 dark:border-slate-700">
+            <div class="shrink-0 w-24 text-slate-400 dark:text-slate-500 font-mono text-sm pt-0.5">
+              <%= trend.date %>
+            </div>
+            <div class="grow">
+              <% if @related_units && trend.units %>
+                <% trend.units.each do |unit_data| %>
+                  <% unit = @related_units[unit_data['unit_id']] %>
+                  <% next unless unit %>
+                  <%= link_to "[#{unit.name}]", profile_path(unit.key), class: "font-bold text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors mr-1" %>
+                <% end %>
+              <% end %>
+              <%= link_to format_wiki_title(trend.title), trend_path(trend), class: "font-bold text-slate-700 dark:text-slate-200 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors inline" %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mt-8 flex justify-center">
+        <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -1,0 +1,29 @@
+<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+    <div class="p-5 md:p-8">
+      <div class="mb-6 pb-6 border-b border-slate-100 dark:border-slate-700">
+        <div class="flex items-center gap-3 text-sm text-slate-400 dark:text-slate-500 font-mono mb-2">
+          <%= @trend.date %>
+        </div>
+        <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
+          <% if @related_units %>
+            <% @trend.units.each do |unit_data| %>
+              <% unit = @related_units[unit_data['unit_id']] %>
+              <% next unless unit %>
+              <%= link_to "[#{unit.name}]", profile_path(unit.key), class: "text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors mr-2" %>
+            <% end %>
+          <% end %>
+          <%= format_wiki_title(@trend.title) %>
+        </h1>
+      </div>
+
+      <div class="prose prose-slate dark:prose-invert max-w-none">
+        <%= format_wiki_content(@trend.content) %>
+      </div>
+      
+      <div class="mt-12 pt-8 border-t border-slate-100 dark:border-slate-700">
+        <%= link_to "Back to Trends", trends_path, class: "text-sm font-bold text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
 
   resources :people, param: :key, only: %i[index show], constraints: { key: %r{[^/]+} }
   resources :units, param: :key, only: %i[index show], constraints: { key: %r{[^/]+} }
+  resources :trends, only: %i[index show]
 
   # Legacy redirects for .html extensions
   get '/:old_key.html', to: 'legacy_redirects#show', constraints: { old_key: %r{[^/]+} }


### PR DESCRIPTION
Issue #144: トレンドページとWiki記法リンクのサポート

- `/trends` 一覧・詳細ページの追加
- `WikiLinkHelper` の実装（`[[link|target]]` のパース）
- ページネーションのTailwind CSS対応
- グローバルナビゲーションの更新