### PR TITLE
feat: Items convert 時に artist の alias 対応 (#295)

### DIFF
--- a/app/services/item_converter.rb
+++ b/app/services/item_converter.rb
@@ -114,14 +114,16 @@ class ItemConverter
 
     # [[表示名|名前]] または [[名前]] の形式を抽出
     text.scan(/\[\[(?:([^\]|]+)\|)?([^\]]+)\]\]/) do |display_name, actual_name|
-      name = display_name.presence || actual_name
       # (アーティスト) などの接尾辞を削除
-      name = name.gsub(/\(.*?\)/, '').strip
+      name = actual_name.gsub(/\(.*?\)/, '').strip
 
-      artists << {
+      artist = {
         'name' => name,
         'old_key' => encode_euc_jp(actual_name)
       }
+      artist['alias'] = display_name.gsub(/\(.*?\)/, '').strip if display_name.present?
+
+      artists << artist
     end
 
     artists

--- a/test/services/item_converter_test.rb
+++ b/test/services/item_converter_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ItemConverterTest < ActiveSupport::TestCase
+  # extract_wiki_links のテスト（private メソッドなので send で呼び出す）
+  def extract_wiki_links(text)
+    ItemConverter.new(nil).send(:extract_wiki_links, text)
+  end
+
+  test '[[名前]] 形式は name のみ設定される' do
+    result = extract_wiki_links('[[アーティスト名]]')
+    assert_equal 1, result.size
+    assert_equal 'アーティスト名', result.first['name']
+    assert_nil result.first['alias']
+  end
+
+  test '[[表示名|名前]] 形式は name と alias が設定される' do
+    result = extract_wiki_links('[[表示名|正式名]]')
+    assert_equal 1, result.size
+    assert_equal '正式名', result.first['name']
+    assert_equal '表示名', result.first['alias']
+  end
+
+  test '(アーティスト) などの接尾辞が除去される' do
+    result = extract_wiki_links('[[アーティスト名(アーティスト)]]')
+    assert_equal 'アーティスト名', result.first['name']
+    assert_nil result.first['alias']
+  end
+
+  test '[[表示名(suffix)|名前]] 形式は alias から suffix が除去される' do
+    result = extract_wiki_links('[[表示名(アーティスト)|正式名]]')
+    assert_equal '正式名', result.first['name']
+    assert_equal '表示名', result.first['alias']
+  end
+
+  test '複数の wiki リンクが解析される' do
+    result = extract_wiki_links('[[表示A|名前A]] と [[名前B]]')
+    assert_equal 2, result.size
+
+    assert_equal '名前A', result[0]['name']
+    assert_equal '表示A', result[0]['alias']
+
+    assert_equal '名前B', result[1]['name']
+    assert_nil result[1]['alias']
+  end
+end


### PR DESCRIPTION
## Summary

- `ItemConverter#extract_wiki_links` で `[[表示名|名前]]` 形式を解析する際、表示名（display_name）を `alias` として artists JSON に保存するよう修正
- 修正前は表示名が `name` として使われ、alias は保存されていなかった
- あわせて `test/services/item_converter_test.rb` を新規作成

## Test plan

- [ ] `bin/rails test test/services/item_converter_test.rb` が全件パスすること
- [ ] DB 上で alias 付きレコードが検索できること（`Item.where("artists::text LIKE ?", "%\"alias\"%").count` → 344件確認済み）

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)