### PR TITLE
fix: Unit一覧のインクリメンタルサジェストがスクロール時に消えてしまう問題を修正 (#321)

### DIFF
--- a/app/javascript/controllers/search_suggest_controller.js
+++ b/app/javascript/controllers/search_suggest_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
     this.activeIndex = -1
     this.handleClickOutside = this.handleClickOutside.bind(this)
     this.handleReposition = this.reposition.bind(this)
-    this.handleScroll = this.hideSuggestions.bind(this)
+    this.handleScroll = this._onScroll.bind(this)
     document.addEventListener('click', this.handleClickOutside)
     window.addEventListener('resize', this.handleReposition)
     window.addEventListener('scroll', this.handleScroll, true)
@@ -22,6 +22,11 @@ export default class extends Controller {
     window.removeEventListener('resize', this.handleReposition)
     window.removeEventListener('scroll', this.handleScroll, true)
     clearTimeout(this.timeout)
+  }
+
+  _onScroll(event) {
+    if (this.suggestionsTarget.contains(event.target)) return
+    this.hideSuggestions()
   }
 
   handleClickOutside(event) {


### PR DESCRIPTION
## Summary

- `search_suggest_controller.js` の `handleScroll` で、suggestions コンテナ内部のスクロールイベントを無視するよう修正
- ↓キー長押し時に `scrollIntoView()` が発火する scroll イベントや、suggestions 内のスクロール操作で候補が消えてしまう問題を解消

## 原因

`window.addEventListener('scroll', this.handleScroll, true)` でキャプチャモードの全スクロールを監視しており、`handleScroll` が直接 `hideSuggestions()` を呼んでいた。そのため、↓キー長押しによる `scrollIntoView()` や suggestions コンテナ内のスクロールでも候補が非表示になっていた。

## 修正内容

`_onScroll` メソッドを追加し、イベントの発生元が suggestions コンテナ内であれば処理をスキップするよう変更した。

```javascript
_onScroll(event) {
  if (this.suggestionsTarget.contains(event.target)) return
  this.hideSuggestions()
}
```

## Test plan

- [ ] Unit一覧ページでキーワードを入力してサジェストを表示させる
- [ ] ↓キーを長押ししてもサジェストが消えずに選択できることを確認
- [ ] サジェストをマウスでスクロールしても消えないことを確認
- [ ] サジェスト外をクリックすると閉じることを確認
- [ ] ページ本体をスクロールするとサジェストが閉じることを確認

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)