### PR TITLE
fix: wikiリンクなしのメンバー名（プレーンテキスト）をインポート対象に追加

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -317,8 +317,10 @@ class WikipageImporter < BaseWikipageImporter
     # Current supported formats:
     # 1. !Part… [[Name]]
     # 2. ![[Name]]… Part
+    # 3. !Part… PlainName (no wiki link)
     old_member_regex1 = /^!([^…\n]+)…\s*\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/
     old_member_regex2 = /^!\[\[([^|\]\n]+)(?:\|([^\]\n]+))?\]\]…([^…\n]+)/
+    old_member_regex3 = /^!([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
 
     @wiki_content.scan(old_member_regex1) do |match|
       match_data = Regexp.last_match
@@ -343,6 +345,19 @@ class WikipageImporter < BaseWikipageImporter
       part_str = match[2].strip
 
       register_old_format_member(unit, part_str, name_str, old_member_key, member_status, current_order)
+      current_order += 1
+    end
+
+    @wiki_content.scan(old_member_regex3) do |match|
+      match_data = Regexp.last_match
+      current_pos = match_data.begin(0)
+      member_status = current_pos > separator_index ? :left : :active
+
+      part_str = match[0].strip
+      name_str = match[1].strip
+      next if name_str.empty?
+
+      register_old_format_member(unit, part_str, name_str, nil, member_status, current_order)
       current_order += 1
     end
   end

--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -314,6 +314,7 @@ class WikipageImporterV2 < WikipageImporter
   def collect_old_format_entries(entries, separator_index)
     old_member_regex1 = /^!([^…\n]+)…\s*\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/
     old_member_regex2 = /^!\[\[([^|\]\n]+)(?:\|([^\]\n]+))?\]\]…([^…\n]+)/
+    old_member_regex3 = /^!([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
 
     @wiki_content.scan(old_member_regex1) do |match|
       match_data = Regexp.last_match
@@ -347,6 +348,28 @@ class WikipageImporterV2 < WikipageImporter
       part_str = match[2].strip
       old_member_key = name_str if old_member_key.blank?
       old_member_key = URI.encode_www_form_component(old_member_key.encode('EUC-JP'))
+
+      entries << {
+        position: current_pos,
+        part_str: part_str,
+        name_str: name_str,
+        old_member_key: old_member_key,
+        sns_account: nil,
+        inline_history: nil,
+        member_status: member_status
+      }
+    end
+
+    @wiki_content.scan(old_member_regex3) do |match|
+      match_data = Regexp.last_match
+      current_pos = match_data.begin(0)
+      member_status = current_pos > separator_index ? :left : :active
+
+      part_str = match[0].strip
+      name_str = match[1].strip
+      next if name_str.empty?
+
+      old_member_key = URI.encode_www_form_component(name_str.encode('EUC-JP'))
 
       entries << {
         position: current_pos,


### PR DESCRIPTION
## 概要

`!!関係者` セクションで `!Part … プレーンテキスト名` 形式（`[[...]]` なし）のメンバーがインポートされていなかった問題を修正。

## 問題

以下のような内容で、ジェロニモのように wiki リンクを持たないメンバーが取り込まれていなかった。

```
!!関係者
!Bass … ジェロニモ
!Guitar … [[TAKUYA]]
{{include TAKUYA,経歴}}
!Guitar … [[SCOTTIE|朝井泰生]]
{{include 朝井泰生,経歴}}
```

既存の正規表現パターンは `[[...]]` を必須としていたため、プレーンテキスト名の行にはマッチしなかった。

## 修正

第3パターン `old_member_regex3` を追加：

```ruby
old_member_regex3 = /^!([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
```

- `[^\S\n]*` — 行末改行を含まない水平空白をすべて消費（バックトラック回避）
- `[^\[\s\n]` — `[`・空白・改行で始まらない文字のみマッチ（wiki リンク行と重複しない）

`wikipage_importer.rb` と `wikipage_importer_v2.rb` の両方に対応。

## 確認（wikipages.id=5319）

```
regex1: ["Guitar ", "TAKUYA", nil]、["Guitar ", "SCOTTIE", "朝井泰生"]、...（wikiリンクあり）
regex3: ["Bass", "ジェロニモ"]  ← 追加されたマッチ
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)