### PR TITLE
feat: bqプラグインのtweet embed対応 (#272)

### DIFF
--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -104,7 +104,10 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
 
       if line.match?(/^\{\{bq/)
         blocks << current_block unless current_block[:lines].empty?
-        current_block = { type: :blockquote, lines: [] }
+        # 先頭行にTwitter URLが含まれる場合はtweet_embedタイプとして扱う
+        tweet_url = line.match(%r{https?://(?:twitter\.com|x\.com)/\S+})&.to_s
+        block_type = tweet_url ? :tweet_embed : :blockquote
+        current_block = { type: block_type, lines: [] }
         in_blockquote = true
         next
       end
@@ -194,6 +197,8 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
         end
       when :list
         render_wiki_list(block[:lines])
+      when :tweet_embed
+        render_tweet_embed(block[:lines].join)
       when :blockquote
         content = block[:lines].join
         tag.blockquote(class: 'border-l-4 border-slate-300 dark:border-slate-600 pl-4 italic text-slate-600 dark:text-slate-400 my-4') do
@@ -280,5 +285,18 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
     link_to(display.html_safe, "/#{encoded}.html", class: 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline')
   rescue Encoding::UndefinedConversionError
     link_to(display.html_safe, '#', class: 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline')
+  end
+
+  # Twitter tweet embedを出力する
+  # <blockquote class="twitter-tweet"> をサニタイズしつつそのまま出力し、
+  # Twitter widget scriptを付加する
+  def render_tweet_embed(content)
+    sanitized = sanitize(
+      content,
+      tags: %w[blockquote a p br],
+      attributes: %w[class lang href]
+    )
+    script = tag.script(src: '//platform.twitter.com/widgets.js', async: true, charset: 'utf-8')
+    (sanitized + script).html_safe
   end
 end

--- a/test/helpers/wiki_link_helper_test.rb
+++ b/test/helpers/wiki_link_helper_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WikiLinkHelperTest < ActionView::TestCase
+  include WikiLinkHelper
+
+  # parse_wiki_lines は private なため format_wiki_content 経由でテスト
+
+  test 'Twitter URLを含むbqブロックがtweet embedとして出力される' do
+    wiki_text = <<~WIKI
+      {{bq https://twitter.com/rui_0726_dv/status/516968877503180801
+      <blockquote class="twitter-tweet" lang="ja"><p>バンド名はDevelop One's Faculties</p>&#8212; rui (@rui_0726_dv) <a href="https://twitter.com/rui_0726_dv/status/516968877503180801">2014, 9月 30</a></blockquote>
+      <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+      }}
+    WIKI
+
+    result = format_wiki_content(wiki_text)
+
+    # <blockquote class="twitter-tweet"> が出力に含まれること
+    assert_match(/twitter-tweet/, result)
+    # Twitter widget scriptが付加されること
+    assert_match(%r{platform\.twitter\.com/widgets\.js}, result)
+  end
+
+  test 'Twitter URLのないbqブロックは通常のblockquoteとして出力される' do
+    wiki_text = <<~WIKI
+      {{bq
+      これは通常の引用文です。
+      }}
+    WIKI
+
+    result = format_wiki_content(wiki_text)
+
+    # 通常の<blockquote>が出力されること
+    assert_match(/<blockquote/, result)
+    # tweet embed用のscriptは付加されないこと
+    assert_no_match(/platform\.twitter\.com/, result)
+  end
+
+  test 'x.com URLを含むbqブロックもtweet embedとして出力される' do
+    wiki_text = <<~WIKI
+      {{bq https://x.com/example/status/123456789
+      <blockquote class="twitter-tweet" lang="ja"><p>テスト</p></blockquote>
+      }}
+    WIKI
+
+    result = format_wiki_content(wiki_text)
+
+    assert_match(/twitter-tweet/, result)
+    assert_match(%r{platform\.twitter\.com/widgets\.js}, result)
+  end
+end


### PR DESCRIPTION
## 概要

Issue #272 への対応。

ユニット・個人ページのsection出力で、Wikiテキスト中の `{{bq}}` プラグインブロックがTwitter URLを含む場合、tweet embed（`<blockquote class="twitter-tweet">` + widget script）として出力するように対応しました。

## 変更内容

### `app/helpers/wiki_link_helper.rb`

- `parse_wiki_lines`: `{{bq` 開始行にTwitter/X URLが含まれる場合、`:tweet_embed` タイプに振り分け
- `render_wiki_blocks`: `:tweet_embed` タイプの処理を追加
- `render_tweet_embed`: 新規メソッド。`<blockquote class="twitter-tweet">` をサニタイズしてembed出力し、widget scriptを付加

### `test/helpers/wiki_link_helper_test.rb` (新規)

- twitter.com URLを含むbqブロック → tweet embed出力
- URLなしのbqブロック → 通常のblockquote出力
- x.com URLを含むbqブロック → tweet embed出力

## 入力例

```
{{bq https://twitter.com/rui_0726_dv/status/516968877503180801
<blockquote class="twitter-tweet" lang="ja"><p>バンド名は...</p>...</blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
}}
```

Closes #272