### PR TITLE
categoryプラグインのバッジ表示対応と複数バッジサポート

### DIFF
--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -67,8 +67,10 @@
                 <% if item[:part_and_name].present? %>
                   <span class="text-xs font-bold text-slate-500 dark:text-slate-400 opacity-80">(<%= item[:part_and_name] %>)</span>
                 <% end %>
-                <% if item[:note].present? %>
-                  <span class="text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-2"><%= item[:note] %></span>
+                <% if item[:notes].present? %>
+                  <% item[:notes].each do |note| %>
+                    <span class="text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-2"><%= note %></span>
+                  <% end %>
                 <% end %>
               </span>
             <% end %>

--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -29,9 +29,9 @@ module WikiParser
 
       # Split by 、 to handle concurrent activities
       period_segment.split('、').each do |item_segment|
-        metadata = {}
+        metadata = { notes: [] }
         item_segment = process_plugins(item_segment.strip, metadata)
-        next if item_segment.empty?
+        next if item_segment.empty? && metadata[:notes].empty?
 
         # Check if the entire segment is wrapped in parentheses
         wrapped_in_parens = item_segment.start_with?('(') && item_segment.end_with?(')')
@@ -64,7 +64,7 @@ module WikiParser
             unit_name: display_unit_name,
             part_and_name: part_and_name&.strip,
             old_key: encoded_unit_name,
-            note: metadata[:fn]
+            notes: metadata[:notes]
           }
         # Pattern 2: [LinkText|URL] or [LinkText|URL](Part) - External link
         when /\[([^\]|]+)\|([^\]]+)\](?:\(([^)]+)\))?/
@@ -79,13 +79,13 @@ module WikiParser
             unit_name: display_link_text,
             part_and_name: part_and_name&.strip,
             external_url: url.strip,
-            note: metadata[:fn]
+            notes: metadata[:notes]
           }
         # Pattern 3: Plain text - No link, display as-is (including parentheses)
         else
           concurrent_items << {
             unit_name: item_segment.strip,
-            note: metadata[:fn],
+            notes: metadata[:notes],
             is_temp: metadata[:is_temp]
           }
         end
@@ -109,7 +109,10 @@ module WikiParser
       when 'tweet'
         ''
       when 'fn'
-        metadata[:fn] = plugin_value&.strip
+        metadata[:notes] << plugin_value&.strip if plugin_value.present?
+        ''
+      when 'category'
+        metadata[:notes] << plugin_value&.strip if plugin_value.present?
         ''
       when 'temp'
         if plugin_value&.include?(',')
@@ -118,7 +121,7 @@ module WikiParser
           name_part = plugin_value&.strip
           badge_part = nil
         end
-        metadata[:fn] = badge_part
+        metadata[:notes] << badge_part if badge_part.present?
         metadata[:is_temp] = true
         name_part
       else

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -55,8 +55,10 @@
                               <% if item[:part_and_name].present? %>
                                 <span class="text-xs font-bold text-slate-600 dark:text-slate-300 ml-1">(<%= item[:part_and_name] %>)</span>
                               <% end %>
-                              <% if item[:note].present? %>
-                                <span class="text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-2"><%= item[:note] %></span>
+                              <% if item[:notes].present? %>
+                                <% item[:notes].each do |note| %>
+                                  <span class="text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-2"><%= note %></span>
+                                <% end %>
                               <% end %>
                             </h3>
                           <% end %>


### PR DESCRIPTION
## 概要
`category` プラグイン (`{{category Parameter}}`) のパラメータをバッジとして表示し、複数のバッジを並べて表示できるように改善しました。

## 変更点

### 解析ロジック (`WikiParser`)
- **複数バッジ対応**: アイテムのデータ構造を `note` (String) から `notes` (Array) に変更し、複数の情報を保持できるようにしました。
- **`category` プラグイン対応**: パラメータを抽出し、`notes` 配列に追加するようにしました。
- **空アイテムの許容**: プラグインのみで表示テキストがない場合（例: `{{category Vocal}}`）でも、バッジ情報があればスキップせずに表示するように修正しました。

### 表示 (`Views`)
- **[app/views/profiles/show.html.erb]**: `item[:note]` の単一表示を `item[:notes]` のループ表示に変更。
- **[app/components/member_row_component.html.erb]**: 同様にループ表示に変更。

これにより、`{{category Vocal}}{{fn 2024}}` のように記述されている場合に「Vocal」「2024」の両方がバッジとして表示されるようになります。

## 検証
Rails Console にて以下のパース結果を確認済み。
- `{{category Vocal}}` 単独でのパース
- `category` と `fn` の併用時のパース
- 複数アイテム混在時のパース
