### PR TITLE
Add daily summary page for specific dates

### DIFF
--- a/app/controllers/daily_controller.rb
+++ b/app/controllers/daily_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class DailyController < ApplicationController
+  def show
+    @date = parse_date_params
+    return redirect_to root_path, alert: '日付の形式が正しくありません' unless @date
+
+    @trends = Trend.on_date(@date).order(created_at: :desc)
+    @birthdays = Person.birthday_on(@date).where(status: %i[active hiatus]).order(name_kana: :asc)
+    @releases = Item.released_on(@date).order(created_at: :desc)
+
+    # Load related units for trends
+    all_unit_ids = @trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
+    @related_units = Unit.where(id: all_unit_ids).index_by(&:id)
+  end
+
+  private
+
+  def parse_date_params
+    year = params[:year].to_i
+    month = params[:month].to_i
+    day = params[:day].to_i
+
+    Date.new(year, month, day)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,4 +27,7 @@ class Item < ApplicationRecord
   scope :by_artist_old_key, lambda { |old_key|
     where('artists @> ?', [{ old_key: old_key }].to_json)
   }
+
+  # 発売日で検索するスコープ
+  scope :released_on, ->(date) { where(release_date: date) }
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -47,6 +47,12 @@ class Person < ApplicationRecord
   # Valid parts for a person
   AVAILABLE_PARTS = %w[vocal guitar bass drums keyboard dj dancer manipulator].freeze
 
+  # Scopes
+  scope :birthday_on, lambda { |date|
+    where('EXTRACT(MONTH FROM birthday) = ? AND EXTRACT(DAY FROM birthday) = ?',
+          date.month, date.day)
+  }
+
   STATUS_TRANSLATIONS = {
     'pre' => '準備中',
     'active' => '活動中',

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -71,6 +71,9 @@ class Trend < ApplicationRecord
     other: 100
   }, prefix: true
 
+  # Scopes
+  scope :on_date, ->(date) { where(date: date) }
+
   # Validations
   validates :date, presence: true
   validates :active, inclusion: { in: [true, false] }

--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -1,0 +1,110 @@
+<div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
+
+    <!-- Date Header -->
+    <header class="mb-8 text-center border-b border-slate-200 dark:border-slate-700 pb-6">
+      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
+        <%= @date.strftime('%Y年%-m月%-d日') %>
+      </h1>
+      <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
+        Daily Summary
+      </p>
+    </header>
+
+    <!-- Navigation -->
+    <div class="space-y-3 mb-8">
+      <!-- Year Navigation -->
+      <div class="flex justify-between">
+        <% prev_year_date = @date - 1.year %>
+        <%= link_to "← 前年同日", daily_path(year: prev_year_date.year, month: prev_year_date.month, day: prev_year_date.day),
+            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
+        <% today = Date.today %>
+        <%= link_to "今年同日", daily_path(year: today.year, month: @date.month, day: @date.day),
+            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
+        <% next_year_date = @date + 1.year %>
+        <%= link_to "翌年同日 →", daily_path(year: next_year_date.year, month: next_year_date.month, day: next_year_date.day),
+            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
+      </div>
+      <!-- Day Navigation -->
+      <div class="flex justify-between">
+        <% prev_date = @date - 1.day %>
+        <%= link_to "← 前日", daily_path(year: prev_date.year, month: prev_date.month, day: prev_date.day),
+            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+        <%= link_to "今日", daily_path(year: today.year, month: today.month, day: today.day),
+            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+        <% next_date = @date + 1.day %>
+        <%= link_to "翌日 →", daily_path(year: next_date.year, month: next_date.month, day: next_date.day),
+            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+      </div>
+    </div>
+
+    <!-- Trends Section -->
+    <% if @trends.present? %>
+      <section class="mb-12">
+        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4">
+          Trends
+        </h2>
+        <div class="space-y-0">
+          <% @trends.each do |trend| %>
+            <div class="p-4 border-b border-slate-200 dark:border-slate-700 last:border-0">
+              <% if trend.units %>
+                <% trend.units.each do |unit_data| %>
+                  <% unit = @related_units&.dig(unit_data['unit_id']) %>
+                  <% if unit %>
+                    <%= link_to unit.name, profile_path(unit.key), class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors mr-1 border border-indigo-200 dark:border-indigo-700" %>
+                  <% elsif unit_data['name'].present? %>
+                    <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-gray-50 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 mr-1"><%= unit_data['name'] %></span>
+                  <% end %>
+                <% end %>
+              <% end %>
+              <%= link_to trend_path(trend), class: "inline" do %>
+                <span class="font-bold text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 transition-colors"><%= format_wiki_title(trend.title, link: false) %></span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
+
+    <!-- Birthdays Section -->
+    <% if @birthdays.present? %>
+      <section class="mb-12">
+        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4">
+          Birthdays
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          <% @birthdays.each do |person| %>
+            <%= link_to profile_path(person.key), class: "block p-4 bg-slate-50 dark:bg-slate-900/50 rounded-lg hover:border-person transition-colors border border-slate-100 dark:border-slate-700" do %>
+              <h3 class="font-bold text-slate-800 dark:text-slate-200"><%= person.name %></h3>
+              <% if person.birthday_display %>
+                <p class="text-sm text-slate-500 dark:text-slate-400 mt-1"><%= person.birthday_display %></p>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
+
+    <!-- Releases Section -->
+    <% if @releases.present? %>
+      <section class="mb-12">
+        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4">
+          Releases
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <%= render ItemCardComponent.with_collection(@releases) %>
+        </div>
+      </section>
+    <% end %>
+
+    <!-- Empty State -->
+    <% if @trends.blank? && @birthdays.blank? && @releases.blank? %>
+      <div class="py-20 text-center">
+        <p class="text-slate-400 dark:text-slate-500 font-bold">
+          この日には記録がありません。
+        </p>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,10 @@ Rails.application.routes.draw do
   resources :trends, only: %i[index show]
   resources :items, only: %i[index]
 
+  # Daily page
+  get '/date/:year/:month/:day', to: 'daily#show', as: :daily,
+                                 constraints: { year: /\d{4}/, month: /\d{1,2}/, day: /\d{1,2}/ }
+
   # Cross-search
   get 'search', to: 'search#index'
 


### PR DESCRIPTION
## 概要
特定日付の情報を表示する日別ページを実装しました。

- エンドポイント: `/date/:year/:month/:day`
- 表示内容: Trends、Birthday、Release の3つのセクション

## 変更内容

### モデルスコープの追加
- `Person.birthday_on(date)`: 誕生日が指定月日の Person を検索
- `Trend.on_date(date)`: 指定日付の Trend を検索
- `Item.released_on(date)`: 指定日付にリリースされた Item を検索

### コントローラー
- `DailyController` を新規作成
- 日付のバリデーション機能を実装
- 不正な日付は root_path にリダイレクト

### ビュー
- 日別サマリーページを作成
- Trends セクション（Trends ページと同じ形式で表示）
- Birthdays セクション（グリッド表示）
- Releases セクション（ItemCardComponent を使用）
- ナビゲーション機能:
  - 前日/今日/翌日
  - 前年同日/今年同日/翌年同日

### ルーティング
- `/date/:year/:month/:day` を追加
- 年月日の形式を正規表現で制約

## テスト

- ✅ RuboCop チェック: 合格
- ✅ テスト: 全て合格 (20 tests)
- [x] ブラウザでの動作確認
  - `/date/2026/2/11` で今日のサマリーを表示
  - 3つのセクションが正しく表示されることを確認
  - ナビゲーションリンクの動作確認
  - 不正な日付が root_path にリダイレクトされることを確認

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)