### PR TITLE
Add Trends link to admin navigation menu

### DIFF
--- a/app/views/admin/trends/index.html.erb
+++ b/app/views/admin/trends/index.html.erb
@@ -10,8 +10,8 @@
     </div>
   </div>
 
-  <div class="mb-4">
-    <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+  <div class="mb-4 flex justify-center">
+    <%== render partial: 'pagy/nav', locals: {pagy: @pagy} if @pagy.pages > 1 %>
   </div>
 
   <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
@@ -82,7 +82,7 @@
     </table>
   </div>
 
-  <div class="mt-4">
-    <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+  <div class="mt-4 flex justify-center">
+    <%== render partial: 'pagy/nav', locals: {pagy: @pagy} if @pagy.pages > 1 %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -113,6 +113,12 @@
                       </svg>
                       Index Groups
                     <% end %>
+                    <%= link_to admin_trends_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.307a11.95 11.95 0 0 1 5.814-5.519l2.74-1.22m0 0-5.94-2.28m5.94 2.28-2.28 5.941" />
+                      </svg>
+                      Trends
+                    <% end %>
                     <%= link_to admin_external_sites_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
@@ -252,6 +258,9 @@
                       <% end %>
                       <%= link_to admin_index_groups_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
                         Settings: Index Groups
+                      <% end %>
+                      <%= link_to admin_trends_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                        Settings: Trends
                       <% end %>
                       <%= link_to admin_external_sites_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
                         Settings: External Sites


### PR DESCRIPTION
## Summary
- デスクトップのAdminドロップダウンメニューにTrendsリンクを追加
- モバイルのAdmin/Userメニューパネルに Settings: Trends リンクを追加

## Test plan
- [ ] デスクトップ: ユーザー名ドロップダウンにTrendsリンクが表示されること
- [ ] モバイル: Admin/Userメニューに Settings: Trends が表示されること
- [ ] 各リンクから `/admin/trends` に遷移できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)