### PR TITLE
fix: セクションパース処理をscanからsplitに変更し、空行の扱いや区切り認識を改善

### DIFF
--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -205,9 +205,15 @@ class BaseWikipageImporter
     return unless @wiki_content
 
     # セクションを抽出: !!セクション名 から次の !! または文末まで
-    # ^!!(?!!) で「!!」ちょうど2つで始まる行のみにマッチ（!!!以上は除外）
+    # ^!!(?!!) で「!!」ちょうど2つで始まる行で分割
+    # splitの結果: [preamble, name1, content1, name2, content2, ...]
+    parts = @wiki_content.split(/^!!(?!!)(.*?)[\r\n]+/)
+    parts.shift # 先頭の要素（最初のセクションより前のテキスト）は無視
+
     sections_data = []
-    @wiki_content.scan(/^!!(?!!)(.*?)\s*\n(.*?)(?=\n!!|\z)/m) do |section_name, section_content|
+    parts.each_slice(2) do |section_name, section_content|
+      next if section_name.nil? || section_content.nil?
+
       sections_data << {
         name: section_name.strip,
         content: section_content.strip


### PR DESCRIPTION
fix: セクションパース処理をscanからsplitに変更

## 概要
インポート処理 (`BaseWikipageImporter#parse_sections`) において、正規表現による `scan` を使用したセクションの抽出で、空行が含まれる場合などに正しく分割されない不具合がありました。
これを解消するため、`split` を使用してセクション名とコンテンツを分割するロジックに変更しました。

## 変更内容
- `BaseWikipageImporter`
  - `parse_sections`: `scan` メソッドを廃止し、`split(/^!!(?!!)(.*?)[\r\n]+/)` を使用するように変更。
  - 区切られた配列を2要素ずつスライスして (名前, コンテンツ) のペアとして処理。

## 動作確認
再現スクリプト (`tmp/test_section_parsing.rb`) により、以下のケースで正しくパースされることを確認しました。
```
!!備考
//コメント

!!動向
{{trend}}
```
上記のような、セクション間に空行やコメント行が含まれる場合でも、後続のセクションが前のセクションに取り込まれることなく、正しく分離されます。
