### PR TITLE
fix: {{member}} の old_member_key '-' を name_str にフォールバック (#275)

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -300,7 +300,7 @@ class WikipageImporter < BaseWikipageImporter
 
       next if name_str.blank?
 
-      if old_member_key.present?
+      if old_member_key.present? && old_member_key != '-'
         old_member_key = old_member_key.strip
         old_member_key = [name_str, old_member_key].join if old_member_key =~ /^\(/ && old_member_key =~ /\)$/
       else

--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -293,14 +293,7 @@ class WikipageImporterV2 < WikipageImporter
 
       next if name_str.blank?
 
-      if old_member_key.present?
-        old_member_key = old_member_key.strip
-        old_member_key = [name_str, old_member_key].join if old_member_key =~ /^\(/ && old_member_key =~ /\)$/
-      else
-        old_member_key = name_str
-      end
-
-      old_member_key = URI.encode_www_form_component(old_member_key.encode('EUC-JP'))
+      old_member_key = resolve_old_member_key(name_str, old_member_key)
 
       entries << {
         position: current_pos,
@@ -312,6 +305,16 @@ class WikipageImporterV2 < WikipageImporter
         member_status: member_status
       }
     end
+  end
+
+  def resolve_old_member_key(name_str, old_member_key)
+    key = if old_member_key.present? && old_member_key != '-'
+            raw = old_member_key.strip
+            raw =~ /^\(/ && raw =~ /\)$/ ? [name_str, raw].join : raw
+          else
+            name_str
+          end
+    URI.encode_www_form_component(key.encode('EUC-JP'))
   end
 
   def collect_old_format_entries(entries, separator_index)


### PR DESCRIPTION
## Summary

- `{{member Guitar,rui,-,...}}` のように第3引数に `-` が指定された場合、person との接続が失敗する問題を修正
- `-` は「wikiページ名なし（= DisplayName を使う）」という慣習だが、`present?` が `true` なのでフォールバックが実行されず `old_person_key = '-'` が UnitPerson に保存されていた

## Root Cause

```
DOF wiki: {{member Guitar,rui,-,...}}
  → old_member_key = "-" （present? が true）
  → old_person_key = "-" として UnitPerson に保存

person import（rui）:
  → link_existing_unit_people: UnitPerson.where(old_person_key: "rui")
  → 一致なし（"-" ≠ "rui"）→ 接続されない
```

## Fix

`old_member_key != '-'` の条件を追加し、`-` の場合は `name_str` にフォールバック。

`WikipageImporterV2` では複雑度削減のため `resolve_old_member_key` ヘルパーに抽出。

## Test plan

- [x] 全テスト通過（54 runs, 155 assertions）
- [x] RuboCop チェック通過

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)