### PR TITLE
fix: system-test ジョブでテストファイルがない場合はスキップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,14 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/vkdby_test
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test:system
+        run: |
+          bin/rails db:test:prepare
+          count=$(find test/system -name '*_test.rb' 2>/dev/null | wc -l)
+          if [ "$count" -gt 0 ]; then
+            bin/rails test:system
+          else
+            echo "No system tests found, skipping"
+          fi
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

`test/system` が空の場合に CI の system-test ジョブが失敗する問題を修正。

## 問題

Ruby 4.0.0 環境で `bin/rails test:system` を実行すると、`test/system` ディレクトリを `require` しようとして `LoadError` が発生する。

## 修正

`*_test.rb` ファイルが存在する場合のみ `bin/rails test:system` を実行するよう変更。

## 背景

`dependabot/github_actions/actions/upload-artifact-6` PR の CI が以下の3つの理由で失敗していた：

1. **lint**: PR 開設 (2026-01-16) 後に develop へ rubocop 修正が追加されたため stale
2. **scan_js**: PR 開設後に `bin/importmap` が develop に追加されたため stale  
3. **system-test**: 本 PR で修正する空ディレクトリ問題

本 PR を develop にマージ後、`@dependabot rebase` で stale 問題も解消予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)