### PR TITLE
fix: セクションの表示位置をHistoryの下へ移動

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,9 +22,7 @@
 
 
 
-          <% if @resource.sections.exists? %>
-            <%= render SectionComponent.with_collection(@resource.sections.order(:sort_order)) %>
-          <% end %>
+
 
           <% if (@resource.is_a?(Person) && (@logs.present? || @old_history_items.present?)) || (@resource.is_a?(Unit) && @history.present?) %>
             <section>
@@ -79,6 +77,10 @@
                 <% end %>
               </div>
             </section>
+          <% end %>
+
+          <% if @resource.sections.exists? %>
+            <%= render SectionComponent.with_collection(@resource.sections.order(:sort_order)) %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
fix: セクションの表示位置をHistoryの下へ移動

## 概要
ユーザーの要望により、個人ページ（およびユニットページ）におけるセクション情報の表示位置を、History情報の下へ移動しました。

## 変更内容
- `app/views/profiles/show.html.erb`: `SectionComponent` のレンダリングブロックを History セクションの後ろへ移動。

## 動作確認
- プロフィールページにおいて、Historyが表示される場合、その下にセクション情報（備考など）が表示されることを確認。
