### PR TITLE
Support Ruby tag parsing for wiki text

### DIFF
--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -52,21 +52,21 @@
                 <span class="mx-1">、</span>
               <% end %>
               <span class="font-bold text-slate-600 dark:text-slate-300">
-                <% if item[:external_url].present? %>
-                  <%= link_to item[:unit_name], item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
-                <% elsif item[:old_key].present? %>
-                  <%= link_to item[:unit_name], "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
-                <% else %>
-                  <% if item[:is_temp] %>
-                    <span class="text-slate-400 dark:text-slate-500"><%= item[:unit_name] %></span>
+                  <% if item[:external_url].present? %>
+                    <%= link_to sanitize_with_ruby(item[:unit_name]), item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
+                  <% elsif item[:old_key].present? %>
+                    <%= link_to sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
                   <% else %>
-                    <%= item[:unit_name] %>
+                    <% if item[:is_temp] %>
+                      <span class="text-slate-400 dark:text-slate-500"><%= sanitize_with_ruby(item[:unit_name]) %></span>
+                    <% else %>
+                      <%= sanitize_with_ruby(item[:unit_name]) %>
+                    <% end %>
                   <% end %>
-                <% end %>
 
-                <% if item[:part_and_name].present? %>
-                  <span class="text-xs font-bold text-slate-500 dark:text-slate-400 opacity-80">(<%= item[:part_and_name] %>)</span>
-                <% end %>
+                  <% if item[:part_and_name].present? %>
+                    <span class="text-xs font-bold text-slate-500 dark:text-slate-400 opacity-80">(<%= sanitize_with_ruby(item[:part_and_name]) %>)</span>
+                  <% end %>
                 <% if item[:notes].present? %>
                   <% item[:notes].each do |note| %>
                     <span class="text-xs font-normal text-slate-500 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-2"><%= note %></span>

--- a/app/components/member_row_component.rb
+++ b/app/components/member_row_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MemberRowComponent < ViewComponent::Base
+  include WikiLinkHelper
+
   def initialize(member:, hide_active: false)
     @member = member
     @hide_active = hide_active

--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -235,18 +235,31 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
       end
     end
 
+    # 4. Parse rb plugin {{rb Text,Ruby}}
+    protected_text = protected_text.gsub(/\{\{rb\s+([^,]+),([^}]+)\}\}/) do
+      text_part = Regexp.last_match(1).strip
+      ruby_part = Regexp.last_match(2).strip
+      "<ruby>#{text_part}<rt>#{ruby_part}</rt></ruby>"
+    end
+
     # 3. Restore protected links
     placeholders.each do |key, value|
       protected_text.gsub!(key, value)
     end
 
-    sanitize(protected_text, tags: %w[a div p br ul li dt dd dl blockquote], attributes: %w[href target rel class])
+    sanitize(protected_text, tags: %w[a div p br ul li dt dd dl blockquote ruby rt], attributes: %w[href target rel class])
+  end
+
+  def sanitize_with_ruby(text)
+    return '' if text.blank?
+
+    sanitize(text, tags: %w[ruby rt span], attributes: %w[class]).html_safe
   end
 
   def create_internal_link(display, target)
     encoded = URI.encode_www_form_component(target.encode('EUC-JP'))
-    link_to(display, "/#{encoded}.html", class: 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline')
+    link_to(display.html_safe, "/#{encoded}.html", class: 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline')
   rescue Encoding::UndefinedConversionError
-    link_to(display, '#', class: 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline')
+    link_to(display.html_safe, '#', class: 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline')
   end
 end

--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -124,6 +124,13 @@ module WikiParser
         metadata[:notes] << badge_part if badge_part.present?
         metadata[:is_temp] = true
         name_part
+      when 'rb'
+        if plugin_value&.include?(',')
+          text_part, ruby_part = plugin_value.split(',', 2).map(&:strip)
+          "<ruby>#{text_part}<rt>#{ruby_part}</rt></ruby>"
+        else
+          plugin_value
+        end
       else
         match
       end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -48,17 +48,17 @@
                             <h3 class="text-sm font-bold text-slate-800 dark:text-slate-200">
                               <% if item[:is_temp] %>
                                 <span class="font-bold text-slate-400 dark:text-slate-500">
-                                  <%= item[:unit_name] %>
+                                  <%= sanitize_with_ruby(item[:unit_name]) %>
                                 </span>
                               <% elsif item[:external_url].present? %>
-                                <%= link_to item[:unit_name], item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
+                                <%= link_to sanitize_with_ruby(item[:unit_name]), item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
                               <% elsif item[:old_key].present? %>
-                                <%= link_to item[:unit_name], "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
+                                <%= link_to sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
                               <% else %>
-                                <%= item[:unit_name] %>
+                                <%= sanitize_with_ruby(item[:unit_name]) %>
                               <% end %>
                               <% if item[:part_and_name].present? %>
-                                <span class="text-xs font-bold text-slate-600 dark:text-slate-300 ml-1">(<%= item[:part_and_name] %>)</span>
+                                <span class="text-xs font-bold text-slate-600 dark:text-slate-300 ml-1">(<%= sanitize_with_ruby(item[:part_and_name]) %>)</span>
                               <% end %>
                               <% if item[:notes].present? %>
                                 <% item[:notes].each do |note| %>

--- a/reproduce_issue_205.md
+++ b/reproduce_issue_205.md
@@ -1,0 +1,18 @@
+# Issue #205 Reproduction Plan
+
+## Objective
+Confirm that the global navigation menu is hidden on mobile devices and that there is no alternative menu accessible.
+
+## Steps
+1. Open the application in a mobile viewport (e.g., width < 640px).
+2. Observe the header area.
+3. Verify that the "Units", "People", "Trends", "Items" links are not visible.
+4. Verify that there is no "hamburger" icon or other menu trigger to reveal these links.
+
+## Expected Behavior (Current)
+- Navigation links are hidden.
+- No way to access navigation on mobile.
+
+## Goal
+- Implement a mobile menu trigger (hamburger icon).
+- Implement a mobile menu (dropdown or slide-out) containing the navigation links.


### PR DESCRIPTION
## 概要
Wikiテキスト内で日本語のルビ（ふりがな）を表示するためのタグ `{{rb Text,Ruby}}` をサポートしました。

## 変更点

### 1. WikiLinkHelper
- `{{rb 漢字,かんじ}}`形式のタグをパースし、`<ruby>漢字<rt>かんじ</rt></ruby>` に変換する処理を追加しました。
- `sanitize` の許可タグリストに `ruby`, `rt`, `span` を追加しました。
- View側で安全にルビ付きテキストを表示するためのヘルパーメソッド `sanitize_with_ruby` を追加しました。

### 2. WikiParser
- `process_plugins` メソッドに `rb` プラグインの処理を追加しました。これにより、履歴データのパース時にもルビタグが処理されます。

### 3. View / Component
- `Person` 詳細ページの `old_history` 表示部分で `sanitize_with_ruby` を使用するように変更しました。
- `MemberRowComponent` (Unit詳細ページのメンバーリスト) で `sanitize_with_ruby` を使用するように変更しました。
- `MemberRowComponent` に `WikiLinkHelper` を include しました。

## 検証
- 再現スクリプトによるパース処理の検証
- ブラウザによる実画面での表示確認（Personページ、Unitページ）