### PR TITLE
fix: WikipageImporterV2でコメント行（//）を除外するように修正 (#278)

### DIFF
--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -242,9 +242,12 @@ class WikipageImporterV2 < WikipageImporter
   def parse_snapshot_members(snapshot, content)
     return unless content
 
+    # コメント行（行頭が //）を除外する
+    content_without_comments = content.lines.reject { |line| line.strip.start_with?('//') }.join
+
     # 一時的に @wiki_content を section content に置き換え
     original_wiki_content = @wiki_content
-    @wiki_content = content
+    @wiki_content = content_without_comments
 
     separator_index = @wiki_content.index(/^!!関係者/) || Float::INFINITY
 


### PR DESCRIPTION
## 概要

Issue #278（`snapshot_people` テーブル等への不正データ混入問題）への対応。

旧Wikiのテンプレート編集用文字列（`//` で始まる行）が、そのままメンバーとしてインポートされてしまう問題を修正しました。

## 変更内容

- `app/services/wikipage_importer_v2.rb`
  - `parse_snapshot_members` メソッドのパース対象テキストから、一時的に行頭が `//` で始まるコメント行を除外する処理を追加

Closes #278