### PR TITLE
fix: kaminari の page メソッドを pagy に差し替え (close #340)

### DIFF
--- a/app/controllers/admin/external_sites_controller.rb
+++ b/app/controllers/admin/external_sites_controller.rb
@@ -5,7 +5,7 @@ module Admin
     before_action :set_external_site, only: %i[edit update destroy]
 
     def index
-      @external_sites = ExternalSite.order(:site_key).page(params[:page])
+      @pagy, @external_sites = pagy(ExternalSite.order(:site_key))
     end
 
     def new

--- a/app/views/admin/external_sites/index.html.erb
+++ b/app/views/admin/external_sites/index.html.erb
@@ -41,5 +41,5 @@
 </div>
 
 <div class="mt-4">
-  <%= paginate @external_sites %>
+  <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
 </div>


### PR DESCRIPTION
## Summary

- `ExternalSitesController#index` で kaminari の `.page()` を呼んでいたため `NoMethodError` が発生していた
- アプリは `pagy` を採用しているため、コントローラーおよびビューのページネーション処理を `pagy` に統一

## Test plan

- [ ] `/admin/external_sites` にアクセスしてエラーが解消されていることを確認
- [ ] ページネーションが正常に表示・動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)