### PR TITLE
fix: アーティスト名のURLエンコード修正（ASCII文字のスペースを+に変換）

### DIFF
--- a/app/services/item_converter.rb
+++ b/app/services/item_converter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 # ReleaseSchedule を Item に変換するサービス
 # rubocop:disable Metrics/ClassLength
 class ItemConverter
@@ -130,12 +132,12 @@ class ItemConverter
   end
 
   # EUC-JP エンコード処理
-  # ASCII 文字はそのまま、非 ASCII 文字のみ EUC-JP でエンコード
+  # ASCII 文字は CGI.escape で URL エンコード（スペース→+）、非 ASCII 文字は EUC-JP でエンコード
   def encode_euc_jp(text)
     return '' if text.blank?
 
-    # ASCII のみの場合はそのまま返す
-    return text if text.ascii_only?
+    # ASCII のみの場合は CGI.escape でエンコード（Unit の old_key 形式に合わせる）
+    return CGI.escape(text) if text.ascii_only?
 
     # 非 ASCII 文字を含む場合は EUC-JP でエンコード
     text.encode('EUC-JP', invalid: :replace, undef: :replace)

--- a/test/services/item_converter_test.rb
+++ b/test/services/item_converter_test.rb
@@ -44,4 +44,30 @@ class ItemConverterTest < ActiveSupport::TestCase
     assert_equal '名前B', result[1]['name']
     assert_nil result[1]['alias']
   end
+
+  # encode_euc_jp のテスト
+  def encode_euc_jp(text)
+    ItemConverter.new(nil).send(:encode_euc_jp, text)
+  end
+
+  test 'ASCII のみのテキストは CGI.escape でエンコードされる' do
+    assert_equal 'Dir+en+grey', encode_euc_jp('Dir en grey')
+    assert_equal 'Plastic+Tree', encode_euc_jp('Plastic Tree')
+    assert_equal 'the+GazettE', encode_euc_jp('the GazettE')
+  end
+
+  test 'スペースのない ASCII テキストはそのまま返る' do
+    assert_equal 'lynch.', encode_euc_jp('lynch.')
+    assert_equal 'MUCC', encode_euc_jp('MUCC')
+  end
+
+  test '日本語テキストは EUC-JP でエンコードされる' do
+    # ディルアングレイ (EUC-JP) = %A5%C7%A5%A3%A5%EB%A5%A2%A5%F3%A5%B0%A5%EC%A5%A4
+    assert_equal '%A5%C7%A5%A3%A5%EB%A5%A2%A5%F3%A5%B0%A5%EC%A5%A4', encode_euc_jp('ディルアングレイ')
+  end
+
+  test '空文字は空文字を返す' do
+    assert_equal '', encode_euc_jp('')
+    assert_equal '', encode_euc_jp(nil)
+  end
 end


### PR DESCRIPTION
## Summary
- `ItemConverter#encode_euc_jp` でASCII文字をそのまま返していたのを `CGI.escape` でエンコードするよう修正
- これにより `"Dir en grey"` → `"Dir+en+grey"` となり、Unit の `old_key` と一致してリンクが機能するようになる
- 影響範囲: Dir en grey 以外にも Plastic Tree, LUNA SEA, the GazettE 等スペースを含む全ASCII帯アーティスト

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `encode_euc_jp` の新規テスト（9件）がパスすること
- [ ] インポートしなおした後、商品ページのアーティストリンクが正しく遷移できること

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)