### PR TITLE
fix: Links フォームのバリデーションエラーとリダイレクト先を修正

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -43,7 +43,7 @@ module Admin
 
     def update
       if @unit.update(unit_params)
-        redirect_to admin_units_path, notice: 'Unit updated successfully.'
+        redirect_to edit_admin_unit_path(@unit), notice: 'Unit updated successfully.'
       else
         @unit_logs = @unit.unit_logs.order(:log_date)
         @unit_people = @unit.unit_people.includes(:person).order(:period, :order_in_period)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -43,7 +43,7 @@ class Person < ApplicationRecord
   has_many :sections, as: :sectionable, dependent: :destroy
   has_many :snapshot_people
 
-  accepts_nested_attributes_for :links, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :links, allow_destroy: true, reject_if: proc { |attrs| attrs['url'].blank? }
 
   enum :status, { pre: 0, active: 1, free: 2, hiatus: 3, retirement: 90, passed_away: 98, unknown: 99 }
 

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -30,7 +30,7 @@ require 'ostruct'
 
 class Unit < ApplicationRecord
   has_many :links, as: :linkable, dependent: :destroy
-  accepts_nested_attributes_for :links, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :links, allow_destroy: true, reject_if: proc { |attrs| attrs['url'].blank? }
   has_many :unit_people
   has_many :people, through: :unit_people
   has_many :unit_logs, dependent: :destroy

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,14 @@
 ja:
+  errors:
+    messages:
+      blank: "を入力してください"
   activerecord:
+    errors:
+      messages:
+        blank: "を入力してください"
     attributes:
+      link:
+        url: "URL"
       trend:
         unit_phenomenon:
           announcement: お知らせ


### PR DESCRIPTION
## Summary

- `Unit`/`Person` モデルの `links` の `reject_if: :all_blank` を `proc { |attrs| attrs['url'].blank? }` に変更
  - `check_box :active` が hidden field を常に送信するため `:all_blank` が機能せず、URL 空の新規リンクがバリデーションエラーになっていた問題を修正
- Unit 更新成功後のリダイレクト先を一覧画面（`admin_units_path`）から編集画面（`edit_admin_unit_path`）に変更
- `config/locales/ja.yml` に `errors.messages.blank` の日本語訳（`を入力してください`）と `link.url` の属性名を追加

## Test plan

- [ ] Unit 編集画面でリンクを追加・更新できること
- [ ] URL 欄が空の追加用フィールドを残したまま保存してもエラーにならないこと
- [ ] 保存後、一覧ではなく編集画面に戻ること
- [ ] URL が空のまま既存リンクを保存しようとするとエラーメッセージが日本語で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)