### PR TITLE
feat: Unit編集画面のMembersにStatusバッジを表示する

### DIFF
--- a/app/views/admin/units/_members_list.html.erb
+++ b/app/views/admin/units/_members_list.html.erb
@@ -14,6 +14,7 @@
           <th scope="col" class="px-3 py-3.5 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Name</th>
           <th scope="col" class="px-3 py-3.5 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Key / Old Key</th>
           <th scope="col" class="px-3 py-3.5 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Part</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Status</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700"
@@ -59,6 +60,21 @@
               <% end %>
             </td>
             <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400"><%= member.part.humanize %></td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm">
+              <%
+                status_styles = {
+                  "active"    => "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+                  "left"      => "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400",
+                  "pending"   => "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+                  "pre"       => "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+                  "concerned" => "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+                  "undefined" => "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400",
+                }
+              %>
+              <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium <%= status_styles[member.status] %>">
+                <%= member.status.humanize %>
+              </span>
+            </td>
             <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
               <%= link_to "Edit", edit_admin_unit_unit_person_path(unit, member), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
             </td>


### PR DESCRIPTION
## Summary

- `_members_list` の Members テーブルに Status 列を追加
- ステータスごとに色分けしたバッジで表示
  - `active`: 緑 / `left`: グレー / `pending`: 黄 / `pre`: 青 / `concerned`: 紫 / `undefined`: グレー

## Test plan

- [ ] Unit 編集画面の Members テーブルに Status 列が表示されること
- [ ] 各ステータスに対応した色のバッジが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)