### PR TITLE
feat: プロフィールページのアイテム表示件数を10件にし、文言を詳細化

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -32,7 +32,7 @@ class ProfilesController < ApplicationController
     if @resource.old_key.present?
       @items = Item.by_artist_old_key(@resource.old_key)
                    .order(release_date: :desc)
-                   .limit(5)
+                   .limit(10)
     end
 
     respond_to do |format|

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -80,11 +80,13 @@
       <% if @items.present? %>
         <section class="mt-8">
           <div class="flex items-center justify-between mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
-            <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Items</h2>
-            <%= link_to "View All", items_path(old_key: @resource.old_key), class: "text-xs font-medium text-slate-400 hover:text-indigo-500 transition-colors" %>
+            <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Recent Items (Max 10)</h2>
           </div>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <%= render ItemCardComponent.with_collection(@items) %>
+          </div>
+          <div class="mt-4 flex justify-center">
+            <%= link_to "View all Items for \"#{@resource.name}\" on Items page »", items_path(old_key: @resource.old_key), class: "text-xs font-medium text-slate-400 hover:text-indigo-500 transition-colors" %>
           </div>
         </section>
       <% end %>


### PR DESCRIPTION
## 概要
ユニットページと個人ページのアイテム表示件数を現在の 5 件から 10 件に増やし、表示件数の制限（最大10件）の明示と、全件表示リンクの文言をアーティスト専用のアイテムページへのリンクであることを明確にしました。

## 変更点
-  で取得するアイテム件数の上限を 10 件に変更
- ユニット・個人ページのアイテムセクションのヘッダーを "RECENT ITEMS (MAX 10)" に変更
- 全件表示リンクをアイテムリストの下部に移動し、文言を "View all Items for \"[Artist Name]\" on Items page »" に変更