### PR TITLE
feat: Unit編集画面にスナップショット一覧を表示する

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class UnitsController < Admin::BaseController
-    before_action :set_unit, only: %i[edit update destroy]
+    before_action :set_unit, only: %i[show edit update destroy]
     before_action :require_super_operator, only: %i[destroy]
 
     def index
@@ -23,10 +23,15 @@ module Admin
       @unit.old_key ||= params[:old_key]
     end
 
+    def show
+      redirect_to edit_admin_unit_path(@unit)
+    end
+
     def edit
       @unit_logs = @unit.unit_logs.order(:log_date)
       @unit_people = @unit.unit_people.includes(:person).order(:period, :order_in_period)
       @unit_person = @unit.unit_people.build(period: 1, order_in_period: (@unit_people.last&.order_in_period || 0) + 1)
+      @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(snapshot_date: :desc)
       @unit.links.build # Build an empty link for the form
     end
 
@@ -49,6 +54,7 @@ module Admin
         @unit_people = @unit.unit_people.includes(:person).order(:period, :order_in_period)
         @unit_person = @unit.unit_people.build(period: 1,
                                                order_in_period: (@unit_people.last&.order_in_period || 0) + 1)
+        @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(snapshot_date: :desc)
         @unit.links.build if @unit.links.none?(&:new_record?)
         render :edit, status: :unprocessable_entity
       end

--- a/app/views/admin/unit_snapshots/index.html.erb
+++ b/app/views/admin/unit_snapshots/index.html.erb
@@ -30,7 +30,7 @@
               <% @unit_snapshots.each do |snapshot| %>
                 <tr>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 dark:text-gray-200">
-                    <%= snapshot.snapshot_date.strftime("%Y/%m/%d") %>
+                    <%= snapshot.snapshot_date&.strftime("%Y/%m/%d") %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
                     <%= snapshot.label %>

--- a/app/views/admin/units/_snapshots_list.html.erb
+++ b/app/views/admin/units/_snapshots_list.html.erb
@@ -1,0 +1,46 @@
+<div class="bg-white shadow rounded-lg p-6 mb-6 dark:bg-gray-900">
+  <div class="flex items-center justify-between mb-4">
+    <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">Snapshots</h3>
+    <%= link_to "Manage Snapshots", admin_unit_unit_snapshots_path(unit), class: "text-sm text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+  </div>
+  <% if unit_snapshots.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Date</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Label</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Members</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Current</th>
+            <th scope="col" class="relative py-2 pl-3 pr-4 sm:pr-6"><span class="sr-only">Edit</span></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700">
+          <% unit_snapshots.each do |snapshot| %>
+            <tr>
+              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-900 dark:text-gray-200">
+                <%= snapshot.snapshot_date&.strftime("%Y/%m/%d") %>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400">
+                <%= snapshot.label %>
+              </td>
+              <td class="px-3 py-3 text-sm text-gray-500 dark:text-gray-400">
+                <%= snapshot.snapshot_people.map(&:name).join("、") %>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm">
+                <% if snapshot.current? %>
+                  <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">Current</span>
+                <% end %>
+              </td>
+              <td class="relative whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+                <%= link_to "Edit", edit_admin_unit_unit_snapshot_path(unit, snapshot), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 dark:text-gray-400">No snapshots yet.</p>
+  <% end %>
+</div>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -13,17 +13,11 @@
       </div>
       
       <div class="md:col-span-2">
+        <%= render "snapshots_list", unit: @unit, unit_snapshots: @unit_snapshots %>
         <%= render "members_list", unit_people: @unit_people, unit: @unit %>
         <%= render "new_member_form", unit: @unit, unit_person: @unit_person %>
         <%= render "links_form", unit: @unit %>
       </div>
-    </div>
-  </div>
-
-  <div class="mt-6">
-    <div class="sm:flex sm:items-center justify-between mb-4">
-      <h2 class="text-xl font-bold dark:text-white">Snapshots</h2>
-      <%= link_to "Manage Snapshots", admin_unit_unit_snapshots_path(@unit), class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto" %>
     </div>
   </div>
 


### PR DESCRIPTION
closes #303

## Summary

- `app/views/admin/units/_snapshots_list.html.erb` を新規作成し、Unit 編集画面の Members 枠の上に配置
  - 日付・ラベル・メンバー名・Current バッジ・Edit リンクを表示
  - 「Manage Snapshots」リンクをヘッダーに配置
- `UnitsController#edit` / `#update`（失敗時）に `@unit_snapshots` を追加
  - `includes(snapshot_people: :person)` で N+1 クエリを防止
- `show` アクションを追加し `edit` へリダイレクト（`GET /admin/units/:id` でのエラーを解消）
- `unit_snapshots/index.html.erb` の `snapshot_date.strftime` を `&.strftime` に修正（nil 安全）

## Test plan

- [ ] Unit 編集画面（`/admin/units/:id/edit`）でスナップショット一覧が Members 枠の上に表示されること
- [ ] スナップショットが 0 件の場合「No snapshots yet.」と表示されること
- [ ] Members 列に名前が表示されること
- [ ] Edit リンクからスナップショット編集画面に遷移できること
- [ ] Manage Snapshots リンクからスナップショット管理画面に遷移できること
- [ ] `GET /admin/units/:id` にアクセスすると edit にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)