### PR TITLE
feat: Add Name History display component

### DIFF
--- a/app/components/name_history_component.html.erb
+++ b/app/components/name_history_component.html.erb
@@ -1,0 +1,6 @@
+<section class="mt-8">
+  <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">Name History</h2>
+  <div class="space-y-6">
+    <%= render NameHistoryItemComponent.with_collection(name_logs) %>
+  </div>
+</section>

--- a/app/components/name_history_component.rb
+++ b/app/components/name_history_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Displays the name history timeline for a Unit or Person
+class NameHistoryComponent < ViewComponent::Base
+  def initialize(resource:)
+    super()
+    @resource = resource
+  end
+
+  def render?
+    @resource.name_logs.present?
+  end
+
+  def name_logs
+    @resource.name_logs.sort_by { |log| log.date.to_s }
+  end
+end

--- a/app/components/name_history_item_component.html.erb
+++ b/app/components/name_history_item_component.html.erb
@@ -1,0 +1,12 @@
+<div class="relative flex items-start gap-4">
+  <div class="flex-shrink-0 w-3 h-3 mt-1.5 bg-slate-200 dark:bg-slate-600 rounded-full border-2 border-white dark:border-slate-800"></div>
+  <div class="flex flex-col flex-1">
+    <% if @log.date.present? %>
+      <span class="text-xs font-semibold text-slate-400 dark:text-slate-500 mb-0.5"><%= @log.date %></span>
+    <% end %>
+    <span class="text-sm font-bold text-slate-700 dark:text-slate-200"><%= @log.name %></span>
+    <% if @log.name_kana.present? %>
+      <span class="text-xs text-slate-500 dark:text-slate-400">(<%= @log.name_kana %>)</span>
+    <% end %>
+  </div>
+</div>

--- a/app/components/name_history_item_component.rb
+++ b/app/components/name_history_item_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Displays a single name history log entry with date, name, and kana
+class NameHistoryItemComponent < ViewComponent::Base
+  with_collection_parameter :log
+
+  def initialize(log:)
+    super()
+    @log = log
+  end
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,6 +6,7 @@
       <div class="grid gap-8 grid-cols-1 md:grid-cols-[350px_1fr] items-start">
         <div>
           <%= render BasicAttributesComponent.new(resource: @resource) %>
+          <%= render NameHistoryComponent.new(resource: @resource) %>
           <%= render LinksComponent.new(links: @links) %>
           <%= render SpotifyEmbedComponent.new(links: @links) %>
         </div>

--- a/test/components/previews/name_history_item_component_preview.rb
+++ b/test/components/previews/name_history_item_component_preview.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class NameHistoryItemComponentPreview < ViewComponent::Preview
+  # @label Default
+  def default
+    log = OpenStruct.new(
+      date: '2024/01/01',
+      name: 'Sample Band Name',
+      name_kana: 'サンプルバンドメイ'
+    )
+    render(NameHistoryItemComponent.new(log: log))
+  end
+
+  # @label No Date
+  def no_date
+    log = OpenStruct.new(
+      date: nil,
+      name: 'Undated Band Name',
+      name_kana: 'ヒヅケナシ'
+    )
+    render(NameHistoryItemComponent.new(log: log))
+  end
+
+  # @label No Kana
+  def no_kana
+    log = OpenStruct.new(
+      date: '2020/05/05',
+      name: 'Band Name Only',
+      name_kana: nil
+    )
+    render(NameHistoryItemComponent.new(log: log))
+  end
+
+  # @label Collection
+  def collection
+    logs = [
+      OpenStruct.new(date: '2020/01/01', name: 'First Name', name_kana: 'イチバンメ'),
+      OpenStruct.new(date: '2022/01/01', name: 'Second Name', name_kana: 'ニバンメ'),
+      OpenStruct.new(date: nil, name: 'Current Name', name_kana: 'ゲンザイ')
+    ]
+    render(NameHistoryItemComponent.with_collection(logs))
+  end
+end


### PR DESCRIPTION
## Summary
- プロフィールページ（Unit/Person）に「Name History」セクションを追加しました。
-  データを表示する  と  を作成しました。

## Changes
### New Components
- :  を表示するラッパーコンポーネント
- : 個々の履歴エントリを表示（ 対応）

### Modified Files
- : Basic Information の下に  を配置

### Lookbook
- : Lookbook プレビューを追加

## Design
- Flexbox レイアウトを使用してドットとテキストを分離
-  でドットとテキストの間に適切な間隔を確保
- ダークモード対応

## Verified
- Lookbook でコンポーネントの表示を確認
- RuboCop とテストが通過