### PR TITLE
Feat: Person history in unit members & Management info updates

### DIFF
--- a/app/components/management_information_component.html.erb
+++ b/app/components/management_information_component.html.erb
@@ -2,6 +2,10 @@
   <h2 class="text-xs font-bold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-4 tracking-[0.2em] border-b border-slate-200 dark:border-slate-800 pb-2">Management Information</h2>
   <dl class="grid gap-2 text-xs">
     <div class="flex justify-between items-center">
+      <dt class="font-bold text-slate-400 dark:text-slate-500 italic">ID</dt>
+      <dd><code class="bg-white dark:bg-slate-800 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700 font-mono text-slate-500 dark:text-slate-400"><%= @resource.id %></code></dd>
+    </div>
+    <div class="flex justify-between items-center">
       <dt class="font-bold text-slate-400 dark:text-slate-500 italic">Key</dt>
       <dd><code class="bg-white dark:bg-slate-800 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700 font-mono text-slate-500 dark:text-slate-400"><%= @resource.key %></code></dd>
     </div>

--- a/app/components/management_information_component.rb
+++ b/app/components/management_information_component.rb
@@ -4,4 +4,8 @@ class ManagementInformationComponent < ViewComponent::Base
   def initialize(resource:)
     @resource = resource
   end
+
+  def render?
+    helpers.logged_in?
+  end
 end

--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -43,24 +43,28 @@
         <% end %>
       </div>
     </div>
-    <% if @member.person && @member.person.person_logs.present? %>
+    <% if (p_items = person_history_items).present? %>
       <div class="mt-3 pl-4 border-l-2 border-slate-100 dark:border-slate-800 flex flex-col gap-1">
-        <% sorted_person_logs.each do |log| %>
-          <div class="flex items-start gap-3 text-[0.7rem] leading-relaxed text-slate-500 dark:text-slate-400">
-            <span class="font-black opacity-60 tabular-nums shrink-0"><%= log.log_date %></span>
-            <span class="truncate">
-              <% if log.unit %>
-                <%= link_to log.unit.name, profile_path(log.unit.key), class: "font-bold text-slate-600 dark:text-slate-300 hover:text-person" %>
-              <% else %>
-                <span class="font-bold"><%= log.unit_name %></span>
+        <% p_items.each do |concurrent_items| %>
+          <div class="text-[0.7rem] leading-relaxed text-slate-500 dark:text-slate-400">
+            <% concurrent_items.each_with_index do |item, index| %>
+              <% if index > 0 %>
+                <span class="mx-1">、</span>
               <% end %>
-              <% if log.name.present? %>
-                <span class="text-xs font-bold text-slate-500 dark:text-slate-400 opacity-80">(<%= log.name %>)</span>
-              <% end %>
-              <% if log.phenomenon.present? && log.phenomenon != "stay" %>
-                <small class="text-[0.65rem] opacity-70 ml-1">(<%= log.try(:phenomenon_text) || log.phenomenon %>)</small>
-              <% end %>
-            </span>
+              <span class="font-bold text-slate-600 dark:text-slate-300">
+                <% if item[:external_url].present? %>
+                  <%= link_to item[:unit_name], item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
+                <% elsif item[:old_key].present? %>
+                  <%= link_to item[:unit_name], "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
+                <% else %>
+                  <%= item[:unit_name] %>
+                <% end %>
+
+                <% if item[:part_and_name].present? %>
+                  <span class="text-xs font-bold text-slate-500 dark:text-slate-400 opacity-80">(<%= item[:part_and_name] %>)</span>
+                <% end %>
+              </span>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/components/member_row_component.rb
+++ b/app/components/member_row_component.rb
@@ -29,10 +29,10 @@ class MemberRowComponent < ViewComponent::Base
     !(@hide_active && @member.status == 'active')
   end
 
-  def sorted_person_logs
-    return [] unless @member.person
+  def person_history_items
+    return [] unless @member.person&.old_history.present?
 
-    @member.person.person_logs.sort_by { |l| [l.log_date.to_s, l.sort_order || 0] }
+    @member.person.parse_old_history
   end
 
   def parse_wiki_links(text)


### PR DESCRIPTION
# Issue 135: メンバーリスト内ヒストリー表示改善 & 管理情報表示アップデート

## 概要
ユニット詳細ページのメンバーリストにおいて、`Person` に紐付いているメンバーの活動履歴 (`old_history`) を表示するようにしました。また、Management Informationセクションの内容と表示条件を更新しました。

## 変更点

### 1. メンバーリスト履歴表示 (Issue 135)
- **対象**: `MemberRowComponent`
- **変更**:
  - `person_logs` が空の場合、`Person` モデルの `old_history` をパースして表示するように変更。
  - 既存の `inline_history` と同様のスタイルで表示。
  - 同時期の活動（「、」区切り）や内部リンク/外部リンクも適切にレンダリング。

### 2. Management Information 更新
- **項目の追加**: `ID` を表示するようにしました。
- **表示条件**: ログイン中のユーザーにのみ表示されるように変更しました（`render?` メソッドで制御）。

## 確認方法

### メンバー履歴
1. `old_history` を持ち、かつ `person_logs` がないPersonがメンバーのユニットページを表示。
2. メンバー名の下に、過去の活動履歴（バンド名等）が表示されることを確認。

### Management Information
1. ログイン/未ログイン状態でユニットまたは個人ページを表示。
2. ログイン時のみ「Management Information」セクションが表示されることを確認。
3. セクション内に `ID`, `Key`, `Old Key` (あれば), `Old Wiki ID` (あれば) が表示されていることを確認。

## 関連Issue
Closes #135
