### PR TITLE
feat: trendsの日付を日付ページへのリンクに変更

### DIFF
--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -2,7 +2,14 @@
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-slate-50 dark:bg-slate-900/30 p-6 md:p-8 border-b border-slate-100 dark:border-slate-700">
       <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400 font-mono mb-2 font-bold">
-        <%= @trend.date.strftime('%Y/%m/%d') %>
+        <% date_path, date_label = if @trend.month_unknown?
+                                      [yearly_path(year: @trend.date.year), @trend.date.strftime('%Y')]
+                                    elsif @trend.day_unknown?
+                                      [monthly_path(year: @trend.date.year, month: @trend.date.month), @trend.date.strftime('%Y/%m')]
+                                    else
+                                      [daily_path(year: @trend.date.year, month: @trend.date.month, day: @trend.date.day), @trend.date.strftime('%Y/%m/%d')]
+                                    end %>
+        <%= link_to date_label, date_path, class: "hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors" %>
       </div>
       <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
         <% if @trend.units %>


### PR DESCRIPTION
## Summary

- `/trends/:id` の日付表示をクリッカブルなリンクに変更
- `day_unknown` / `month_unknown` フラグに応じてリンク先・表示を出し分け
  - 通常 → `/date/YYYY/MM/DD`（年月日表示）
  - `day_unknown` → `/date/YYYY/MM`（年月のみ表示）
  - `month_unknown` → `/date/YYYY`（年のみ表示）

## Test plan

- [ ] 通常の日付が `/date/YYYY/MM/DD` へのリンクになっている
- [ ] `day_unknown=true` のtrendで日が表示されず `/date/YYYY/MM` へリンクされる
- [ ] `month_unknown=true` のtrendで月・日が表示されず `/date/YYYY` へリンクされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)