### PR TITLE
日付サマリーページの改善と年インデックスページの追加

### DIFF
--- a/app/controllers/yearly_controller.rb
+++ b/app/controllers/yearly_controller.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class YearlyController < ApplicationController
+  def index
+    @start_year = 1970
+    @end_year = Date.today.year
+    @years = (@start_year..@end_year).to_a.reverse
+  end
+
   def show
     @year = parse_year_param
     return redirect_to root_path, alert: '年の形式が正しくありません' unless @year

--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -2,46 +2,42 @@
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 
     <!-- Date Header -->
-    <header class="mb-8 text-center border-b border-slate-200 dark:border-slate-700 pb-6">
-      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
-        <%= link_to "#{@date.year}年#{@date.month}月", monthly_path(year: @date.year, month: @date.month), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-d日') %>
-      </h1>
-      <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
-        Daily Summary
-      </p>
+    <header class="mb-8 border-b border-slate-200 dark:border-slate-700 pb-6">
+      <div class="flex justify-between items-center gap-4">
+        <div class="flex gap-2 flex-shrink-0">
+          <% prev_year_date = @date - 1.year %>
+          <%= link_to "← 前年同日", daily_path(year: prev_year_date.year, month: prev_year_date.month, day: prev_year_date.day),
+              class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+          <% prev_date = @date - 1.day %>
+          <%= link_to "← 前日", daily_path(year: prev_date.year, month: prev_date.month, day: prev_date.day),
+              class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+        </div>
+        <div class="text-center flex-grow">
+          <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
+            <%= link_to "#{@date.year}年#{@date.month}月", monthly_path(year: @date.year, month: @date.month), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-d日') %>
+          </h1>
+          <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
+            Daily Summary
+          </p>
+        </div>
+        <div class="flex gap-2 flex-shrink-0">
+          <% next_date = @date + 1.day %>
+          <%= link_to "翌日 →", daily_path(year: next_date.year, month: next_date.month, day: next_date.day),
+              class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+          <% next_year_date = @date + 1.year %>
+          <%= link_to "翌年同日 →", daily_path(year: next_year_date.year, month: next_year_date.month, day: next_year_date.day),
+              class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+        </div>
+      </div>
     </header>
-
-    <!-- Navigation -->
-    <div class="space-y-3 mb-8">
-      <!-- Year Navigation -->
-      <div class="flex justify-between">
-        <% prev_year_date = @date - 1.year %>
-        <%= link_to "← 前年同日", daily_path(year: prev_year_date.year, month: prev_year_date.month, day: prev_year_date.day),
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
-        <% today = Date.today %>
-        <%= link_to "今年同日", daily_path(year: today.year, month: @date.month, day: @date.day),
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
-        <% next_year_date = @date + 1.year %>
-        <%= link_to "翌年同日 →", daily_path(year: next_year_date.year, month: next_year_date.month, day: next_year_date.day),
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
-      </div>
-      <!-- Day Navigation -->
-      <div class="flex justify-between">
-        <% prev_date = @date - 1.day %>
-        <%= link_to "← 前日", daily_path(year: prev_date.year, month: prev_date.month, day: prev_date.day),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-        <%= link_to "今日", daily_path(year: today.year, month: today.month, day: today.day),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-        <% next_date = @date + 1.day %>
-        <%= link_to "翌日 →", daily_path(year: next_date.year, month: next_date.month, day: next_date.day),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-      </div>
-    </div>
 
     <!-- Trends Section -->
     <% if @trends.present? %>
       <section class="mb-12">
-        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4">
+        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4 flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+          </svg>
           Trends
         </h2>
         <div class="space-y-0">
@@ -69,15 +65,40 @@
     <!-- Birthdays Section -->
     <% if @birthdays.present? %>
       <section class="mb-12">
-        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4">
+        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4 flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15.546c-.523 0-1.046.151-1.5.454a2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.704 2.704 0 00-3 0 2.704 2.704 0 01-3 0 2.701 2.701 0 00-1.5-.454M9 6v2m3-2v2m3-2v2M9 3h.01M12 3h.01M15 3h.01M21 21v-7a2 2 0 00-2-2H5a2 2 0 00-2 2v7h18zm-3-9v-2a2 2 0 00-2-2H8a2 2 0 00-2 2v2h12z"/>
+          </svg>
           Birthdays
         </h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
           <% @birthdays.each do |person| %>
