### PR TITLE
feat: Itemの画像をAmazonへのリンクにする (close #361)

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -2,7 +2,13 @@
   <!-- 画像（左側） -->
   <% if @item.image_url.present? %>
     <div class="shrink-0 w-40 h-40 flex items-center justify-center bg-slate-50 dark:bg-slate-900">
-      <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-40 h-40 object-cover">
+      <% if @item.link_url.present? %>
+        <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer" do %>
+          <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-40 h-40 object-cover hover:opacity-90 transition-opacity">
+        <% end %>
+      <% else %>
+        <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-40 h-40 object-cover">
+      <% end %>
     </div>
   <% else %>
     <div class="shrink-0 w-40 h-40 bg-slate-100 dark:bg-slate-700 flex items-center justify-center">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -12,7 +12,14 @@
         <!-- 画像（左） -->
         <% if @item.image_url.present? %>
           <div class="shrink-0">
-            <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-52 h-52 object-cover shadow-md">
+            <% amazon_url = safe_url(@item.link_url) %>
+            <% if amazon_url %>
+              <%= link_to amazon_url, target: "_blank", rel: "noopener noreferrer" do %>
+                <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-52 h-52 object-cover shadow-md hover:opacity-90 transition-opacity">
+              <% end %>
+            <% else %>
+              <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-52 h-52 object-cover shadow-md">
+            <% end %>
           </div>
         <% end %>
 


### PR DESCRIPTION
## Summary

- `items#show` の商品画像を、`link_url` が存在する場合にAmazonへのリンクで包むよう変更
- `ItemCardComponent` の商品画像も同様に変更
- リンクなしの場合は従来通り画像のみ表示

## Test plan

- [ ] link_url がある商品の画像をクリックするとAmazonページが新タブで開くことを確認
- [ ] link_url がない商品の画像が正常に表示されることを確認（items#show、ItemCard両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)