### PR TITLE
タブレット画面で検索フォームを縮小可能なレスポンシブデザインに変更

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -12,3 +12,22 @@
     @apply bg-linear-to-br from-slate-50 to-slate-200 dark:from-slate-900 dark:to-slate-800 text-slate-900 dark:text-slate-100 min-h-screen antialiased font-sans;
   }
 }
+
+@layer components {
+  .search-input-responsive {
+    width: 2.5rem; /* 40px */
+    transition: width 300ms ease-in-out, padding 300ms ease-in-out;
+  }
+
+  .search-input-responsive:focus {
+    width: 16rem; /* 256px */
+    padding-left: 1rem; /* 16px */
+  }
+
+  @media (min-width: 768px) {
+    .search-input-responsive {
+      width: 16rem; /* 256px */
+      padding-left: 1rem; /* 16px */
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,8 +41,8 @@
             <!-- Search Form (Desktop) - Next to logo -->
             <%= form_with url: search_path, method: :get, local: true, class: "hidden sm:flex items-center ml-6" do |f| %>
               <div class="relative">
-                <%= f.text_field :q, placeholder: "Search...", class: "w-64 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg px-4 py-2 pr-10 text-sm text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-gray-400" %>
-                <button type="submit" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+                <%= f.text_field :q, placeholder: "Search...", class: "search-input-responsive bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg pl-10 py-2 pr-2 text-sm text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 placeholder:text-gray-400 placeholder:opacity-0 md:placeholder:opacity-100 focus:placeholder:opacity-100" %>
+                <button type="submit" class="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
                   </svg>


### PR DESCRIPTION
## 概要

グローバルナビゲーションの検索フォームにレスポンシブ動作を追加し、タブレット画面（640px-767px）での表示を最適化しました。

## 変更内容

- **縮小状態（640px-767px）**: 検索フォームをアイコンのみ（40px幅）で表示
- **展開状態**: フォーカス時にフルサイズ（256px幅）に展開
- **デスクトップ（768px以上）**: 常にフルサイズで表示（既存動作を維持）
- **モバイル（640px未満）**: モバイルメニュー内に表示（既存動作を維持）

## 実装アプローチ

- CSS-onlyソリューション（JavaScriptなし）
- カスタムCSSクラス `.search-input-responsive` を追加
- `focus` 疑似クラスとメディアクエリを使用
- 300msのスムーズなトランジション効果

## 変更ファイル

- `app/views/layouts/application.html.erb` - 検索フォームのHTMLマークアップ
- `app/assets/tailwind/application.css` - カスタムCSSクラス定義

## スクリーンショット

### 縮小状態（640px-767px）
検索アイコンのみ表示（40px幅）

### 展開状態（フォーカス時）
フルサイズ（256px幅）に展開

## テスト

- ✅ RuboCop: 203ファイル検査、違反なし
- ✅ テスト: 20テスト、すべて成功
- ✅ ブラウザでの動作確認済み

## 利点

1. **スペース効率**: 限られたタブレット画面を有効活用
2. **使いやすさ**: 必要時にはフルサイズで快適に入力可能
3. **パフォーマンス**: CSS-onlyで軽量・高速
4. **保守性**: シンプルで理解しやすい実装
5. **アクセシビリティ**: キーボードナビゲーション対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)