### PR TITLE
fix: バンド名の半角空白を含む場合のold_keyエンコードを修正

### DIFF
--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -167,7 +167,8 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
   end
 
   def encode_euc_jp(str)
-    str.encode('EUC-JP').bytes.map { |b| "%#{b.to_s(16).upcase}" }.join
+    # スペース（0x20）はDBのold_keyに合わせて+に変換する
+    str.encode('EUC-JP').bytes.map { |b| b == 0x20 ? '+' : "%#{b.to_s(16).upcase}" }.join
   rescue Encoding::UndefinedConversionError
     # Fallback if conversion fails
     str

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -141,4 +141,16 @@ class PersonTest < ActiveSupport::TestCase
 
     assert_equal '他サポート多数', concurrent[2][:unit_name]
   end
+
+  test 'parse_old_history encodes space in band name as plus sign for old_key' do
+    # DBのold_keyはスペースが+で保存されるため、+でエンコードされることを確認
+    person = Person.new(old_history: '[[BULL ZEICHEN 88]]')
+    history = person.parse_old_history
+
+    assert_equal 1, history.size
+    item = history[0][0]
+    assert_equal 'BULL ZEICHEN 88', item[:unit_name]
+    # スペースは+に変換される（DBのold_keyフォーマットに合わせる）
+    assert_equal '%42%55%4C%4C+%5A%45%49%43%48%45%4E+%38%38', item[:old_key]
+  end
 end


### PR DESCRIPTION
## 概要

個人の経歴内にスペースを含むバンド名（例: `BULL ZEICHEN 88`）が記載されていた場合、バンドのプロフィールページへ遷移できない問題を修正。

## 原因

DBに保存されている `old_key` はスペースが `+` で表現されているが（例: `BULL+ZEICHEN+88`）、`WikiParser#encode_euc_jp` はスペースを `%20` にエンコードしていた。

このフォーマットの不一致により、`LegacyRedirectsController` で `Unit.find_by(old_key: ...)` が一致するレコードを見つけられず 404 になっていた。

## 修正内容

`WikiParser#encode_euc_jp` でスペース（EUC-JP: `0x20`）を `%20` ではなく `+` に変換するよう修正。

```ruby
# 修正前
str.encode('EUC-JP').bytes.map { |b| "%#{b.to_s(16).upcase}" }.join
# 修正後
str.encode('EUC-JP').bytes.map { |b| b == 0x20 ? '+' : "%#{b.to_s(16).upcase}" }.join
```

## テスト

`person_test.rb` にスペースを含むバンド名のエンコード検証テストを追加。

- 変更ファイル: `app/models/concerns/wiki_parser.rb`, `test/models/person_test.rb`
- 47 tests, 0 failures, 0 errors