### PR TITLE
トレンド一覧のプルダウン表示修正

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -26,7 +26,8 @@ export default class extends Controller {
 
     show() {
         this.menuTarget.classList.remove("hidden")
-        this.menuTarget.classList.add("enter-active") // For transitions if needed
+        this.enter()
+
         // Rotate icon if exists
         const icon = this.buttonTarget.querySelector("svg")
         if (icon) icon.classList.add("rotate-180")
@@ -36,10 +37,68 @@ export default class extends Controller {
         if (event && (this.element.contains(event.target))) {
             return
         }
-        this.openValue = false
-        this.menuTarget.classList.add("hidden")
+
+        // If called from event (click outside), update state which triggers openValueChanged -> hide()
+        if (this.openValue) {
+            this.openValue = false
+            return
+        }
+
+        this.leave()
 
         const icon = this.buttonTarget.querySelector("svg")
         if (icon) icon.classList.remove("rotate-180")
+    }
+
+    enter() {
+        const element = this.menuTarget
+        const enterClasses = this.getClasses("transitionEnter")
+        const enterStartClasses = this.getClasses("transitionEnterStart")
+        const enterEndClasses = this.getClasses("transitionEnterEnd")
+
+        element.classList.add(...enterClasses)
+        element.classList.add(...enterStartClasses)
+        element.classList.remove(...enterEndClasses)
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                element.classList.remove(...enterStartClasses)
+                element.classList.add(...enterEndClasses)
+
+                element.addEventListener("transitionend", () => {
+                    element.classList.remove(...enterClasses)
+                }, { once: true })
+            })
+        })
+    }
+
+    leave() {
+        const element = this.menuTarget
+        const leaveClasses = this.getClasses("transitionLeave")
+        const leaveStartClasses = this.getClasses("transitionLeaveStart")
+        const leaveEndClasses = this.getClasses("transitionLeaveEnd")
+
+        element.classList.add(...leaveClasses)
+        element.classList.add(...leaveStartClasses)
+        element.classList.remove(...leaveEndClasses)
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                element.classList.remove(...leaveStartClasses)
+                element.classList.add(...leaveEndClasses)
+
+                element.addEventListener("transitionend", () => {
+                    if (!this.openValue) {
+                        element.classList.add("hidden")
+                    }
+                    element.classList.remove(...leaveClasses)
+                    element.classList.remove(...leaveEndClasses)
+                }, { once: true })
+            })
+        })
+    }
+
+    getClasses(name) {
+        return (this.menuTarget.dataset[name] || "").split(" ").filter(c => c.length > 0)
     }
 }


### PR DESCRIPTION
## 概要
トレンド一覧ページの年選択プルダウンが開かない不具合を修正しました。

## 原因
HTML側では `opacity-0` などの非表示クラスが指定されていましたが、Javascriptコントローラー側でこれらを切り替える処理が不足しており、`hidden` クラスを削除しても透明なままでした。

## 変更内容
- **`app/javascript/controllers/dropdown_controller.js`**: `show` / `hide` メソッドを改修し、HTMLの `data-transition-*` 属性を利用してクラスを動的に切り替える処理（`enter` / `leave`）を追加しました。

これにより、ドロップダウンメニューがフェードイン・フェードアウトのアニメーション付きで正しく表示されるようになります。
