### PR TITLE
feat: Renderへのデータ転送スクリプトと手順を追加する (close #348)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 /*.sql
 
 /.idea/*
+.envrc

--- a/docs/import/render_transfer.md
+++ b/docs/import/render_transfer.md
@@ -1,0 +1,44 @@
+# Renderへのデータ転送
+
+ローカルの開発DBデータをRenderの本番DBに転送する手順です。
+
+## 事前準備（初回のみ）
+
+### 1. direnv のインストール
+
+```bash
+brew install direnv
+```
+
+`~/.zshrc` に hook を追加します。
+
+```bash
+echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### 2. .envrc の設定
+
+リポジトリルートに `.envrc` を作成し、Renderの接続URLを設定します（`.envrc` はリポジトリに含まれません）。
+
+```sh
+export DB_CONNECTION=postgresql://<user>:<password>@<host>/<dbname>
+```
+
+接続URLはRenderのダッシュボード（Database > Connection String）から確認できます。
+
+### 3. direnv に .envrc を許可する
+
+```bash
+direnv allow .
+```
+
+## データ転送
+
+```bash
+./script/transfer_to_render.sh
+```
+
+実行すると確認プロンプトが表示されます。`y` を入力すると転送が開始されます。
+
+転送対象テーブル: `units`, `unit_people`, `people`, `trends`, `items`, `sections`, `links`, `index_groups`, `tag_index_items`, `tag_indices`, `snapshot_people`, `unit_snapshots`, `users`

--- a/script/transfer_to_render.sh
+++ b/script/transfer_to_render.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# ローカルの開発DBデータをRenderの本番DBに転送するスクリプト
+# 事前に .envrc の DB_CONNECTION が設定されていること（direnv 等で読み込む）
+
+set -e
+
+if [ -z "$DB_CONNECTION" ]; then
+  echo "エラー: DB_CONNECTION が設定されていません"
+  echo "  .envrc に export DB_CONNECTION=... を設定し、direnv allow を実行してください"
+  exit 1
+fi
+
+TABLES="units unit_people people trends items sections links index_groups tag_index_items tag_indices snapshot_people unit_snapshots users"
+DB_NAME="vkdby_development"
+
+TRUNCATE_SQL="TRUNCATE ${TABLES// /, } RESTART IDENTITY CASCADE;"
+
+PG_DUMP_OPTS=""
+for t in $TABLES; do
+  PG_DUMP_OPTS="$PG_DUMP_OPTS -t $t"
+done
+
+echo "=== Renderへのデータ転送を開始します ==="
+echo "転送対象テーブル: $TABLES"
+echo ""
+echo "警告: Renderの本番DBのデータが上書きされます。続行しますか？ [y/N]"
+read -r answer
+if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+  echo "中止しました"
+  exit 0
+fi
+
+echo "--- データ転送中 ---"
+(echo "$TRUNCATE_SQL" && pg_dump $PG_DUMP_OPTS -a "$DB_NAME") | psql "$DB_CONNECTION"
+
+echo ""
+echo "=== 転送完了 ==="


### PR DESCRIPTION
## Summary

- `script/transfer_to_render.sh`: pg_dump + psql でローカルDBをRenderに転送するスクリプト
- `docs/import/render_transfer.md`: direnv セットアップから転送実行までの手順ドキュメント
- `.gitignore` に `.envrc` を追加（本番DB認証情報の誤コミット防止）

## Test plan

- [ ] `direnv allow .` 後に `DB_CONNECTION` が環境変数として読み込まれることを確認
- [ ] `./script/transfer_to_render.sh` を実行し、確認プロンプトが表示されることを確認
- [ ] `DB_CONNECTION` 未設定時にエラーメッセージが出て終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)