### PR TITLE
feat: 個人・ユニット検索でよみがな(name_kana)も対象に追加

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,7 +3,7 @@
 class PeopleController < ApplicationController
   def index
     scope = Person.where.not(key: [nil, '']).order(updated_at: :desc)
-    scope = scope.where('name ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
+    scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
     @pagy, @people = pagy(scope, limit: 60)
   end
 

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -3,7 +3,7 @@
 class UnitsController < ApplicationController
   def index
     scope = Unit.all.order(updated_at: :desc)
-    scope = scope.where('name ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
+    scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q', q: "%#{params[:q]}%") if params[:q].present?
     @pagy, @units = pagy(scope, limit: 60)
   end
 


### PR DESCRIPTION
feat: 個人・ユニット検索でよみがな(name_kana)も対象に追加

## 概要
これまで個人一覧・ユニット一覧の検索フォームでは、名前 (`name`) と変更履歴 (`name_log`) のみが検索対象でしたが、よみがな (`name_kana`) も検索対象に追加しました。
これにより、ひらがなやカタカナでの検索が容易になります。

## 変更内容
- `UnitsController#index`: 検索スコープに `OR name_kana ILIKE :q` を追加。
- `PeopleController#index`: 検索スコープに `OR name_kana ILIKE :q` を追加。

## 動作確認
- コンソールでの検証スクリプトにより、`name_kana` にマッチするクエリでレコードがヒットすることを確認済み。
