### PR TITLE
fix: サポートフラグ設定時に part_alias から「サポート」表記を除去する

### DIFF
--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -516,6 +516,7 @@ class WikipageImporterV2 < WikipageImporter
     # パートをパース
     part_enum = parse_part(part_str)
     support = part_str&.include?('サポート') || part_str&.include?('sup') || false
+    cleaned_part_alias = extract_name_from_wiki_link(part_str)&.gsub(/サポート|sup/i, '')&.strip
 
     # SNSをパース（V1と同じArray形式で保存）
     sns_data = sns_account.present? ? [sns_account.strip] : nil
@@ -529,7 +530,7 @@ class WikipageImporterV2 < WikipageImporter
       person_key: person&.key,
       old_person_key: old_member_key,
       part: part_enum,
-      part_alias: extract_name_from_wiki_link(part_str),
+      part_alias: cleaned_part_alias,
       status: member_status,
       support: support,
       sns: sns_data,


### PR DESCRIPTION
## Summary

- `WikipageImporterV2` で part が「サポート◯◯」の場合、`support = true` を設定するが、`part_alias` にも「サポート」が残っていたため画面表示時に重複が発生していた
- `part_alias` 生成時に `/サポート|sup/i` を除去するよう修正し、重複表示を解消

Closes #318

## Test plan

- [ ] サポート表記を含む part（例: 「サポートGt.」「sup Gt.」）でインポートを実行し、`part_alias` から「サポート」が除去されていることを確認
- [ ] 画面表示で「サポート Gt.」のように重複なく表示されることを確認
- [ ] サポートフラグなしの通常パートが影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)