### PR TITLE
fix: カスタムページ管理の操作ボタンを列分けして位置を揃える

### DIFF
--- a/app/views/admin/custom_pages/index.html.erb
+++ b/app/views/admin/custom_pages/index.html.erb
@@ -32,7 +32,8 @@
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">タイトル</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">状態</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
-          <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">操作</th>
+          <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">編集</th>
+          <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">削除</th>
         </tr>
       </thead>
       <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
@@ -60,7 +61,7 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
               <%= page.updated_at.strftime('%Y/%m/%d %H:%M') %>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-3">
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
               <% if page.discarded? %>
                 <% if current_user.super_operator_or_above? %>
                   <%= link_to "復元", undiscard_admin_custom_page_path(page),
@@ -70,18 +71,20 @@
               <% else %>
                 <%= link_to "編集", edit_admin_custom_page_path(page),
                     class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-                <% if current_user.super_operator_or_above? && !page.protected? %>
-                  <%= link_to "削除", admin_custom_page_path(page),
-                      data: { turbo_method: :delete, turbo_confirm: "「#{page.title}」を削除しますか？" },
-                      class: "text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300" %>
-                <% end %>
+              <% end %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+              <% if !page.discarded? && current_user.super_operator_or_above? && !page.protected? %>
+                <%= link_to "削除", admin_custom_page_path(page),
+                    data: { turbo_method: :delete, turbo_confirm: "「#{page.title}」を削除しますか？" },
+                    class: "text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300" %>
               <% end %>
             </td>
           </tr>
         <% end %>
         <% if @custom_pages.empty? %>
           <tr>
-            <td colspan="5" class="px-6 py-8 text-center text-gray-500 dark:text-gray-400">ページがありません</td>
+            <td colspan="6" class="px-6 py-8 text-center text-gray-500 dark:text-gray-400">ページがありません</td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
## Summary

- 「操作」列を「編集」「削除」の2列に分割
- これにより削除ボタンがないprotectedなページでも「編集」ボタンの位置が揃う

## Test plan

- [ ] カスタムページ管理画面で「編集」ボタンの位置がすべての行で揃っていることを確認
- [ ] protectedなページ（index等）に「削除」列が空であることを確認
- [ ] 削除可能なページに「削除」ボタンが表示されることを確認
- [ ] 削除済みページで「復元」ボタンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)