### PR TITLE
feat: 管理画面にold_wiki_textを表示

### DIFF
--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -125,6 +125,12 @@
   </div>
 
   <div>
+    <%= form.label :old_wiki_text, "Old Wiki Text", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <%= form.text_area :old_wiki_text, rows: 10, readonly: true, class: "mt-1 block w-full rounded-md border-gray-300 bg-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono text-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 cursor-not-allowed" %>
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">移行元のWikiテキスト (Read Only)</p>
+  </div>
+
+  <div>
     <%= form.label :note, "Note", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <%= form.text_area :note, rows: 5, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">管理用メモ</p>

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -78,6 +78,11 @@
   </div>
 
   <div>
+    <%= form.label :old_wiki_text, "Old Wiki Text", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <%= form.text_area :old_wiki_text, rows: 10, readonly: true, class: "mt-1 block w-full rounded-md border-gray-300 bg-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono text-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 cursor-not-allowed" %>
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">移行元のWikiテキスト (Read Only)</p>
+  </div>
+  <div>
     <%= form.label :note, "Note", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <%= form.text_area :note, rows: 5, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">管理用メモ</p>


### PR DESCRIPTION
Feature: Show old_wiki_text in Admin Forms

## 概要

管理画面の `Person` および `Unit` 編集フォームにおいて、移行元のWikiテキスト (`old_wiki_text`) を参照専用で表示するようにしました。これにより、管理者が元のデータを確認しながら編集作業を行えるようになります。

## 変更内容

- `app/views/admin/people/_form.html.erb`: `Name History` の下に `old_wiki_text` を追加 (readonly)。
- `app/views/admin/units/_form.html.erb`: `Name History` の下に `old_wiki_text` を追加 (readonly)。
- スタイル調整: 背景色をグレーにし、編集不可であることを視覚的に示しました。

## 関連Issue
Closes #148

## 検証
- [x] 管理画面でPerson編集ページを開き、old_wiki_textが表示されること
- [x] 管理画面でUnit編集ページを開き、old_wiki_textが表示されること
- [x] フィールドが編集不可（readonly）であること
