### PR TITLE
fix: 活動時期のバックスラッシュエスケープを除去する (close #282)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 ## ブランチ運用
 - 修正・機能開発のベースブランチは原則として `develop`
+- ブランチ名は `feat/issue-{番号}-{内容}` の形式にする（例: `feat/issue-282-backslash-in-activity-period`）
+- `/release-pr` スキルはリリース専用。機能修正・バグ修正には使わない
 
 ## コマンド実行
 - Rails コマンドは必ず `bundle exec` をつける（例: `bundle exec rails db:migrate`）

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -554,7 +554,7 @@ class WikipageImporter < BaseWikipageImporter
   def extract_date_only(value)
     return nil if value.nil?
 
-    value.gsub(/\(.*?\)/, '').gsub(/（.*?）/, '').strip.presence
+    value.gsub(/\(.*?\)/, '').gsub(/（.*?）/, '').gsub(/\\/, '').strip.presence
   end
 
   def resolve_key_collision(base_key, current_id = nil)

--- a/test/services/wikipage_importer_test.rb
+++ b/test/services/wikipage_importer_test.rb
@@ -53,4 +53,12 @@ class WikipageImporterTest < ActiveSupport::TestCase
     unit.reload
     assert_equal [{ 'from' => '1998/08/25', 'to' => '活動中' }], unit.activity_period
   end
+
+  test 'バックスラッシュエスケープされた区切り文字（\~）が含まれる場合はバックスラッシュを除去する' do
+    unit = units(:one)
+    wiki = "*活動時期 … 2003/07/01\\~2009/12/31\n"
+    parse_activity_period(unit, wiki)
+    unit.reload
+    assert_equal [{ 'from' => '2003/07/01', 'to' => '2009/12/31' }], unit.activity_period
+  end
 end


### PR DESCRIPTION
## 概要

wiki の活動時期データに `\~` のようなバックスラッシュエスケープが含まれる場合、`~` で split した際に `from` にバックスラッシュが残ってしまう問題を修正。

## 原因

`extract_date_only` がバックスラッシュを除去していなかった。

例: `2003/07/01\~2009/12/31` → split 後 `from = "2003/07/01\"` となっていた。

## 修正内容

- `extract_date_only` に `.gsub(/\\/, '')` を追加してバックスラッシュを除去
- `\~` パターンのテストケースを追加

## テスト

```
6 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```