### PR TITLE
feat: key=footerのカスタムページをグローバルフッターとして表示

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -43,18 +43,20 @@
     img { max-width: 100%; height: auto; border-radius: 0.5em; margin: 0.5em 0; }
   }
 
-  .dark .markdown-content {
-    color: #cbd5e1;
-    h1, h2, h3, h4, h5 { color: #f1f5f9; }
-    h2 { border-bottom-color: #334155; }
-    h6 { color: #94a3b8; }
-    strong { color: #f1f5f9; }
-    code { background-color: #1e293b; color: #e2e8f0; }
-    blockquote { border-left-color: #6366f1; color: #94a3b8; background-color: #1e293b; }
-    hr { border-top-color: #334155; }
-    th { background-color: #1e293b; border-color: #334155; color: #94a3b8; }
-    td { border-color: #334155; }
-    tr:nth-child(even) td { background-color: #1e293b; }
+  @variant dark {
+    .markdown-content {
+      color: #cbd5e1;
+      h1, h2, h3, h4, h5 { color: #f1f5f9; }
+      h2 { border-bottom-color: #334155; }
+      h6 { color: #94a3b8; }
+      strong { color: #f1f5f9; }
+      code { background-color: #1e293b; color: #e2e8f0; }
+      blockquote { border-left-color: #6366f1; color: #94a3b8; background-color: #1e293b; }
+      hr { border-top-color: #334155; }
+      th { background-color: #1e293b; border-color: #334155; color: #94a3b8; }
+      td { border-color: #334155; }
+      tr:nth-child(even) td { background-color: #1e293b; }
+    }
   }
 
   .history-row::before {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,13 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Method
 
+  before_action :load_footer_page
+
   private
+
+  def load_footer_page
+    @footer_page = CustomPage.published.find_by(key: 'footer')
+  end
 
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -313,5 +313,14 @@
     <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
       <%= yield %>
     </main>
+    <% if @footer_page %>
+      <footer class="border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 mt-8">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div class="markdown-content text-sm">
+            <%= markdown(@footer_page.body) %>
+          </div>
+        </div>
+      </footer>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- `key = 'footer'` かつ公開中のカスタムページが存在する場合、全ページのフッターにMarkdownレンダリングして表示
- `ApplicationController` に `before_action :load_footer_page` を追加
- `application.html.erb` に `<footer>` タグを追加
- `markdown-content` のダークモードCSSを `.dark` クラスセレクターから `@variant dark` に修正（Tailwind v4のメディアクエリ方式に対応）

## Test plan

- [ ] `key: 'footer'`、`active: true` のカスタムページを作成すると全ページのフッターに表示されること
- [ ] `active: false`（下書き）の場合はフッターが表示されないこと
- [ ] ダークモードでmarkdownコンテンツのテキストが正しく明るい色で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)