### PR TITLE
Fix NameHistoryComponent: hide if history has only 1 item

### DIFF
--- a/app/components/name_history_component.rb
+++ b/app/components/name_history_component.rb
@@ -8,7 +8,7 @@ class NameHistoryComponent < ViewComponent::Base
   end
 
   def render?
-    @resource.name_logs.present?
+    name_logs.present? && name_logs.size > 1
   end
 
   def name_logs


### PR DESCRIPTION
name_log が1件のみ（現在の名前のみ）の場合は、Name Historyセクションを表示しないように変更しました。