### PR TITLE
Separate mobile navigation into two independent hamburger menus

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -132,95 +132,119 @@
             <% end %>
           </div>
           
-          <!-- Mobile menu button -->
-          <div class="-mr-2 flex items-center sm:hidden" data-controller="mobile-menu">
-            <button type="button" class="bg-white dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-controls="mobile-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
-              <span class="sr-only">Open main menu</span>
-              <!-- Icon when menu is closed. -->
-              <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconOpen">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-              </svg>
-              <!-- Icon when menu is open. -->
-              <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconClose">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-            
-            <!-- Mobile menu, show/hide based on menu state. -->
-            <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-gray-800 shadow-lg border-t border-gray-200 dark:border-gray-700" id="mobile-menu" data-mobile-menu-target="menu">
-              <div class="pt-2 pb-3 space-y-1">
-                <%= link_to units_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
-                  <div class="flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 13.742a6.051 6.051 0 0 1 12 0c0 .94-.251 1.815-.695 2.571ZM10.5 8.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Zm0 1.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm6.75 3a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM17.25 10.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" />
-                    </svg>
-                    Units
-                  </div>
-                <% end %>
-                <%= link_to people_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
-                  <div class="flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
-                    </svg>
-                    People
-                  </div>
-                <% end %>
-                <%= link_to trends_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
-                  <div class="flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.307a11.95 11.95 0 0 1 5.814-5.519l2.74-1.22m0 0-5.94-2.28m5.94 2.28-2.28 5.941" />
-                    </svg>
-                    Trends
-                  </div>
-                <% end %>
-                <%= link_to items_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
-                  <div class="flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
-                    </svg>
-                    Items
-                  </div>
-                <% end %>
+          <!-- Mobile Navigation: Two separate hamburger menus -->
+          <div class="flex items-center gap-2 sm:hidden">
+            <!-- Left Hamburger: Common Navigation (Units, People, Trends, Items) -->
+            <div data-controller="mobile-menu">
+              <button type="button" class="bg-white dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-controls="common-nav-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
+                <span class="sr-only">Open navigation menu</span>
+                <!-- Icon when menu is closed -->
+                <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconOpen">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                </svg>
+                <!-- Icon when menu is open -->
+                <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconClose">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+              
+              <!-- Common Navigation Menu Panel -->
+              <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-gray-800 shadow-lg border-t border-gray-200 dark:border-gray-700" id="common-nav-menu" data-mobile-menu-target="menu">
+                <div class="pt-2 pb-3 space-y-1">
+                  <%= link_to units_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                    <div class="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 13.742a6.051 6.051 0 0 1 12 0c0 .94-.251 1.815-.695 2.571ZM10.5 8.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Zm0 1.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm6.75 3a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM17.25 10.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" />
+                      </svg>
+                      Units
+                    </div>
+                  <% end %>
+                  <%= link_to people_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                    <div class="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+                      </svg>
+                      People
+                    </div>
+                  <% end %>
+                  <%= link_to trends_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                    <div class="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.307a11.95 11.95 0 0 1 5.814-5.519l2.74-1.22m0 0-5.94-2.28m5.94 2.28-2.28 5.941" />
+                      </svg>
+                      Trends
+                    </div>
+                  <% end %>
+                  <%= link_to items_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                    <div class="flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
+                      </svg>
+                      Items
+                    </div>
+                  <% end %>
+                </div>
               </div>
-              <div class="pt-4 pb-3 border-t border-gray-200 dark:border-gray-700">
+            </div>
+
+            <!-- Right Hamburger: Admin/User Menu -->
+            <div data-controller="mobile-menu">
+              <button type="button" class="bg-white dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-controls="admin-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
+                <span class="sr-only">Open user menu</span>
+                <!-- Icon when menu is closed -->
+                <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconOpen">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                </svg>
+                <!-- Icon when menu is open -->
+                <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconClose">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+              
+              <!-- Admin/User Menu Panel -->
+              <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-gray-800 shadow-lg border-t border-gray-200 dark:border-gray-700" id="admin-menu" data-mobile-menu-target="menu">
                 <% if logged_in? %>
