### PR TITLE
fix: ウィキリンク正規表現が複数リンクをまたいでマッチする問題を修正

### DIFF
--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -201,7 +201,7 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
 
     # 1. Protect wiki links [[...]] and [...]
     # [[Display|Link]]
-    protected_text = text.gsub(/\[\[(.*?)\|(.*?)\]\]/) do
+    protected_text = text.gsub(/\[\[([^\[\]|]+)\|([^\[\]]+)\]\]/) do
       key = "WIKILINKPLACEHOLDER#{placeholders.size}"
       display = Regexp.last_match(1)
       target = Regexp.last_match(2)
@@ -210,7 +210,7 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
     end
 
     # [[Link]]
-    protected_text = protected_text.gsub(/\[\[([^|]+?)\]\]/) do
+    protected_text = protected_text.gsub(/\[\[([^\[\]|]+)\]\]/) do
       key = "WIKILINKPLACEHOLDER#{placeholders.size}"
       target = Regexp.last_match(1)
       placeholders[key] = link ? create_internal_link(target, target) : target


### PR DESCRIPTION
## 概要

`parse_wiki_links` の `[[Display|Target]]` マッチ用正規表現に起因する表示バグを修正。

## 問題

`.*?`（非欲張りマッチ）は `[` や `]` を含む任意文字にマッチするため、`|` を持たない `[[Link]]` 形式のリンクを読み飛ばして次の `|` まで複数リンクをまたいでマッチしていた。

**例（入力）:**
```
＜Vo.[[Ricky|Ricky Astrovich Primakov]]（[[DASEIN]]）、Gu.[[KAZUYA|KAZUYA(ex-FANATIC◇CRISIS)]]...
```

`[[DASEIN]]）、Gu.[[KAZUYA|KAZUYA(ex-FANATIC◇CRISIS)]]` が1つのマッチになり、displayに `DASEIN]]）、Gu.[[KAZUYA` という壊れた値が入っていた。

## 修正

`.*?` を `[^\[\]|]`（`[`, `]`, `|` を含まない文字）に変更し、`[[...]]` の境界をまたがないよう制約した。

```ruby
# Before
/\[\[(.*?)\|(.*?)\]\]/
/\[\[([^|]+?)\]\]/

# After
/\[\[([^\[\]|]+)\|([^\[\]]+)\]\]/
/\[\[([^\[\]|]+)\]\]/
```

## 確認

- 修正後の出力: `＜Vo.Ricky（DASEIN）、Gu.KAZUYA(ex-FANATIC◇CRISIS)、Gu.SHUN(ex-同左)、Ba.ZERO(ex-D'espairsRay)、Dr.TSUKASA(ex-同左)＞ 1st.LIVE(Shibuya O-East)`
- 既存テスト 46件 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)