-            <%= link_to profile_path(person.key), class: "block p-4 bg-slate-50 dark:bg-slate-900/50 rounded-lg hover:border-person transition-colors border border-slate-100 dark:border-slate-700" do %>
-              <h3 class="font-bold text-slate-800 dark:text-slate-200"><%= person.name %></h3>
-              <% if person.birthday_display %>
-                <p class="text-sm text-slate-500 dark:text-slate-400 mt-1"><%= person.birthday_display %></p>
+            <%= link_to profile_path(person.key), class: "block p-4 bg-slate-50 dark:bg-slate-900/50 rounded-lg border border-slate-100 dark:border-slate-700 hover:border-person transition-colors" do %>
+              <h3 class="font-bold text-slate-800 dark:text-slate-200">
+                <%= person.name %>
+              </h3>
+              <% if person.old_history.present? %>
+                <% recent_histories = person.parse_old_history.last(3) %>
+                <% if recent_histories.present? %>
+                  <% recent_histories.each do |recent_history| %>
+                    <div class="mt-2 pl-3 text-xs text-slate-500 dark:text-slate-400">
+                      <% recent_history.each_with_index do |item, index| %>
+                        <% if index > 0 %>
+                          <span class="mx-1">、</span>
+                        <% end %>
+                        <span class="<%= item[:is_temp] ? 'text-slate-400 dark:text-slate-500' : 'font-semibold' %>"><%= sanitize_with_ruby(item[:unit_name]) %></span>
+                        <% if item[:part_and_name].present? %>
+                          <span class="text-xs opacity-80">(<%= sanitize_with_ruby(item[:part_and_name]) %>)</span>
+                        <% end %>
+                        <% if item[:notes].present? %>
+                          <% item[:notes].each do |note| %>
+                            <span class="text-xs bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-1"><%= note %></span>
+                          <% end %>
+                        <% end %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
@@ -88,7 +109,10 @@
     <!-- Releases Section -->
     <% if @releases.present? %>
       <section class="mb-12">
-        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4">
+        <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4 flex items-center gap-2">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+          </svg>
           Releases
         </h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/views/monthly/show.html.erb
+++ b/app/views/monthly/show.html.erb
@@ -2,40 +2,32 @@
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 
     <!-- Month Header -->
-    <header class="mb-8 text-center border-b border-slate-200 dark:border-slate-700 pb-6">
-      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
-        <%= link_to "#{@date.year}年", yearly_path(year: @date.year), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-m月') %>
-      </h1>
-      <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
-        Monthly Summary
-      </p>
-    </header>
-
-    <!-- Navigation -->
-    <div class="space-y-3 mb-8">
-      <!-- Year Navigation -->
-      <div class="flex justify-between">
-        <% prev_year_date = @date - 1.year %>
-        <%= link_to "← 前年同月", monthly_path(year: prev_year_date.year, month: prev_year_date.month),
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
-        <% today = Date.today %>
-        <%= link_to "当年同月", monthly_path(year: today.year, month: @date.month),
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
-        <% next_year_date = @date + 1.year %>
-        <%= link_to "翌年同月 →", monthly_path(year: next_year_date.year, month: next_year_date.month),
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
-      </div>
-
-      <!-- Month Navigation -->
-      <div class="flex justify-between">
-        <% prev_month = @date - 1.month %>
-        <%= link_to "← 前月", monthly_path(year: prev_month.year, month: prev_month.month),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-        <%= link_to "今月", monthly_path(year: today.year, month: today.month),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-        <% next_month = @date + 1.month %>
-        <%= link_to "翌月 →", monthly_path(year: next_month.year, month: next_month.month),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+    <header class="mb-8 border-b border-slate-200 dark:border-slate-700 pb-6">
+      <div class="flex justify-between items-center gap-4 mb-6">
+        <div class="flex gap-2 flex-shrink-0">
+          <% prev_year_date = @date - 1.year %>
+          <%= link_to "← 前年同月", monthly_path(year: prev_year_date.year, month: prev_year_date.month),
+              class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+          <% prev_month = @date - 1.month %>
+          <%= link_to "← 前月", monthly_path(year: prev_month.year, month: prev_month.month),
+              class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+        </div>
+        <div class="text-center flex-grow">
+          <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
+            <%= link_to "#{@date.year}年", yearly_path(year: @date.year), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-m月') %>
+          </h1>
+          <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
+            Monthly Summary
+          </p>
+        </div>
+        <div class="flex gap-2 flex-shrink-0">
+          <% next_month = @date + 1.month %>
+          <%= link_to "翌月 →", monthly_path(year: next_month.year, month: next_month.month),
+              class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+          <% next_year_date = @date + 1.year %>
+          <%= link_to "翌年同月 →", monthly_path(year: next_year_date.year, month: next_year_date.month),
+              class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+        </div>
       </div>
 
       <!-- 12 Months Navigation (Same Year) -->
@@ -46,7 +38,7 @@
               class: "px-3 py-1.5 rounded-full text-sm font-bold transition-colors whitespace-nowrap border #{is_current ? 'bg-indigo-600 text-white border-indigo-600 dark:bg-indigo-500 dark:border-indigo-500' : 'bg-white text-slate-600 border-slate-300 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600 dark:hover:bg-slate-700'}" %>
         <% end %>
       </div>
