### PR TITLE
feat: youtube2プラグインのURL対応

### DIFF
--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -180,11 +180,31 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def handle_youtube2(line, blocks, current_block, &block)
-    video_id = line.match(/\{\{youtube2\s+([^,}\s]+)/i)&.captures&.first&.strip
+    raw = line.match(/\{\{youtube2\s+([^,}\s]+)/i)&.captures&.first&.strip
+    return handle_text(line, blocks, current_block, &block) unless raw
+
+    video_id = extract_youtube_video_id(raw)
     return handle_text(line, blocks, current_block, &block) unless video_id
 
     blocks << current_block unless current_block[:lines].empty?
     block.call({ type: :youtube2, video_id: video_id, lines: [line] })
+  end
+
+  # YouTube URLまたはIDからビデオIDを抽出する
+  # 対応フォーマット:
+  #   https://www.youtube.com/watch?v=XXXX
+  #   https://youtu.be/XXXX
+  #   XXXX (IDそのまま)
+  def extract_youtube_video_id(raw)
+    case raw
+    when %r{youtu\.be/([^?&\s]+)}
+      Regexp.last_match(1)
+    when /[?&]v=([^&\s]+)/
+      Regexp.last_match(1)
+    else
+      # URLでなければそのままIDとして扱う
+      raw
+    end
   end
 
   def render_wiki_blocks(blocks)

--- a/test/helpers/wiki_link_helper_test.rb
+++ b/test/helpers/wiki_link_helper_test.rb
@@ -50,4 +50,22 @@ class WikiLinkHelperTest < ActionView::TestCase
     assert_match(/twitter-tweet/, result)
     assert_match(%r{platform\.twitter\.com/widgets\.js}, result)
   end
+
+  test 'youtube2プラグインにIDを指定した場合はそのままembedされる' do
+    result = format_wiki_content('{{youtube2 dQw4w9WgXcQ}}')
+
+    assert_match(%r{youtube\.com/embed/dQw4w9WgXcQ}, result)
+  end
+
+  test 'youtube2プラグインにyoutube.com URLを指定した場合はIDを抽出してembedされる' do
+    result = format_wiki_content('{{youtube2 https://www.youtube.com/watch?v=dQw4w9WgXcQ}}')
+
+    assert_match(%r{youtube\.com/embed/dQw4w9WgXcQ}, result)
+  end
+
+  test 'youtube2プラグインにyoutu.be URLを指定した場合はIDを抽出してembedされる' do
+    result = format_wiki_content('{{youtube2 https://youtu.be/dQw4w9WgXcQ}}')
+
+    assert_match(%r{youtube\.com/embed/dQw4w9WgXcQ}, result)
+  end
 end


### PR DESCRIPTION
## 概要

youtube2プラグインのパラメータに動画URLが渡された場合に、URLからビデオIDを抽出してembedする対応。

## 変更内容

### `app/helpers/wiki_link_helper.rb`

- `extract_youtube_video_id` メソッドを新規追加
  - `https://www.youtube.com/watch?v=XXXX` 形式のURLからIDを抽出
  - `https://youtu.be/XXXX` 形式のURLからIDを抽出
  - IDそのまま指定の場合は変更なし
- `handle_youtube2`: `extract_youtube_video_id` を経由してIDを取得するよう修正

### `test/helpers/wiki_link_helper_test.rb`

- youtube2プラグインのテスト3ケースを追加
  - IDを直接指定した場合
  - `youtube.com` URLを指定した場合
  - `youtu.be` URLを指定した場合