### PR TITLE
feat: インポート時にその他のセクションを取り込む機能を追加 (Issue #184, #188)

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,6 +38,7 @@ class Person < ApplicationRecord
   has_many :person_logs
   has_many :tag_index_items, as: :indexable, dependent: :destroy
   has_many :tag_indices, through: :tag_index_items
+  has_many :sections, as: :sectionable, dependent: :destroy
 
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: :all_blank
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: sections
+#
+#  id               :bigint           not null, primary key
+#  name             :string
+#  wiki_text        :text
+#  sort_order       :integer
+#  sectionable_type :string           not null
+#  sectionable_id   :bigint           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_sections_on_sectionable  (sectionable_type,sectionable_id)
+#
+class Section < ApplicationRecord
+  belongs_to :sectionable, polymorphic: true
+
+  validates :name, presence: true
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -36,6 +36,7 @@ class Unit < ApplicationRecord
   has_many :person_logs, dependent: :destroy
   has_many :tag_index_items, as: :indexable, dependent: :destroy
   has_many :tag_indices, through: :tag_index_items
+  has_many :sections, as: :sectionable, dependent: :destroy
   enum :unit_type, { band: 0, unit: 1, session: 2, solo: 3, limited: 4, other: 99 }
   enum :status, { pre: 0, active: 1, freeze: 2, disbanded: 3, unknown: 99 }
 

--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -174,4 +174,65 @@ class BaseWikipageImporter
       str
     end
   end
+
+  # ==========================================
+  # Section Parsing Logic
+  # ==========================================
+
+  # Issue#188: セクションの取り込み
+  # 除外対象: リンク、メンバー*、関係者、個人情報、情報*、ディスコグラフィ*、経歴
+  EXCLUDED_SECTIONS = %w[
+    リンク
+    メンバー
+    関係者
+    個人情報
+    情報
+    ディスコグラフィ
+    経歴
+    動向
+    DVD
+    関連記事
+    関連商品
+  ].freeze
+
+  def parse_sections(owner)
+    return unless @wiki_content
+
+    # セクションを抽出: !!セクション名 から次の !! または文末まで
+    # ^!!(?!!) で「!!」ちょうど2つで始まる行のみにマッチ（!!!以上は除外）
+    sections_data = []
+    @wiki_content.scan(/^!!(?!!)(.*?)\s*\n(.*?)(?=\n!!|\z)/m) do |section_name, section_content|
+      sections_data << {
+        name: section_name.strip,
+        content: section_content.strip
+      }
+    end
+
+    # 既存の Section レコードを削除
+    owner.sections.destroy_all
+
+    # 除外対象以外のセクションを保存
+    sort_order = 1
+    sections_data.each do |section_data|
+      section_name = section_data[:name]
+      section_content = section_data[:content]
+
+      # 除外チェック: 完全一致またはワイルドカード（前方一致）
+      is_excluded = EXCLUDED_SECTIONS.any? do |excluded|
+        section_name == excluded || section_name.start_with?(excluded)
+      end
+
+      next if is_excluded
+
+      # wiki_text が空の場合は除外
+      next if section_content.blank?
+
+      owner.sections.create!(
+        name: section_name,
+        wiki_text: section_content,
+        sort_order: sort_order
+      )
+      sort_order += 1
+    end
+  end
 end

--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -135,6 +135,9 @@ class PersonImporter < BaseWikipageImporter
 
     # 5. Parse Career History
     parse_career_history(person)
+
+    # 6. Parse Sections
+    parse_sections(person)
   end
 
   def link_existing_unit_people(person)

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -143,6 +143,7 @@ class WikipageImporter < BaseWikipageImporter
     parse_members(unit)
     parse_footer_links(unit)
     parse_youtube_tags(unit)
+    parse_sections(unit)
   end
 
   def parse_categories(unit)

--- a/db/migrate/20260206125041_create_sections.rb
+++ b/db/migrate/20260206125041_create_sections.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSections < ActiveRecord::Migration[8.1]
+  def change
+    create_table :sections do |t|
+      t.string :name
+      t.text :wiki_text
+      t.integer :sort_order
+      t.references :sectionable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_05_124747) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_06_125041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -147,6 +147,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_05_124747) do
     t.index ["asin"], name: "index_release_schedules_on_asin"
     t.index ["plugin_text"], name: "index_release_schedules_on_plugin_text", unique: true
     t.index ["wiki", "release_date"], name: "index_release_schedules_on_wiki_and_release_date"
+  end
+
+  create_table "sections", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.bigint "sectionable_id", null: false
+    t.string "sectionable_type", null: false
+    t.integer "sort_order"
+    t.datetime "updated_at", null: false
+    t.text "wiki_text"
+    t.index ["sectionable_type", "sectionable_id"], name: "index_sections_on_sectionable"
   end
 
   create_table "tag_index_items", force: :cascade do |t|


### PR DESCRIPTION
## 概要
Issue #184 および #188 の対応として、`Unit` や `Person` の Wiki テキストに含まれる「その他のセクション」を保存する機能を実装しました。

## 変更内容
- **データベース**: `sections` テーブルを作成（多態性関連で `Unit` と `Person` に紐付け）
- **モデル**: `Section` モデルを作成し、`Unit` / `Person` に関連付けを追加
- **インポート処理**:
  - `BaseWikipageImporter` に `parse_sections` メソッドを追加
  - Wiki テキストから `!!` で始まるセクションを抽出（`!!!` など3つ以上の `!` で始まるものは除外）
  - 以下の **除外対象セクション** 以外を `sections` テーブルに保存
    - リンク, メンバー*, 関係者, 個人情報, 情報*, ディスコグラフィ*, 経歴, 動向, DVD, 関連記事, 関連商品
  - `wiki_text` が空の場合は保存しないように制御

## 関連 Issue
- #184
- #188