-    </div>
+    </header>
 
     <!-- Calendar Section -->
     <section class="mb-12">

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -79,7 +79,7 @@
         <% @trends.each do |trend| %>
           <div class="flex items-start gap-4 p-4 border-b border-slate-200 dark:border-slate-700 last:border-0">
             <div class="shrink-0 w-24 text-slate-600 dark:text-slate-400 font-mono text-sm pt-0.5 font-bold">
-              <%= trend.date.strftime('%Y/%m/%d') %>
+              <%= link_to trend.date.strftime('%Y/%m/%d'), daily_path(year: trend.date.year, month: trend.date.month, day: trend.date.day), class: "hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
             </div>
             <div class="grow">
               <% if trend.units %>

--- a/app/views/yearly/index.html.erb
+++ b/app/views/yearly/index.html.erb
@@ -1,0 +1,31 @@
+<div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
+
+    <!-- Header -->
+    <header class="mb-8 text-center border-b border-slate-200 dark:border-slate-700 pb-6">
+      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
+        年別サマリー
+      </h1>
+      <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
+        <%= @start_year %>年 - <%= @end_year %>年
+      </p>
+    </header>
+
+    <!-- Years Grid -->
+    <section>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+        <% @years.each do |year| %>
+          <%= link_to yearly_path(year: year), class: "block p-6 bg-slate-50 dark:bg-slate-900/50 rounded-lg border border-slate-100 dark:border-slate-700 hover:border-indigo-500 dark:hover:border-indigo-400 transition-colors text-center" do %>
+            <div class="text-2xl font-black text-slate-800 dark:text-slate-100">
+              <%= year %>
+            </div>
+            <div class="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              年
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </section>
+
+  </div>
+</div>

--- a/app/views/yearly/show.html.erb
+++ b/app/views/yearly/show.html.erb
@@ -14,12 +14,11 @@
     <!-- Navigation -->
     <div class="space-y-3 mb-8">
       <!-- Year Navigation -->
-      <div class="flex justify-between">
+      <div class="flex justify-between items-center">
         <%= link_to "← 前年", yearly_path(year: @year - 1),
             class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-        <% today = Date.today %>
-        <%= link_to "今年", yearly_path(year: today.year),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+        <%= link_to "年一覧", date_index_path,
+            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
         <%= link_to "翌年 →", yearly_path(year: @year + 1),
             class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,9 @@ Rails.application.routes.draw do
   resources :trends, only: %i[index show]
   resources :items, only: %i[index]
 
+  # Date index page (MUST be before other date routes!)
+  get '/date', to: 'yearly#index', as: :date_index
+
   # Yearly page (MUST be before monthly and daily routes!)
   get '/date/:year', to: 'yearly#show', as: :yearly,
                      constraints: { year: /\d{4}/ }


### PR DESCRIPTION
## Summary
日別、月別、年別サマリーページのUIを改善し、新しく年インデックスページを追加しました。

## 主な変更

### 日別ページ (daily)
- 年月表示を月サマリへのリンクに統合（「2012年1月」全体がリンク）
- ナビゲーションを見出しの両端に配置
- Birthdaysセクションに個人の経歴表示を追加（直近3件、古い順）
- セクション見出し（Trends、Birthdays、Releases）にアイコンを追加
- 「今日」「今年同日」への導線を削除してUIをシンプル化

### 月別ページ (monthly)
- ナビゲーションを見出しの両端に配置
- 「当年同月」「今月」への導線を削除してUIをシンプル化
- 12ヶ月ナビゲーションは維持

### 年別ページ (yearly)
- 「今年」を「年一覧」リンクに変更
- 年インデックスページへの導線を追加

### 年インデックスページ (/date) - NEW
- 1970年から現在までの年一覧ページを新規作成
- グリッドレイアウトで視覚的にわかりやすく表示
- 各年をクリックすると年サマリページに遷移
- レスポンシブ対応（2〜5列）
- ダークモード対応

### Trendsページ
- 日付表示を日サマリページへのリンクに変更
- クリックでその日のサマリーページに遷移可能

## Test plan
- [x] 日別ページ (`/date/2026/5/1`) でナビゲーションと経歴表示を確認
- [x] 月別ページ (`/date/2026/5`) でナビゲーションを確認
- [x] 年別ページ (`/date/2026`) で年一覧リンクを確認
- [x] 年インデックスページ (`/date`) で年一覧を確認
- [x] Trendsページで日付リンクを確認
- [x] ダークモードでの表示を確認
- [x] レスポンシブ表示を確認
- [x] RuboCop: ✅ Pass
- [x] Tests: ✅ Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)