### PR TITLE
fix: snapshot_people の part_alias にwikiリンクの表示テキストのみを格納する

### DIFF
--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -409,7 +409,7 @@ class WikipageImporterV2 < WikipageImporter
       person_key: person&.key,
       old_person_key: old_member_key,
       part: part_enum,
-      part_alias: part_str,
+      part_alias: extract_name_from_wiki_link(part_str),
       status: member_status,
       support: support,
       sns: sns_data,


### PR DESCRIPTION
## Summary
- `[[ボヲカル|Vocal]]` のようなwiki形式の `part_alias` が、変換されずそのまま保存されていた問題を修正
- `register_snapshot_member` 内で `extract_name_from_wiki_link` を通して表示テキスト（`ボヲカル`）のみを格納するよう修正

## Test plan
- [ ] 該当するwikiページを再インポートし、`part_alias` が `ボヲカル` として保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)