### PR TITLE
fix: 個人ページのname_log表示を修正・カナを横並びに変更

### DIFF
--- a/app/components/name_history_item_component.html.erb
+++ b/app/components/name_history_item_component.html.erb
@@ -4,9 +4,11 @@
     <% if @log.date.present? %>
       <span class="text-xs font-semibold text-slate-400 dark:text-slate-500 mb-0.5"><%= @log.date %></span>
     <% end %>
-    <span class="text-sm font-bold text-slate-700 dark:text-slate-200"><%= @log.name %></span>
-    <% if @log.name_kana.present? %>
-      <span class="text-xs text-slate-500 dark:text-slate-400">(<%= @log.name_kana %>)</span>
-    <% end %>
+    <span class="flex items-baseline gap-1.5">
+      <span class="text-sm font-bold text-slate-700 dark:text-slate-200"><%= @log.name %></span>
+      <% if @log.name_kana.present? %>
+        <span class="text-xs text-slate-500 dark:text-slate-400">(<%= @log.name_kana %>)</span>
+      <% end %>
+    </span>
   </div>
 </div>

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,7 +3,7 @@
 class ProfilesController < ApplicationController
   def show
     @resource = Unit.includes(:links, unit_people: :person).find_by(key: params[:key]) ||
-                Person.includes(:person_logs, :links).find_by!(key: params[:key])
+                Person.includes(:links).find_by!(key: params[:key])
 
     @links = @resource.links.where(active: true).order(:sort_order)
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -108,10 +108,7 @@ class Person < ApplicationRecord
   # Person logs for form (virtual attribute)
   def name_logs
     require 'ostruct'
-    return person_logs.map { |log| ::OpenStruct.new(log.attributes) } if person_logs.loaded?
-
-    person_log_entries = self[:name_log] || []
-    person_log_entries.map { |entry| ::OpenStruct.new(entry) }
+    (self[:name_log] || []).map { |entry| ::OpenStruct.new(entry) }
   end
 
   def name_logs_attributes=(attributes)


### PR DESCRIPTION
## Summary

- `person_logs`（廃止予定）への依存を削除し、`name_log` JSOBカラムを直接参照するよう修正
- `ProfilesController` から不要な `includes(:person_logs)` を除去
- `NameHistoryItemComponent` でカナ（name_kana）を名前の横に並べて表示

## Test plan

- [ ] `/sami-0818` などの個人ページで name_log の名前履歴が表示されること
- [ ] 名前とカナが横並びで表示されること
- [ ] ユニットページに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)