### PR TITLE
feat: trend content の {{youtube2}} プラグインをYouTube埋め込みとして表示

### DIFF
--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -170,12 +170,12 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def handle_youtube2(line, blocks, current_block)
+  def handle_youtube2(line, blocks, current_block, &block)
     video_id = line.match(/\{\{youtube2\s+([^,}\s]+)/i)&.captures&.first&.strip
-    return handle_text(line, blocks, current_block) { |b| yield b } unless video_id
+    return handle_text(line, blocks, current_block, &block) unless video_id
 
     blocks << current_block unless current_block[:lines].empty?
-    yield({ type: :youtube2, video_id: video_id, lines: [line] })
+    block.call({ type: :youtube2, video_id: video_id, lines: [line] })
   end
 
   def render_wiki_blocks(blocks)


### PR DESCRIPTION
## Summary
- `format_wiki_content` で `{{youtube2 VIDEO_ID,...}}` をYouTube埋め込みiframeとして表示
- 第一パラメータ（動画ID）のみ使用し、16:9レスポンシブ表示

## 実装方法
- `process_line` に `{{youtube2 ...}}` のマッチケースを追加
- `handle_youtube2` メソッドで `:youtube2` ブロックを生成
- `render_wiki_blocks` に `:youtube2` ケースを追加してiframeを出力

## Test plan
- [ ] content に `{{youtube2 WfjLIL59nkg,320,240,}}` を含む trend のページを開き、YouTube動画が埋め込み表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)