### PR TITLE
feat: /NEWS_{id} レガシーURLの301リダイレクトを実装

### DIFF
--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -33,4 +33,13 @@ class LegacyRedirectsController < ApplicationController
 
     render 'not_found', status: :not_found, layout: false
   end
+
+  def news_redirect
+    trend = Trend.find_by(id: params[:id])
+    if trend
+      redirect_to trend_url(trend), status: :moved_permanently
+    else
+      render 'not_found', status: :not_found, layout: false
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,5 +118,8 @@ Rails.application.routes.draw do
   # Legacy redirects for .html extensions
   get '/:old_key.html', to: 'legacy_redirects#show', constraints: { old_key: %r{[^/]+} }
 
+  # Legacy redirects for /NEWS_{id} format
+  get '/NEWS_:id', to: 'legacy_redirects#news_redirect', constraints: { id: /\d+/ }
+
   get '/:key', to: 'profiles#show', as: :profile, constraints: { key: %r{[^/]+} }
 end


### PR DESCRIPTION
## Summary

- `GET /NEWS_:id` ルートを追加（数値IDのみマッチ）
- `LegacyRedirectsController#news_redirect` アクションを追加
  - Trend が見つかれば `/trends/:id` へ 301 リダイレクト
  - 見つからなければ 404

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)