### PR TITLE
Improve mobile menu UX with click-outside and mutual exclusion

### DIFF
--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -6,6 +6,19 @@ export default class extends Controller {
     connect() {
         console.log("MobileMenuController connected")
         this.close()
+
+        // メニュー外クリックで閉じる
+        this.boundHandleClickOutside = this.handleClickOutside.bind(this)
+        document.addEventListener("click", this.boundHandleClickOutside)
+
+        // 他のメニューが開いたら自分を閉じる
+        this.boundHandleOtherMenuOpened = this.handleOtherMenuOpened.bind(this)
+        document.addEventListener("mobile-menu:opened", this.boundHandleOtherMenuOpened)
+    }
+
+    disconnect() {
+        document.removeEventListener("click", this.boundHandleClickOutside)
+        document.removeEventListener("mobile-menu:opened", this.boundHandleOtherMenuOpened)
     }
 
     toggle(event) {
@@ -23,6 +36,12 @@ export default class extends Controller {
         this.element.setAttribute("aria-expanded", "true")
         if (this.hasIconOpenTarget) this.iconOpenTarget.classList.add("hidden")
         if (this.hasIconCloseTarget) this.iconCloseTarget.classList.remove("hidden")
+
+        // 他のメニューに通知
+        const event = new CustomEvent("mobile-menu:opened", {
+            detail: { controller: this }
+        })
+        document.dispatchEvent(event)
     }
 
     close() {
@@ -30,5 +49,26 @@ export default class extends Controller {
         this.element.setAttribute("aria-expanded", "false")
         if (this.hasIconOpenTarget) this.iconOpenTarget.classList.remove("hidden")
         if (this.hasIconCloseTarget) this.iconCloseTarget.classList.add("hidden")
+    }
+
+    handleClickOutside(event) {
+        // メニューが閉じている場合は何もしない
+        if (this.menuTarget.classList.contains("hidden")) return
+
+        // クリックがメニュー内またはボタン内の場合は何もしない
+        if (this.element.contains(event.target) || this.menuTarget.contains(event.target)) {
+            return
+        }
+
+        // メニュー外のクリックなので閉じる
+        this.close()
+    }
+
+    handleOtherMenuOpened(event) {
+        // 自分自身が開いたイベントの場合は無視
+        if (event.detail.controller === this) return
+
+        // 他のメニューが開いたので自分を閉じる
+        this.close()
     }
 }


### PR DESCRIPTION
## 概要

モバイルメニューのUXを改善しました。

## 問題

- 片方のメニューを開いてからもう一つを開くと、2つとも開いて重なった状態になり、✗ボタンが並んでしまう
- メニューを閉じるには明示的に✗ボタンをクリックする必要がある

## 解決策

以下の2つの機能を実装しました:

### 1. メニュー外クリックで閉じる
- メニューパネル外をクリックすると自動的にメニューが閉じます
- ユーザーは✗ボタンを探す必要がなくなります

### 2. 相互排他的な開閉
- 片方のメニューを開くと、もう片方が自動的に閉じます
- 2つのメニューが重なって表示される問題を解消

## 実装詳細

### 技術的なアプローチ

**クリックアウトサイド検知:**
- `connect()`でdocumentにクリックイベントリスナーを追加
- クリックがメニュー内かボタン内かを判定
- 外側のクリックの場合はメニューを閉じる
- `disconnect()`でリスナーをクリーンアップ

**相互排他的な開閉:**
- `open()`時にカスタムイベント`mobile-menu:opened`をdispatchする
- 他のmobile-menuコントローラーがこのイベントをリッスン
- 自分以外のメニューが開いたら自分を閉じる

## 検証結果

- ✅ 左/右メニューともメニュー外クリックで閉じる
- ✅ 片方を開くともう片方が自動的に閉じる
- ✅ Xボタンでの手動閉じも正常動作
- ✅ ハンバーガーボタンでのトグルも正常動作
- ✅ 全テスト通過

## 関連

- PR #209（モバイルメニュー分離）の改善版