### PR TITLE
feat: スナップショットの経歴折りたたみ表示

### DIFF
--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-white dark:bg-slate-800 p-5 border-b border-slate-100 dark:border-slate-700 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-900/40 transition-colors">
   <div>
-    <div class="flex items-center justify-between gap-3 md:gap-4 mb-2 flex-wrap sm:flex-nowrap">
+    <div class="flex items-center justify-between gap-3 md:gap-4 flex-wrap sm:flex-nowrap">
       <div class="flex items-center gap-3 md:gap-4 flex-1">
         <span class="text-xs font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest min-w-[4rem]" title="<%= (@member.part_alias.present? || @member.support?) ? @member.part.upcase : '' %>">
           <%= (@member.support? ? "サポート " : "") + (@member.part_alias.presence || @member.part.upcase) %>
@@ -44,7 +44,7 @@
       </div>
     </div>
     <% if (p_items = person_history_items).present? %>
-      <div class="mt-3 pl-4 border-l-2 border-slate-100 dark:border-slate-800 flex flex-col gap-1">
+      <div class="mt-3 pl-4 border-l-2 border-slate-100 dark:border-slate-800 flex flex-col gap-1" data-toggle-target="content">
         <% p_items.each do |concurrent_items| %>
           <div class="text-[0.7rem] leading-relaxed text-slate-500 dark:text-slate-400">
             <% concurrent_items.each_with_index do |item, index| %>

--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -1,9 +1,9 @@
 <div class="flex flex-col gap-12 mb-12">
   <% @snapshots.each do |snapshot| %>
-    <section>
+    <section data-controller="toggle" data-toggle-open-value="<%= snapshot.current? %>">
       <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
         <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-          Members<% if snapshot.snapshot_date.present? %>（<%= snapshot.snapshot_date.strftime('%Y/%m/%d') %>）<% end %>
+          Members
         </h2>
         <div class="flex items-center gap-2">
           <% if snapshot.label.present? %>
@@ -12,9 +12,14 @@
           <% if snapshot.current? %>
             <span class="text-[0.65rem] font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">Current</span>
           <% end %>
+          <button type="button" data-action="click->toggle#toggle" class="inline-flex items-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors" title="Toggle history">
+            <svg class="w-4 h-4 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+          </button>
         </div>
       </div>
-      <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm">
+      <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
         <% snapshot.snapshot_people.sort_by(&:sort_order).each do |sp| %>
           <%= render MemberRowComponent.new(member: sp, hide_active: true) %>
         <% end %>

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -18,3 +18,6 @@ application.register("mobile-menu", MobileMenuController)
 
 import SortableController from "controllers/sortable_controller"
 application.register("sortable", SortableController)
+
+import ToggleController from "controllers/toggle_controller"
+application.register("toggle", ToggleController)

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,73 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["content", "icon", "area"]
+    static values = { open: Boolean }
+
+    connect() {
+        this.contentTargets.forEach(el => {
+            el.style.transition = "max-height 0.3s ease, opacity 0.3s ease, margin 0.3s ease"
+            el.style.overflow = "hidden"
+        })
+        // Apply initial state without animation
+        this.applyState(false)
+    }
+
+    openValueChanged() {
+        if (this.element.isConnected) {
+            this.applyState(true)
+        }
+    }
+
+    applyState(animate) {
+        this.contentTargets.forEach(el => {
+            if (!animate) {
+                el.style.transition = "none"
+            }
+
+            if (this.openValue) {
+                el.style.maxHeight = el.scrollHeight + "px"
+                el.style.opacity = "1"
+                el.style.marginTop = ""
+                if (animate) {
+                    el.addEventListener("transitionend", () => {
+                        if (this.openValue) el.style.maxHeight = "none"
+                    }, { once: true })
+                } else {
+                    el.style.maxHeight = "none"
+                }
+            } else {
+                if (el.style.maxHeight === "none") {
+                    el.style.maxHeight = el.scrollHeight + "px"
+                    el.offsetHeight // eslint-disable-line no-unused-expressions
+                }
+                el.style.maxHeight = "0px"
+                el.style.opacity = "0"
+                el.style.marginTop = "0px"
+            }
+
+            if (!animate) {
+                el.offsetHeight // eslint-disable-line no-unused-expressions
+                el.style.transition = "max-height 0.3s ease, opacity 0.3s ease, margin 0.3s ease"
+            }
+        })
+
+        if (this.hasIconTarget) {
+            this.iconTarget.classList.toggle("rotate-180", this.openValue)
+        }
+
+        if (this.hasAreaTarget) {
+            this.areaTarget.classList.toggle("cursor-pointer", !this.openValue)
+        }
+    }
+
+    toggle() {
+        this.openValue = !this.openValue
+    }
+
+    expand() {
+        if (!this.openValue) {
+            this.openValue = true
+        }
+    }
+}

--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -204,6 +204,7 @@ class BaseWikipageImporter
     書籍
     バンド名の変遷
     バンド名変遷
+    カラオケ配信
   ].freeze
 
   def parse_sections(owner)


### PR DESCRIPTION
## Summary
- current以外のMembersセクションでメンバー経歴をデフォルト折りたたみ表示にし、トグルボタンまたはメンバー領域クリックで展開可能にする
- スナップショット見出しからsnapshot_dateの重複表示を削除（ラベルのみ表示）
- セクションインポート時の除外キーワードに「カラオケ配信」を追加

## Details
- Stimulus `toggle_controller.js` を新規作成（max-height + opacity + margin のトランジションでスムーズな開閉）
- currentスナップショットはデフォルト展開、それ以外はデフォルト折りたたみ
- 折りたたみ時はメンバー名・パート・SNSは表示したまま経歴部分のみ非表示

## Test plan
- [x] 全44テスト pass
- [x] RuboCop pass
- [x] currentスナップショットが展開状態で表示されることを確認
- [x] current以外が折りたたまれた状態で表示されることを確認
- [x] chevronボタンで開閉が動作することを確認
- [x] メンバー領域クリックで展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)