### PR TITLE
fix(importer): 経歴の [[バンド名]]ローディー 形式の役割テキストを取り込む

### DIFF
--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -41,10 +41,16 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
         content = wrapped_in_parens ? item_segment[1..-2] : item_segment
 
         case content
-        # Pattern 1: [[UnitName]] or [[UnitName]](Part) - Internal unit link
+        # Pattern 1: [[UnitName]] or [[UnitName]](Part) or [[UnitName]]Role - Internal unit link
         when /\[\[([^\]]+)\]\](?:\(([^)]+)\))?/
           unit_text = ::Regexp.last_match(1)
           part_and_name = ::Regexp.last_match(2)
+
+          # [[バンド名]]ローディー のように括弧なしで役割テキストが続く場合に取り込む
+          unless part_and_name
+            trailing = content[::Regexp.last_match(0).length..].strip
+            part_and_name = trailing.presence
+          end
 
           # [[XXXX|YYYY]] の場合、XXXXが表示名、YYYYがold_key(エンコード前)
           if unit_text.include?('|')

--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -240,9 +240,9 @@ class PersonImporter < BaseWikipageImporter
     person.old_history = career_section
     person.save!
 
-    career_section.scan(/→\s*\[\[([^\]]+)\]\](?:\(([^)]+)\))?/).each do |unit_name, part_str|
+    career_section.scan(/→\s*\[\[([^\]]+)\]\](?:\(([^)]+)\))?([^→(、\n]*)/).each do |unit_name, part_in_paren, part_trailing|
       unit_name = unit_name.strip
-      part_str = part_str&.strip
+      part_str = (part_in_paren || part_trailing&.strip).presence
 
       unit = find_unit_by_name(unit_name)
       puts "Warning: Could not find unit '#{unit_name}' for person #{person.name} (ID: #{@wikipage.id})" if unit.nil?
@@ -251,7 +251,10 @@ class PersonImporter < BaseWikipageImporter
       unit_person = UnitPerson.find_or_initialize_by(unit: unit, person: person)
 
       if part_str
-        part_key = case part_str.downcase
+        is_support = part_str.match?(/サポート|support/i)
+        cleaned_part = part_str.gsub(/サポート|support/i, '').strip
+
+        part_key = case cleaned_part.downcase
                    when /vocal/ then :vocal
                    when /guitar/ then :guitar
                    when /bass/ then :bass
@@ -261,6 +264,8 @@ class PersonImporter < BaseWikipageImporter
                    else :unknown
                    end
         unit_person.part = part_key if unit_person.new_record?
+        unit_person.support = is_support
+        unit_person.part_alias = cleaned_part.presence if part_key == :unknown && !is_support
       end
 
       unit_person.status = :left

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -142,6 +142,30 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal '他サポート多数', concurrent[2][:unit_name]
   end
 
+  test 'parse_old_history captures trailing role text after wiki link' do
+    # [[バンド名]]ローディー のように括弧なしで役割テキストが続く場合
+    person = Person.new(old_history: '[[ザアザア]]ローディー → [[OLD CIRCUS]]')
+    history = person.parse_old_history
+
+    assert_equal 2, history.size
+    assert_equal 'ザアザア', history[0][0][:unit_name]
+    assert_equal 'ローディー', history[0][0][:part_and_name]
+    assert_equal 'OLD CIRCUS', history[1][0][:unit_name]
+    assert_nil history[1][0][:part_and_name]
+  end
+
+  test 'parse_old_history captures parenthesized role after wiki link' do
+    # [[バンド名]](サポート) 形式
+    person = Person.new(old_history: '[[バンドA]](サポート) → [[バンドB]]')
+    history = person.parse_old_history
+
+    assert_equal 2, history.size
+    assert_equal 'バンドA', history[0][0][:unit_name]
+    assert_equal 'サポート', history[0][0][:part_and_name]
+    assert_equal 'バンドB', history[1][0][:unit_name]
+    assert_nil history[1][0][:part_and_name]
+  end
+
   test 'parse_old_history encodes space in band name as plus sign for old_key' do
     # DBのold_keyはスペースが+で保存されるため、+でエンコードされることを確認
     person = Person.new(old_history: '[[BULL ZEICHEN 88]]')


### PR DESCRIPTION
## Summary
- `wiki_parser.rb`: Pattern 1 で `[[バンド名]]ローディー` のように `]]` 直後に括弧なしで続く役割テキストを `part_and_name` として取り込むよう修正
- `person_importer.rb`: `parse_career_history` の正規表現を拡張し、同様に括弧なし役割テキストも取得。`(サポート)` 等を `unit_person.support` / `part_alias` に正しくセット
- テスト2件追加（括弧なし・括弧あり役割テキストのパース確認）

## Test plan
- [x] `bin/rails test` が全件パスすること（61 tests, 180 assertions）
- [ ] wikipages.id = 16498 等のページを再インポートし、ローディー役割が `part_and_name` に反映されること
- [ ] `UnitPerson.part_alias` に "ローディー" 等が保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)