### PR TITLE
Fix autocomplete UX and improve search

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -8,7 +8,7 @@ module Admin
     def index
       @q = params[:q]
       scope = Person.all.order(updated_at: :desc)
-      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q', q: "%#{@q}%") if @q.present?
+      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q', q: "%#{@q}%") if @q.present?
       @pagy, @people = pagy(scope)
     end
 
@@ -48,6 +48,19 @@ module Admin
       redirect_to admin_people_path, notice: 'Person deleted successfully.'
     end
 
+    def search
+      q = params[:q]
+      scope = Person.all
+
+      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q', q: "%#{q}%") if q.present?
+
+      @people = scope.limit(10).order(:name)
+
+      render json: @people.map { |p|
+        { id: p.id, name: p.name.presence || p.key, name_kana: p.name_kana, key: p.key }
+      }
+    end
+
     private
 
     def set_person
@@ -61,23 +74,6 @@ module Admin
         links_attributes: %i[id text url active _destroy],
         name_logs_attributes: %i[name name_kana]
       )
-    end
-
-    public
-
-    def search
-      q = params[:q]
-      scope = Person.all
-
-      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q', q: "%#{q}%") if q.present?
-
-      @people = scope.limit(10).order(:name)
-
-      respond_to do |format|
-        format.json do
-          render json: @people.map { |p| { id: p.id, name: p.name, name_kana: p.name_kana, key: p.key } }
-        end
-      end
     end
   end
 end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -8,7 +8,7 @@ module Admin
     def index
       @q = params[:q]
       scope = Unit.all.order(updated_at: :desc)
-      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q', q: "%#{@q}%") if @q.present?
+      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q', q: "%#{@q}%") if @q.present?
       @pagy, @units = pagy(scope)
     end
 
@@ -54,6 +54,17 @@ module Admin
       redirect_to admin_units_path, notice: 'Unit deleted successfully.'
     end
 
+    def search
+      q = params[:q]
+      scope = Unit.all
+
+      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q', q: "%#{q}%") if q.present?
+
+      @units = scope.limit(10).order(:name)
+
+      render json: @units.map { |u| { id: u.id, name: u.name, name_kana: u.name_kana, key: u.key } }
+    end
+
     private
 
     def set_unit
@@ -64,23 +75,6 @@ module Admin
       params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key, :note,
                                    links_attributes: %i[id text url active sort_order _destroy],
                                    name_logs_attributes: %i[name name_kana])
-    end
-
-    public
-
-    def search
-      q = params[:q]
-      scope = Unit.all
-
-      scope = scope.where('name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q', q: "%#{q}%") if q.present?
-
-      @units = scope.limit(10).order(:name)
-
-      respond_to do |format|
-        format.json do
-          render json: @units.map { |u| { id: u.id, name: u.name, name_kana: u.name_kana, key: u.key } }
-        end
-      end
     end
   end
 end

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -10,6 +10,19 @@ export default class extends Controller {
   connect() {
     this.selectedItems = this.loadExistingItems()
     this.timeout = null
+    this.activeIndex = -1
+    this.handleClickOutside = this.handleClickOutside.bind(this)
+    document.addEventListener('click', this.handleClickOutside)
+  }
+
+  disconnect() {
+    document.removeEventListener('click', this.handleClickOutside)
+  }
+
+  handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideResults()
+    }
   }
 
   loadExistingItems() {
@@ -36,6 +49,54 @@ export default class extends Controller {
     }, 300) // Debounce 300ms
   }
 
+  onKeydown(event) {
+    const items = this.resultItems
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        if (this.resultsTarget.classList.contains('hidden')) return
+        this.activeIndex = Math.min(this.activeIndex + 1, items.length - 1)
+        this.highlightItem()
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        if (this.resultsTarget.classList.contains('hidden')) return
+        this.activeIndex = Math.max(this.activeIndex - 1, 0)
+        this.highlightItem()
+        break
+      case 'Enter':
+        event.preventDefault()
+        if (this.activeIndex >= 0 && items[this.activeIndex]) {
+          items[this.activeIndex].click()
+        }
+        break
+      case 'Escape':
+        this.hideResults()
+        this.inputTarget.blur()
+        break
+    }
+  }
+
+  get resultItems() {
+    return Array.from(this.resultsTarget.querySelectorAll('[data-id]'))
+  }
+
+  highlightItem() {
+    const items = this.resultItems
+    items.forEach((item, index) => {
+      if (index === this.activeIndex) {
+        item.classList.add('bg-gray-100', 'dark:bg-gray-700')
+      } else {
+        item.classList.remove('bg-gray-100', 'dark:bg-gray-700')
+      }
+    })
+
+    if (items[this.activeIndex]) {
+      items[this.activeIndex].scrollIntoView({ block: 'nearest' })
+    }
+  }
+
   async performSearch(query) {
     try {
       const response = await fetch(`${this.urlValue}?q=${encodeURIComponent(query)}`, {
@@ -55,6 +116,8 @@ export default class extends Controller {
   }
 
   displayResults(items) {
+    this.activeIndex = -1
+
     if (items.length === 0) {
       this.hideResults()
       return
@@ -63,8 +126,14 @@ export default class extends Controller {
     const idField = this.fieldNameValue === 'units' ? 'unit_id' : 'person_id'
     const selectedIds = this.selectedItems.map(item => item[idField])
 
-    this.resultsTarget.innerHTML = items
-      .filter(item => !selectedIds.includes(item.id))
+    const filtered = items.filter(item => !selectedIds.includes(item.id))
+
+    if (filtered.length === 0) {
+      this.hideResults()
+      return
+    }
+
+    this.resultsTarget.innerHTML = filtered
       .map(item => `
         <div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
              data-action="click->autocomplete#selectItem"
@@ -131,6 +200,7 @@ export default class extends Controller {
   }
 
   hideResults() {
+    this.activeIndex = -1
     this.resultsTarget.classList.add('hidden')
   }
 

--- a/app/views/admin/trends/_form.html.erb
+++ b/app/views/admin/trends/_form.html.erb
@@ -86,7 +86,7 @@
     <div class="mt-1 relative">
       <input type="text"
              data-autocomplete-target="input"
-             data-action="input->autocomplete#search"
+             data-action="input->autocomplete#search keydown->autocomplete#onKeydown"
              placeholder="Type to search units..."
              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white">
 
@@ -125,7 +125,7 @@
     <div class="mt-1 relative">
       <input type="text"
              data-autocomplete-target="input"
-             data-action="input->autocomplete#search"
+             data-action="input->autocomplete#search keydown->autocomplete#onKeydown"
              placeholder="Type to search people..."
              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white">
 


### PR DESCRIPTION
## Summary
- オートコンプリートにキーボード操作（↑↓キー、Enter、Escape）と外部クリックで閉じる機能を追加
- searchアクションを`private`の前に移動し、`respond_to`ブロックを`render json:`に簡素化
- Unit/Personの`index`と`search`両方で`name_log`をILIKE検索対象に追加
- Person searchでnameが空の場合にkeyをフォールバック表示

## Test plan
- [ ] Trend作成フォームでUnitsオートコンプリートが動作すること
- [ ] Trend作成フォームでPeopleオートコンプリートが動作すること
- [ ] ↑↓キーで候補を移動、Enterで選択、Escapeで閉じることを確認
- [ ] ドロップダウン外クリックで閉じることを確認
- [ ] 旧名義（name_log内）で検索がヒットすることを確認
- [ ] Admin Units/People一覧でname_log検索が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)