### PR TITLE
feat: b_hiddenプラグイン内のテキストを解析から除外する機能を追加 (Issue #183)

### DIFF
--- a/app/components/section_component.rb
+++ b/app/components/section_component.rb
@@ -5,7 +5,7 @@ class SectionComponent < ViewComponent::Base
   with_collection_parameter :section
 
   def initialize(section:)
-    super
+    super()
     @section = section
   end
 end

--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -7,13 +7,16 @@ require 'romaji'
 class BaseWikipageImporter
   include IgnorableWikipage
 
+  attr_reader :original_content
+
   def self.import(wikipage)
     new(wikipage).import
   end
 
   def initialize(wikipage)
     @wikipage = wikipage
-    @wiki_content = wikipage.wiki
+    @wiki_content = wikipage.wiki&.dup
+    @original_content = @wiki_content&.dup
     @attributes = wikipage.attributes.slice('dw_id', 'it_id', 'eplus_id')
     @wikipage_name = wikipage.name
   end
@@ -40,8 +43,11 @@ class BaseWikipageImporter
 
   # Override in subclasses if custom preprocessing is needed
   def preprocess_content
+    # Remove b_hidden blocks: {{b_hidden ... }} (ends with }} at the beginning of a line)
+    @wiki_content = @wiki_content&.gsub(/\{\{b_hidden.*?(?:^\}\}|\z)/m, '')
+
     # Default: Remove comment lines
-    @wiki_content = @wiki_content.lines.reject { |line| line.strip.start_with?('//') }.join
+    @wiki_content = @wiki_content&.lines&.reject { |line| line.strip.start_with?('//') }&.join
   end
 
   def parse_youtube_tags(owner)

--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -86,7 +86,7 @@ class PersonImporter < BaseWikipageImporter
     person.name_log = name_log_entries if name_log_entries.present?
     person.old_key = encoded_old_key
     person.old_wiki_id = @wikipage.id
-    person.old_wiki_text = @wiki_content
+    person.old_wiki_text = @original_content
 
     # Status
     person.status = if categories_data[:is_passed_away]

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -25,6 +25,9 @@ class WikipageImporter < BaseWikipageImporter
 
   # Override to preserve {{member...}} blocks during preprocessing
   def preprocess_content
+    # Remove b_hidden blocks first
+    @wiki_content.gsub!(/\{\{b_hidden.*?(?:^\}\}|\z)/m, '')
+
     # Extract and preserve {{member...}} blocks before removing comments
     @member_blocks = []
     @wiki_content.gsub!(/\{\{member2?\s+.*?\}\}/m) do |block|
@@ -134,7 +137,7 @@ class WikipageImporter < BaseWikipageImporter
     unit.name_log = name_log_entries if name_log_entries.present?
     unit.old_key = encoded_old_key
     unit.old_wiki_id = @wikipage.id
-    unit.old_wiki_text = @wiki_content
+    unit.old_wiki_text = @original_content
     unit.unit_type = unit_type
     unit.status = :active
     unit.save!


### PR DESCRIPTION
feat: b_hiddenプラグイン内のテキストを解析から除外する機能を追加 (Issue #183)

## 概要
Issue #183 に基づき、Wikiテキスト内の `{{b_hidden ... }}` プラグインで囲まれた部分を解析対象から除外する機能を実装しました。
また、`old_wiki_text` カラムには、隠しテキストを含む元のテキストがそのまま保存されるようにしました。

## 変更点
- `BaseWikipageImporter`:
  - `initialize` で原文 (`@original_content`) を保持するように修正。
  - `preprocess_content` で `{{b_hidden ... }}` ブロックを除去する処理を追加。
- `WikipageImporter` / `PersonImporter`:
  - `old_wiki_text` の保存元を `@wiki_content` (解析用) から `@original_content` (原文) に変更。
  - `WikipageImporter` で `sanitize` との競合を避けるため `preprocess_content` の順序を調整。
- `SectionComponent`:
  - `initialize` での `super` 呼び出しにおける `ArgumentError` を修正。

## 動作確認
検証用スクリプトにより、以下の動作を確認済みです。
- `{{b_hidden ... }}` ブロックが解析用テキストから削除されること。
- `old_wiki_text` には `{{b_hidden ... }}` を含む原文が保存されていること。
- `}}` が行頭にある場合のみブロック終了とみなされること。
