### PR TITLE
ユニット・個人一覧へのページネーション追加とUI改善

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -2,8 +2,9 @@
 
 class PeopleController < ApplicationController
   def index
-    @people = Person.where.not(key: [nil, '']).order(updated_at: :desc)
-    @people = @people.where('name ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
+    scope = Person.where.not(key: [nil, '']).order(updated_at: :desc)
+    scope = scope.where('name ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
+    @pagy, @people = pagy(scope, limit: 60)
   end
 
   def show

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -22,7 +22,7 @@ class TrendsController < ApplicationController
       scope = scope.where(date: start_date..end_date)
     end
 
-    @pagy, @trends = pagy(scope)
+    @pagy, @trends = pagy(scope, limit: 20)
 
     all_unit_ids = @trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
     @related_units = Unit.where(id: all_unit_ids).index_by(&:id)

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -2,8 +2,9 @@
 
 class UnitsController < ApplicationController
   def index
-    @units = Unit.all.order(updated_at: :desc)
-    @units = @units.where('name ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
+    scope = Unit.all.order(updated_at: :desc)
+    scope = scope.where('name ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
+    @pagy, @units = pagy(scope, limit: 60)
   end
 
   def show

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,9 +1,9 @@
-<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
-    <header class="mb-8">
-      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center gap-3">
+    <header class="mb-8 text-center flex flex-col items-center">
+      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">
         <span class="text-person">PEOPLE</span>
-        <span class="text-slate-300 dark:text-slate-600 text-lg font-bold"><%= @people.count %> records</span>
+        <span class="text-slate-300 dark:text-slate-600 text-lg font-bold"><%= @pagy.count %> records</span>
       </h1>
     </header>
 
@@ -18,31 +18,41 @@
       <% end %>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-      <% @people.each do |person| %>
-        <%= link_to profile_path(person.key), class: "group block bg-slate-50 dark:bg-slate-900/50 p-6 rounded-2xl border border-slate-100 dark:border-slate-700 hover:border-person hover:scale-[1.02] transition-all relative overflow-hidden" do %>
-          <div class="absolute top-0 right-0 p-3 opacity-10 group-hover:opacity-20 transition-opacity">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-            </svg>
-          </div>
-          <div class="relative z-10">
-            <h2 class="text-lg font-black text-slate-800 dark:text-slate-200 group-hover:text-person transition-colors truncate"><%= person.name %></h2>
-            <% if person.name_kana.present? %>
-              <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1"><%= person.name_kana %></p>
-            <% end %>
-            <div class="mt-4 flex flex-wrap gap-2">
-              <% if person.status.present? %>
-                <span class="text-[0.65rem] font-black uppercase px-2 py-0.5 rounded-md bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300"><%= person.status %></span>
+    <% if @people.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        <% @people.each do |person| %>
+          <%= link_to profile_path(person.key), class: "group block bg-slate-50 dark:bg-slate-900/50 p-6 rounded-2xl border border-slate-100 dark:border-slate-700 hover:border-person hover:scale-[1.02] transition-all relative overflow-hidden" do %>
+            <div class="absolute top-0 right-0 p-3 opacity-10 group-hover:opacity-20 transition-opacity">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+              </svg>
+            </div>
+            <div class="relative z-10">
+              <h2 class="text-lg font-black text-slate-800 dark:text-slate-200 group-hover:text-person transition-colors truncate"><%= person.name %></h2>
+              <% if person.name_kana.present? %>
+                <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1"><%= person.name_kana %></p>
               <% end %>
+              <div class="mt-4 flex flex-wrap gap-2">
+                <% if person.status.present? %>
+                  <span class="text-[0.65rem] font-black uppercase px-2 py-0.5 rounded-md bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300"><%= person.status %></span>
+                <% end %>
+              </div>
+              <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 flex justify-between items-center text-[0.65rem] font-bold text-slate-400 dark:text-slate-500">
+                <span class="uppercase tracking-widest">Update</span>
+                <span><%= person.updated_at.strftime("%Y.%m.%d") %></span>
+              </div>
             </div>
-            <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 flex justify-between items-center text-[0.65rem] font-bold text-slate-400 dark:text-slate-500">
-              <span class="uppercase tracking-widest">Update</span>
-              <span><%= person.updated_at.strftime("%Y.%m.%d") %></span>
-            </div>
-          </div>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
+    <% else %>
+      <div class="py-20 text-center">
+        <p class="text-slate-400 dark:text-slate-500 font-bold">検索結果が見つかりませんでした。</p>
+      </div>
+    <% end %>
+
+    <div class="mt-8 flex justify-center">
+      <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
     </div>
   </div>
 </div>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -1,9 +1,9 @@
-<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
-    <header class="mb-8">
-      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center gap-3">
+    <header class="mb-8 text-center flex flex-col items-center">
+      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">
         <span class="text-unit">UNITS</span>
-        <span class="text-slate-300 dark:text-slate-600 text-lg font-bold"><%= @units.count %> records</span>
+        <span class="text-slate-300 dark:text-slate-600 text-lg font-bold"><%= @pagy.count %> records</span>
       </h1>
     </header>
 
@@ -18,31 +18,41 @@
       <% end %>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-      <% @units.each do |unit| %>
-        <%= link_to profile_path(unit.key), class: "group block bg-slate-50 dark:bg-slate-900/50 p-6 rounded-2xl border border-slate-100 dark:border-slate-700 hover:border-unit hover:scale-[1.02] transition-all relative overflow-hidden" do %>
-          <div class="absolute top-0 right-0 p-3 opacity-10 group-hover:opacity-20 transition-opacity">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
-            </svg>
-          </div>
-          <div class="relative z-10">
-            <h2 class="text-lg font-black text-slate-800 dark:text-slate-200 group-hover:text-unit transition-colors truncate"><%= unit.name %></h2>
-            <% if unit.unit_type.present? %>
-              <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1 uppercase tracking-wider"><%= unit.unit_type %></p>
-            <% end %>
-            <div class="mt-4 flex flex-wrap gap-2">
-              <% if unit.status.present? %>
-                <span class="text-[0.65rem] font-black uppercase px-2 py-0.5 rounded-md bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300"><%= unit.status %></span>
+    <% if @units.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        <% @units.each do |unit| %>
+          <%= link_to profile_path(unit.key), class: "group block bg-slate-50 dark:bg-slate-900/50 p-6 rounded-2xl border border-slate-100 dark:border-slate-700 hover:border-unit hover:scale-[1.02] transition-all relative overflow-hidden" do %>
+            <div class="absolute top-0 right-0 p-3 opacity-10 group-hover:opacity-20 transition-opacity">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+              </svg>
+            </div>
+            <div class="relative z-10">
+              <h2 class="text-lg font-black text-slate-800 dark:text-slate-200 group-hover:text-unit transition-colors truncate"><%= unit.name %></h2>
+              <% if unit.unit_type.present? %>
+                <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1 uppercase tracking-wider"><%= unit.unit_type %></p>
               <% end %>
+              <div class="mt-4 flex flex-wrap gap-2">
+                <% if unit.status.present? %>
+                  <span class="text-[0.65rem] font-black uppercase px-2 py-0.5 rounded-md bg-slate-200 dark:bg-slate-700 text-slate-600 dark:text-slate-300"><%= unit.status %></span>
+                <% end %>
+              </div>
+              <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 flex justify-between items-center text-[0.65rem] font-bold text-slate-400 dark:text-slate-500">
+                <span class="uppercase tracking-widest">Update</span>
+                <span><%= unit.updated_at.strftime("%Y.%m.%d") %></span>
+              </div>
             </div>
-            <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 flex justify-between items-center text-[0.65rem] font-bold text-slate-400 dark:text-slate-500">
-              <span class="uppercase tracking-widest">Update</span>
-              <span><%= unit.updated_at.strftime("%Y.%m.%d") %></span>
-            </div>
-          </div>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
+    <% else %>
+      <div class="py-20 text-center">
+        <p class="text-slate-400 dark:text-slate-500 font-bold">検索結果が見つかりませんでした。</p>
+      </div>
+    <% end %>
+
+    <div class="mt-8 flex justify-center">
+      <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
     </div>
   </div>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,5 +4,5 @@
 require 'pagy/extras/overflow'
 
 # Pagy initializer
-Pagy::DEFAULT[:items] = 20
+Pagy::DEFAULT[:limit] = 60
 Pagy::DEFAULT[:overflow] = :last_page


### PR DESCRIPTION
## 概要
ユニット一覧 (`/units`) と個人一覧 (`/people`) にページネーションを追加し、視認性と利便性を向上させるためのUI改善を行いました。

## 変更点

### ページネーション (Pagy)
- **1ページ60件表示**: Pagy 9系の仕様（`limit` キーワード）に基づき、各アクションおよび初期化設定を修正しました。
- **ナビゲーションの追加**: 一覧の下部にページ切り替え用のナビゲーションを中央揃えで配置しました。

### UI/レイアウト改善
- **上寄せの適用**: 検索結果が少ない場合にコンテンツが画面中央に浮いてしまうのを防ぐため、コンテナを上寄せに変更しました。
- **ヘッダーのセンタリング**: ページタイトルと件数表示を中央揃えに配置しました。
- **検索結果なしメッセージ**: 検索結果が0件の場合に「検索結果が見つかりませんでした。」というメッセージを表示するようにし、グリッドレイアウトの影響を受けないよう配置を最適化しました。
- **件数表示の修正**: 現在のページ件数ではなく、全体のレコード数を表示するように `pagy.count` を使用するように変更しました。

## 検証
- `/units` および `/people` で 60 件ずつ表示されることを確認。
- 検索実行時および結果 0 件時の表示が正しく中央に配置されることを確認。
- トレンド一覧への影響がないこと（20件表示を維持）を確認。
