### PR TITLE
feat: アイテム表示・フィルタリング機能の総合的な改善

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,16 +2,22 @@
 
 class ItemsController < ApplicationController
   def index
-    dates = Item.pluck(:release_date)
+    # 基本となるスコープの作成
+    base_scope = Item.all
+    if params[:old_key].present?
+      @artist = Unit.find_by(old_key: params[:old_key]) || Person.find_by(old_key: params[:old_key])
+      base_scope = base_scope.by_artist_old_key(params[:old_key])
+    end
+
+    # 年月タブ用のカウント取得（アーティスト絞り込みがある場合はそれに限定）
+    dates = base_scope.pluck(:release_date)
     @year_counts = dates.map(&:year).tally
     @years = @year_counts.keys.sort.reverse
 
-    scope = Item.all.order(release_date: :desc)
+    # 最終的な表示スコープの構築
+    scope = base_scope.order(release_date: :desc)
 
-    if params[:old_key].present?
-      @artist = Unit.find_by(old_key: params[:old_key]) || Person.find_by(old_key: params[:old_key])
-      scope = scope.by_artist_old_key(params[:old_key])
-    elsif params[:year].present?
+    if params[:year].present?
       year = params[:year].to_i
       month = params[:month].presence&.to_i
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,7 +3,7 @@
     <div class="p-5 md:p-8">
       <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-8">
         <% if @artist %>
-          Items for "<%= @artist.name %>"
+          Items for "<%= link_to @artist.name, profile_path(key: @artist.key), class: "hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors underline decoration-slate-300 dark:decoration-slate-600 underline-offset-4" %>"
         <% else %>
           Items
         <% end %>
@@ -21,7 +21,7 @@
           years_by_decade = @years.group_by { |y| (y / 10) * 10 }
         %>
 
-        <%= link_to "NEWEST", items_path, class: "#{base_classes} #{current_year.nil? ? active_classes : inactive_classes}" %>
+        <%= link_to "NEWEST", items_path(old_key: params[:old_key]), class: "#{base_classes} #{current_year.nil? ? active_classes : inactive_classes}" %>
 
         <% years_by_decade.each do |decade, years| %>
           <% is_active_decade = years.include?(current_year) %>
@@ -49,7 +49,7 @@
                  data-transition-leave-start="transform opacity-100 scale-100"
                  data-transition-leave-end="transform opacity-0 scale-95">
               <% years.each do |year| %>
-                <%= link_to "#{year} <span class='text-xs opacity-50 ml-1 font-normal'>(#{@year_counts[year]})</span>".html_safe, items_path(year: year), class: "block px-4 py-2 text-sm whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white #{current_year == year ? 'bg-indigo-50 dark:bg-slate-700 font-bold text-indigo-700 dark:text-indigo-300' : ''}" %>
+                <%= link_to "#{year} <span class='text-xs opacity-50 ml-1 font-normal'>(#{@year_counts[year]})</span>".html_safe, items_path(year: year, old_key: params[:old_key]), class: "block px-4 py-2 text-sm whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white #{current_year == year ? 'bg-indigo-50 dark:bg-slate-700 font-bold text-indigo-700 dark:text-indigo-300' : ''}" %>
               <% end %>
             </div>
           </div>
@@ -66,10 +66,10 @@
               current_month = params[:month].presence&.to_i
             %>
 
-            <%= link_to params[:year], items_path(year: params[:year]), class: "#{month_base_classes} #{current_month.nil? ? month_active_classes : month_inactive_classes}" %>
+            <%= link_to params[:year], items_path(year: params[:year], old_key: params[:old_key]), class: "#{month_base_classes} #{current_month.nil? ? month_active_classes : month_inactive_classes}" %>
 
             <% @months.each do |month| %>
-                <%= link_to "#{month} <span class='opacity-60 ml-0.5 font-normal'>(#{@month_counts[month]})</span>".html_safe, items_path(year: params[:year], month: month), class: "#{month_base_classes} #{current_month == month ? month_active_classes : month_inactive_classes}" %>
+                <%= link_to "#{month} <span class='opacity-60 ml-0.5 font-normal'>(#{@month_counts[month]})</span>".html_safe, items_path(year: params[:year], month: month, old_key: params[:old_key]), class: "#{month_base_classes} #{current_month == month ? month_active_classes : month_inactive_classes}" %>
             <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
## 概要
プロフィールページのアイテム全件リンク（"View all Items..."）の視認性を向上させ、遷移先のアイテム一覧ページでどのアーティストのアイテムを表示しているかを明示するようにしました。

## 変更点

### 1. プロフィールページの改善
- **視認性の向上**: リンクの色を `text-slate-400` から `text-slate-600`（ダークモードでは `text-slate-300`）に濃くしました。
- **強調**: フォントウェイトを `font-semibold` に変更しました。

### 2. アイテム一覧ページの改善
- **アーティスト名の明示**: `old_key` パラメータがある場合、対応するアーティスト名を表示するようにしました。
  - 例: `Items` -> `Items for "lynch."`
- **コントローラーの修正**: `ItemsController` で `old_key` から `Unit` または `Person` を特定するロジックを追加しました。

## スクリーンショット

### リンクのスタイリング
![Link Styling](/Users/kuwa/.gemini/antigravity/brain/b3873076-907a-446c-8740-debb2e50eb08/profile_page_all_items_link_1770307140315.png)

### アイテム一覧ページのタイトル
![Items Page Title](/Users/kuwa/.gemini/antigravity/brain/b3873076-907a-446c-8740-debb2e50eb08/items_page_title_1770307356775.png)
