### PR TITLE
style: Adjust definition list styling

### DIFF
--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -41,8 +41,8 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
       if line =~ /^:(.+?):(.*)$/
         term = Regexp.last_match(1)
         desc = Regexp.last_match(2)
-        dt = tag.dt(class: 'font-bold text-slate-700 dark:text-slate-300') { parse_wiki_links(term) }
-        dd = tag.dd(class: 'text-slate-600 dark:text-slate-400 ml-4 mb-2') { parse_wiki_links(desc) }
+        dt = tag.dt(class: 'text-sm font-semibold text-slate-500 dark:text-slate-400 mt-2') { parse_wiki_links(term) }
+        dd = tag.dd(class: 'text-slate-700 dark:text-slate-300 ml-4 mb-2') { parse_wiki_links(desc) }
         dt + dd
       else
         ''


### PR DESCRIPTION
## Summary
定義リスト（`<dl>`）のスタイルを微調整しました。`<dt>`（用語）の主張が強すぎたため、フォントサイズと色を抑えてラベルとしての役割を明確にしました。

## Changes
- `app/helpers/wiki_link_helper.rb`:
    - `dt`:
        - `font-bold` -> `font-semibold`
        - `text-slate-700` -> `text-slate-500`
        - `text-base` (implied) -> `text-sm`
    - `dd`:
        - `text-slate-600` -> `text-slate-700` (読みやすさ向上のため少し濃く変更)

## Verification
検証スクリプトにて出力されるHTMLクラスが変更されていることを確認しました。