### PR TITLE
fix: Past Members セクションで LEFT バッジを非表示にする

### DIFF
--- a/app/components/member_row_component.rb
+++ b/app/components/member_row_component.rb
@@ -3,9 +3,10 @@
 class MemberRowComponent < ViewComponent::Base
   include WikiLinkHelper
 
-  def initialize(member:, hide_active: false)
+  def initialize(member:, hide_active: false, hide_left: false)
     @member = member
     @hide_active = hide_active
+    @hide_left = hide_left
   end
 
   private
@@ -28,7 +29,10 @@ class MemberRowComponent < ViewComponent::Base
   end
 
   def show_status?
-    !(@hide_active && @member.status == 'active')
+    return false if @hide_active && @member.status == 'active'
+    return false if @hide_left && @member.status == 'left'
+
+    true
   end
 
   def person_history_items

--- a/app/components/unit_members_component.html.erb
+++ b/app/components/unit_members_component.html.erb
@@ -3,7 +3,7 @@
     <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">Past Members</h2>
     <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm">
       <% @past_members.each do |up| %>
-        <%= render MemberRowComponent.new(member: up, hide_active: false) %>
+        <%= render MemberRowComponent.new(member: up, hide_left: true) %>
       <% end %>
     </div>
   </section>


### PR DESCRIPTION
## 概要

Past Members は全員脱退済みのため、LEFT バッジを表示する必要がない。

## 変更内容

- `MemberRowComponent` に `hide_left` オプションを追加
- `unit_members_component.html.erb` の Past Members 描画で `hide_left: true` を渡すよう変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)