### PR TITLE
fix: プロフィールヘッダーのtype_label削除・よみがなを名前の上に移動

### DIFF
--- a/app/components/profile_header_component.html.erb
+++ b/app/components/profile_header_component.html.erb
@@ -1,11 +1,8 @@
 <header class="p-6 md:p-8 text-center text-white relative <%= bg_class %>">
-  <div class="text-[0.7rem] font-black uppercase tracking-widest opacity-80 mb-2">
-    <%= type_label %>
-  </div>
-  <h1 class="text-3xl md:text-4xl font-black mb-1 tracking-tight"><%= name %></h1>
   <% if name_kana.present? %>
     <p class="text-sm md:text-base opacity-90 font-medium"><%= name_kana %></p>
   <% end %>
+  <h1 class="text-3xl md:text-4xl font-black mb-1 tracking-tight"><%= name %></h1>
   <% if helpers.respond_to?(:logged_in?) && helpers.logged_in? %>
     <% if @resource.is_a?(Person) %>
       <div class="absolute top-4 right-4">

--- a/app/components/profile_header_component.rb
+++ b/app/components/profile_header_component.rb
@@ -11,14 +11,6 @@ class ProfileHeaderComponent < ViewComponent::Base
     @resource.is_a?(Unit) ? 'bg-unit' : 'bg-person'
   end
 
-  def type_label
-    if @resource.is_a?(Unit)
-      @resource.unit_type.present? ? @resource.unit_type.upcase : 'UNIT'
-    else
-      'PERSON'
-    end
-  end
-
   def name
     @resource.name
   end


### PR DESCRIPTION
## Summary

- ユニットタイプ・PERSON ラベルの表示を削除
- よみがな（name_kana）を名前（name）の上に表示するよう順序を変更
- 未使用になった `type_label` メソッドを `ProfileHeaderComponent` から削除

## Test plan

- [ ] 個人ページのヘッダーにPERSONラベルが表示されないこと
- [ ] ユニットページのヘッダーにユニットタイプラベルが表示されないこと
- [ ] よみがなが名前の上に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)