-                  <div class="flex items-center px-4">
-                    <div class="flex-shrink-0">
-                      <div class="h-10 w-10 rounded-full bg-gray-300 flex items-center justify-center text-gray-700 font-bold">
-                        <%= current_user.name.first.upcase %>
+                  <div class="pt-4 pb-3">
+                    <div class="flex items-center px-4">
+                      <div class="flex-shrink-0">
+                        <div class="h-10 w-10 rounded-full bg-gray-300 flex items-center justify-center text-gray-700 font-bold">
+                          <%= current_user.name.first.upcase %>
+                        </div>
+                      </div>
+                      <div class="ml-3">
+                        <div class="text-base font-medium text-gray-800 dark:text-white"><%= current_user.name %></div>
                       </div>
                     </div>
-                    <div class="ml-3">
-                      <div class="text-base font-medium text-gray-800 dark:text-white"><%= current_user.name %></div>
+                    <div class="mt-3 space-y-1">
+                      <!-- Mobile Admin Links -->
+                      <%= link_to admin_units_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Settings: Units
+                      <% end %>
+                      <%= link_to admin_people_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Settings: People
+                      <% end %>
+                      <%= link_to admin_index_groups_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Settings: Index Groups
+                      <% end %>
+                      <%= link_to admin_external_sites_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Settings: External Sites
+                      <% end %>
+                      <%= link_to admin_users_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Settings: Users
+                      <% end %>
+                      <%= link_to edit_password_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Password Settings
+                      <% end %>
+                      <%= button_to logout_path, method: :delete, class: "block w-full text-left px-4 py-2 text-base font-medium text-red-600 hover:text-red-800 hover:bg-gray-100 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-gray-700" do %>
+                        Logout
+                      <% end %>
                     </div>
                   </div>
-                  <div class="mt-3 space-y-1">
-                    <!-- Mobile Admin Links -->
-                    <%= link_to admin_units_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
-                      Settings: Units
-                    <% end %>
-                    <%= link_to admin_people_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
-                      Settings: People
-                    <% end %>
-                    <%= link_to admin_index_groups_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
-                      Settings: Index Groups
-                    <% end %>
-                    <%= link_to admin_external_sites_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
-                      Settings: External Sites
-                    <% end %>
-                    <%= link_to admin_users_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
-                      Settings: Users
-                    <% end %>
-                    <%= link_to edit_password_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
-                      Password Settings
-                    <% end %>
-                    <%= button_to logout_path, method: :delete, class: "block w-full text-left px-4 py-2 text-base font-medium text-red-600 hover:text-red-800 hover:bg-gray-100 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-gray-700" do %>
-                      Logout
-                    <% end %>
-                  </div>
                 <% else %>
-                  <div class="mt-3 space-y-1">
-                    <%= link_to "Login", login_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" %>
+                  <div class="pt-4 pb-3">
+                    <div class="space-y-1">
+                      <%= link_to "Login", login_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" %>
+                    </div>
                   </div>
                 <% end %>
               </div>


### PR DESCRIPTION
## 概要

モバイルナビゲーションを2つの独立したハンバーガーメニューに分離しました。

## 変更内容

### モバイル表示（640px未満）
- **左側ハンバーガー**（三本線アイコン）: 共通ナビゲーション（Units, People, Trends, Items）
- **右側ハンバーガー**（ユーザーアイコン）: Admin設定またはLoginリンク

### 実装の特徴
- 2つの独立した`mobile-menu`コントローラーインスタンス
- 各メニューが独立して開閉
- ログイン状態に応じて右メニューの内容が切り替わる
- デスクトップレイアウトは変更なし（横並びナビ + ドロップダウン）

## 検証結果
- ✅ モバイル表示で2つのハンバーガーアイコンが表示
- ✅ 左ハンバーガーで共通ナビゲーションが開く
- ✅ 右ハンバーガーでユーザーメニューが開く
- ✅ 両メニューが独立して動作
- ✅ デスクトップレイアウトは変更なし
- ✅ 全テスト通過

## 関連
- 前回のPR #208（モバイルナビゲーション実装）の改善版