### PR TITLE
fix(model): バンド名・個人名の HTML 文字参照をデコードして表示する

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -30,6 +30,8 @@
 #  index_people_on_name_kana  (name_kana)
 #  index_people_on_old_key    (old_key) UNIQUE
 #
+require 'cgi'
+
 class Person < ApplicationRecord
   include WikiParser
   has_many :links, as: :linkable, dependent: :destroy
@@ -70,6 +72,10 @@ class Person < ApplicationRecord
 
   validate :key_immutable, on: :update
   after_create :auto_link_unit_people
+
+  def name
+    CGI.unescapeHTML(super.to_s).presence
+  end
 
   def status_text
     STATUS_TRANSLATIONS[status] || status.humanize

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -25,6 +25,7 @@
 #  index_units_on_name_kana  (name_kana)
 #  index_units_on_old_key    (old_key) UNIQUE
 #
+require 'cgi'
 require 'ostruct'
 
 class Unit < ApplicationRecord
@@ -50,6 +51,10 @@ class Unit < ApplicationRecord
     'disbanded' => '解散',
     'unknown' => '不明'
   }.freeze
+
+  def name
+    CGI.unescapeHTML(super.to_s).presence
+  end
 
   def status_text
     STATUS_TRANSLATIONS[status] || status.humanize


### PR DESCRIPTION
## Summary

- `Unit#name` と `Person#name` のゲッターを `CGI.unescapeHTML` でラップし、DB に `&#248;` のような HTML 文字参照が保存されていても正しい文字（`ø` など）で表示されるようにする
- 既存データの再インポートや DB マイグレーションは不要
- ビュー・コンポーネント・ヘルパーすべてに自動適用

## Test plan

- [ ] `&#248;` を含む名前を持つバンド・個人ページで、文字参照ではなく実際の文字（`ø` など）が表示されることを確認
- [ ] 通常の名前（日本語・ASCII）が引き続き正しく表示されることを確認
- [ ] 既存テスト 61 件がすべて通過することを確認（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)