### PR TITLE
feat: Items カードで artist の alias をリンクテキストに使用 (#291)

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -23,10 +23,11 @@
     <% if @item.artists.present? %>
       <div class="flex flex-wrap gap-1">
         <% @item.artists.each do |artist_data| %>
+          <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
           <% if artist_data['old_key'].present? %>
-            <%= link_to artist_data['name'], "/#{artist_data['old_key']}.html", class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors border border-indigo-200 dark:border-indigo-700" %>
+            <%= link_to artist_label, "/#{artist_data['old_key']}.html", class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors border border-indigo-200 dark:border-indigo-700" %>
           <% else %>
-            <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-gray-50 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600"><%= artist_data['name'] %></span>
+            <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-gray-50 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600"><%= artist_label %></span>
           <% end %>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary

- `ItemCardComponent` でアーティストを表示する際、`alias` が設定されている場合はリンクテキスト（およびプレーンテキスト表示）に `alias` を使用するよう修正
- `alias` がない場合は従来通り `name` を使用

## 変更箇所

`app/components/item_card_component.html.erb` — アーティスト表示部分に `artist_label = alias.presence || name` を追加

## Test plan

- [ ] `bin/rails test` が全件パスすること
- [ ] alias 付きアーティスト（例: `ナイトメア` / alias: `NIGHTMARE`）が items 一覧でリンクテキストとして alias 表示されること

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)