### PR TITLE
feat: update_logs テーブルと記録機能を追加する (close #324)

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -18,5 +18,21 @@ module Admin
 
       redirect_to admin_root_path, alert: '権限がありません'
     end
+
+    def record_update_log(record, action:)
+      diff = case action
+             when 'create'
+               record.saved_changes.except('created_at', 'updated_at')
+             when 'update'
+               record.saved_changes.except('updated_at')
+             end
+
+      UpdateLog.create!(
+        user: current_user,
+        action: action,
+        loggable: record,
+        diff: diff
+      )
+    end
   end
 end

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -39,6 +39,7 @@ module Admin
       @person = Person.new(person_params)
 
       if @person.save
+        record_update_log(@person, action: 'create')
         redirect_to admin_people_path, notice: 'Person created successfully.'
       else
         render :new, status: :unprocessable_entity
@@ -47,6 +48,7 @@ module Admin
 
     def update
       if @person.update(person_params)
+        record_update_log(@person, action: 'update')
         redirect_to admin_people_path, notice: 'Person updated successfully.'
       else
         render :edit, status: :unprocessable_entity
@@ -55,11 +57,13 @@ module Admin
 
     def destroy
       @person.discard
+      record_update_log(@person, action: 'discard')
       redirect_to admin_people_path, notice: 'Person deleted successfully.'
     end
 
     def undiscard
       @person.undiscard
+      record_update_log(@person, action: 'undiscard')
       redirect_to admin_people_path, notice: 'Person restored successfully.'
     end
 

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -44,6 +44,7 @@ module Admin
       @unit = Unit.new(unit_params)
 
       if @unit.save
+        record_update_log(@unit, action: 'create')
         redirect_to admin_units_path, notice: 'Unit created successfully.'
       else
         @unit.links.build if @unit.links.none?(&:new_record?)
@@ -53,6 +54,7 @@ module Admin
 
     def update
       if @unit.update(unit_params)
+        record_update_log(@unit, action: 'update')
         redirect_to edit_admin_unit_path(@unit), notice: 'Unit updated successfully.'
       else
         @unit_logs = @unit.unit_logs.order(:log_date)
@@ -67,11 +69,13 @@ module Admin
 
     def destroy
       @unit.discard
+      record_update_log(@unit, action: 'discard')
       redirect_to admin_units_path, notice: 'Unit deleted successfully.'
     end
 
     def undiscard
       @unit.undiscard
+      record_update_log(@unit, action: 'undiscard')
       redirect_to admin_units_path, notice: 'Unit restored successfully.'
     end
 

--- a/app/models/update_log.rb
+++ b/app/models/update_log.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :loggable, polymorphic: true, optional: true
+
+  validates :action, inclusion: { in: %w[create update discard undiscard] }
+end

--- a/db/migrate/20260228143955_create_update_logs.rb
+++ b/db/migrate/20260228143955_create_update_logs.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateUpdateLogs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :update_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :action, null: false
+      t.string :loggable_type, null: false
+      t.bigint :loggable_id, null: false
+      t.jsonb :diff
+
+      t.datetime :created_at, null: false
+    end
+
+    add_index :update_logs, %i[loggable_type loggable_id]
+    add_index :update_logs, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_28_015352) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_28_143955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -322,6 +322,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_28_015352) do
     t.index ["old_key"], name: "index_units_on_old_key", unique: true
   end
 
+  create_table "update_logs", force: :cascade do |t|
+    t.string "action", null: false
+    t.datetime "created_at", null: false
+    t.jsonb "diff"
+    t.bigint "loggable_id", null: false
+    t.string "loggable_type", null: false
+    t.bigint "user_id", null: false
+    t.index ["created_at"], name: "index_update_logs_on_created_at"
+    t.index ["loggable_type", "loggable_id"], name: "index_update_logs_on_loggable_type_and_loggable_id"
+    t.index ["user_id"], name: "index_update_logs_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
@@ -359,4 +371,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_28_015352) do
   add_foreign_key "unit_people", "people"
   add_foreign_key "unit_people", "units"
   add_foreign_key "unit_snapshots", "units"
+  add_foreign_key "update_logs", "users"
 end


### PR DESCRIPTION
## 概要

- `update_logs` テーブルを新規作成し、`people` / `units` の admin 操作を記録する
- 親 issue: #226

## 変更内容

- マイグレーション: `update_logs` テーブル作成（`user_id`, `action`, `loggable_type`, `loggable_id`, `diff`, `created_at`）
- `UpdateLog` モデル追加（polymorphic 関連、action バリデーション）
- `Admin::BaseController` に `record_update_log` メソッドを追加
- `PeopleController` / `UnitsController` の `create`, `update`, `discard`, `undiscard` 各アクションで呼び出し

## テスト

- [ ] 全テスト通過確認済み（67 runs, 0 failures）