### PR TITLE
feat: people / units edit 画面に更新履歴セクションを追加する (close #325)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -33,6 +33,10 @@ module Admin
     def edit
       @person_logs = @person.person_logs.order(:log_date)
       @person.links.build # Always add an empty link field for new entries
+      @update_logs = UpdateLog.where(loggable_type: 'Person', loggable_id: @person.id)
+                              .includes(:user)
+                              .order(created_at: :desc)
+                              .limit(50)
     end
 
     def create

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -38,6 +38,10 @@ module Admin
       @unit_person = @unit.unit_people.build(period: 1, order_in_period: (@unit_people.last&.order_in_period || 0) + 1)
       @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(snapshot_date: :desc)
       @unit.links.build # Build an empty link for the form
+      @update_logs = UpdateLog.where(loggable_type: 'Unit', loggable_id: @unit.id)
+                              .includes(:user)
+                              .order(created_at: :desc)
+                              .limit(50)
     end
 
     def create

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -28,4 +28,6 @@
     </div>
     <%= render "admin/person_logs/list", person: @person, person_logs: @person_logs %>
   </div>
+
+  <%= render "admin/shared/update_logs", update_logs: @update_logs %>
 </div>

--- a/app/views/admin/shared/_update_logs.html.erb
+++ b/app/views/admin/shared/_update_logs.html.erb
@@ -1,0 +1,60 @@
+<div class="mt-6">
+  <h2 class="text-xl font-bold dark:text-white mb-4">更新履歴</h2>
+  <% if update_logs.any? %>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">日時</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">操作者</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">操作</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">変更内容</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+          <% update_logs.each do |log| %>
+            <tr>
+              <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                <%= log.created_at.strftime('%Y-%m-%d %H:%M') %>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap">
+                <%= log.user.name %>
+              </td>
+              <td class="px-4 py-3 text-sm whitespace-nowrap">
+                <% label, color = case log.action
+                                  when 'create'    then ['作成', 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200']
+                                  when 'update'    then ['更新', 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200']
+                                  when 'discard'   then ['削除', 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200']
+                                  when 'undiscard' then ['復元', 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200']
+                                  end %>
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium <%= color %>">
+                  <%= label %>
+                </span>
+              </td>
+              <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+                <% if log.diff.present? %>
+                  <dl class="space-y-1">
+                    <% log.diff.each do |field, (before, after)| %>
+                      <div>
+                        <dt class="inline font-medium text-gray-500 dark:text-gray-400"><%= field %>:</dt>
+                        <dd class="inline">
+                          <span class="line-through text-red-600 dark:text-red-400"><%= before.presence || '(空)' %></span>
+                          →
+                          <span class="text-green-600 dark:text-green-400"><%= after.presence || '(空)' %></span>
+                        </dd>
+                      </div>
+                    <% end %>
+                  </dl>
+                <% else %>
+                  <span class="text-gray-400">-</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-gray-500 dark:text-gray-400 text-sm">更新履歴はありません。</p>
+  <% end %>
+</div>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -28,4 +28,6 @@
     </div>
     <%= render "admin/unit_logs/list", unit: @unit, unit_logs: @unit_logs %>
   </div>
+
+  <%= render "admin/shared/update_logs", update_logs: @update_logs %>
 </div>


### PR DESCRIPTION
## 概要

people / units の edit 画面に「更新履歴」セクションを追加し、誰がいつ何を変更したかを閲覧できるようにする。

親 issue: #226

## 変更内容

- `PeopleController#edit` / `UnitsController#edit` に `@update_logs` の取得を追加（最新 50 件）
- `app/views/admin/shared/_update_logs.html.erb` を新規作成
  - 日時・操作者・操作種別（作成/更新/削除/復元）・変更内容（diff の前後比較）を表示
  - diff が null（discard/undiscard）の場合は `-` を表示
- `people/edit.html.erb` / `units/edit.html.erb` に更新履歴セクションを追加

## テスト

- [ ] 全テスト通過確認済み（67 runs, 0 failures）