### PR TITLE
feat: 検索結果ページのPerson表示をPersonCardComponentに置き換え (#276)

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -60,14 +60,7 @@
               <%= link_to "View all People →", people_path(q: @query), class: "text-sm font-bold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %>
             </div>
             <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-              <% @people.each do |person| %>
-                <%= link_to profile_path(person.key), class: "group block bg-slate-50 dark:bg-slate-900/50 p-4 rounded-xl border border-slate-100 dark:border-slate-700 hover:border-person hover:scale-[1.02] transition-all" do %>
-                  <h3 class="text-base font-black text-slate-800 dark:text-slate-200 group-hover:text-person transition-colors truncate"><%= person.name %></h3>
-                  <% if person.name_kana.present? %>
-                    <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1"><%= person.name_kana %></p>
-                  <% end %>
-                <% end %>
-              <% end %>
+              <%= render PersonCardComponent.with_collection(@people, show_history: true) %>
             </div>
           </section>
         <% end %>


### PR DESCRIPTION
## 概要

Issue #276 への対応。

検索結果ページ (`/search?q=...`) のPerson一覧表示部分において、これまでは独自にHTMLタグを出力していましたが、他画面と表示を揃えるために `PersonCardComponent` を使用するよう置き換えました。

## 変更内容

- **app/views/search/index.html.erb**
  - `@people.each` でのインラインHTML出力を削除
  - `PersonCardComponent.with_collection(@people, show_history: true)` による描画へ変更

Closes #276