### PR TITLE
fix: wikipage.title が nil の場合、first_line から名前を取得するよう修正

### DIFF
--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -285,7 +285,9 @@ class PersonImporter < BaseWikipageImporter
 
   def extract_person_basic_info
     # 1. Parse Person Data
-    title = @wikipage.title.to_s.strip
+    first_line = @wiki_content.lines.first&.strip&.gsub(/^!+/, '')&.strip
+    title = @wikipage.title.presence || first_line
+    title = title.to_s.strip
     if title =~ /^(.+?)[（(](.+?)[）)]/
       raw_name = Regexp.last_match(1).strip
       person_name = extract_name_from_wiki_link(raw_name)
@@ -296,7 +298,6 @@ class PersonImporter < BaseWikipageImporter
     end
 
     # Parse history from first line: "OldName(Kana) → NewName(Kana)"
-    first_line = @wiki_content.lines.first&.strip&.gsub(/^!+/, '')&.strip
     name_log_entries = []
 
     if first_line&.include?('→')


### PR DESCRIPTION
## Summary
- `wikipage.title` が `nil` のページをインポートした際に `person.name` が空になる問題を修正
- `title` が blank の場合は wiki 本文の1行目（`!` を除去した文字列）をフォールバックとして使用

## 原因
- `PersonImporter#extract_person_basic_info` が `@wikipage.title.to_s.strip` → `""` となり
- first_line（例: `Masahiro（マサヒロ）`）に `→` も `{{rb` もないため名前が抽出されなかった

## Test plan
- [ ] `wikipages.id=6209` を再インポートし、`/masahiro-1005` で Name が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)