### PR TITLE
fix: インポート処理でのName can't be blankエラーを修正

### DIFF
--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -233,6 +233,9 @@ class BaseWikipageImporter
       # wiki_text が空の場合は除外
       next if section_content.blank?
 
+      # 名前が空の場合は除外 (Fix: Name can't be blank error)
+      next if section_name.blank?
+
       owner.sections.create!(
         name: section_name,
         wiki_text: section_content,


### PR DESCRIPTION
fix: インポート処理でのName can't be blankエラーを修正

## 概要
`bin/rails import:people` 実行時に、 Wiki テキストのパース結果でセクション名が空になるケースがあり、`ActiveRecord::RecordInvalid: Validation failed: Name can't be blank` が発生していました。これに対処します。

## 変更内容
- `BaseWikipageImporter#parse_sections`: セクション名 (`section_name`) が空の場合、当該セクションの保存をスキップするように修正しました。

## 動作確認
`next if section_name.blank?` を追加することで、バリデーションエラーが回避されることを想定しています。
