### PR TITLE
fix: 検索結果の並び順を関連度順に変更

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,11 +6,19 @@ class SearchController < ApplicationController
 
     if @query.present?
       search_pattern = "%#{@query}%"
+      exact_pattern = ActiveRecord::Base.sanitize_sql_like(@query)
+      relevance_order = Arel.sql(
+        "CASE WHEN name ILIKE #{Unit.connection.quote(exact_pattern)} THEN 0 " \
+        "WHEN name ILIKE #{Unit.connection.quote("#{exact_pattern}%")} THEN 1 " \
+        "WHEN name_kana ILIKE #{Unit.connection.quote(exact_pattern)} THEN 0 " \
+        "WHEN name_kana ILIKE #{Unit.connection.quote("#{exact_pattern}%")} THEN 1 " \
+        'ELSE 2 END'
+      )
       @units = Unit.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q', q: search_pattern)
-                   .order(updated_at: :desc)
+                   .order(relevance_order, updated_at: :desc)
                    .limit(10)
       @people = Person.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q', q: search_pattern)
-                      .order(updated_at: :desc)
+                      .order(relevance_order, updated_at: :desc)
                       .limit(10)
     else
       @units = []


### PR DESCRIPTION
ILIKEによる部分一致検索で完全一致の結果がlimit(10)から
押し出される問題を修正。完全一致→前方一致→部分一致の
優先順位で並び替えてから updated_at 降順でソートする。