### PR TITLE
fix: 活動時期の取り込み時に日付以外の情報を無視する (#313)

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -545,10 +545,16 @@ class WikipageImporter < BaseWikipageImporter
     @wiki_content.scan(regex) do |match|
       value = match[0].strip
       from, to = value.split(/\s*~\s*/, 2)
-      entries << { 'from' => from&.strip.presence, 'to' => to&.strip.presence }
+      entries << { 'from' => extract_date_only(from), 'to' => extract_date_only(to) }
     end
 
     unit.update!(activity_period: entries) if entries.present?
+  end
+
+  def extract_date_only(value)
+    return nil if value.nil?
+
+    value.gsub(/\(.*?\)/, '').gsub(/（.*?）/, '').strip.presence
   end
 
   def resolve_key_collision(base_key, current_id = nil)

--- a/config/database.yml
+++ b/config/database.yml
@@ -55,6 +55,7 @@ development:
 test:
   <<: *default
   database: vkdby_test
+  gssencmode: disable
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/test/services/wikipage_importer_test.rb
+++ b/test/services/wikipage_importer_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WikipageImporterTest < ActiveSupport::TestCase
+  WikipageStub = Struct.new(:wiki, :name, :title) do
+    def attributes
+      {}
+    end
+  end
+
+  def parse_activity_period(unit, wiki_content)
+    stub = WikipageStub.new(wiki_content, 'テストバンド', 'テストバンド')
+    WikipageImporter.new(stub).send(:parse_activity_period, unit)
+  end
+
+  test '活動時期にwikiリンク形式の会場情報が付加されている場合は日付のみ取り込まれる' do
+    unit = units(:one)
+    wiki = "*活動時期 … 2001/10/14~2007/05/05([[池袋CYBER]])\n"
+    parse_activity_period(unit, wiki)
+    unit.reload
+    assert_equal [{ 'from' => '2001/10/14', 'to' => '2007/05/05' }], unit.activity_period
+  end
+
+  test '活動時期に付加情報がない場合はそのまま取り込まれる' do
+    unit = units(:one)
+    wiki = "*活動時期 … 2001/10/14~2007/05/05\n"
+    parse_activity_period(unit, wiki)
+    unit.reload
+    assert_equal [{ 'from' => '2001/10/14', 'to' => '2007/05/05' }], unit.activity_period
+  end
+
+  test '終了日がない活動時期（活動中バンド）は to が nil になる' do
+    unit = units(:one)
+    wiki = "*活動時期 … 2005/02/15~\n"
+    parse_activity_period(unit, wiki)
+    unit.reload
+    assert_equal [{ 'from' => '2005/02/15', 'to' => nil }], unit.activity_period
+  end
+
+  test 'ワイルドカードの開始日も取り込まれる' do
+    unit = units(:one)
+    wiki = "*活動時期 … 2001/05/**~2004/10/30\n"
+    parse_activity_period(unit, wiki)
+    unit.reload
+    assert_equal [{ 'from' => '2001/05/**', 'to' => '2004/10/30' }], unit.activity_period
+  end
+
+  test '終了日に活動中が含まれる場合もそのまま取り込まれる' do
+    unit = units(:one)
+    wiki = "*活動時期 … 1998/08/25~活動中\n"
+    parse_activity_period(unit, wiki)
+    unit.reload
+    assert_equal [{ 'from' => '1998/08/25', 'to' => '活動中' }], unit.activity_period
+  end
+end


### PR DESCRIPTION
## Summary

- `parse_activity_period` に `extract_date_only` メソッドを追加し、活動時期の日付に付加されている括弧内の情報（解散ライブの会場名等）を除去するよう修正
  - 例: `2007/05/05([[池袋CYBER]])` → `2007/05/05`
  - 半角括弧 `(...)` と全角括弧 `（...）` の両方に対応
- `test/services/wikipage_importer_test.rb` を新規作成し、各パターン（付加情報あり・なし、活動中バンド、ワイルドカード日付等）を検証
- `config/database.yml` の test 設定に `gssencmode: disable` を追加し、並列テスト実行時の libpq/Kerberos クラッシュを回避

## Test plan

- [ ] `bundle exec rails test test/services/wikipage_importer_test.rb` が 5 tests 全て通ること
- [ ] `bundle exec rails test` が全 66 tests 通ること（クラッシュなし）

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)