### PR TITLE
fix: アーティスト作品一覧ページの年月リンクにkeyパラメータを追加 (close #369)

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -25,7 +25,7 @@
           years_by_decade = @years.group_by { |y| (y / 10) * 10 }
         %>
 
-        <%= link_to "NEWEST", items_path(old_key: params[:old_key]), class: "#{base_classes} #{current_year.nil? ? active_classes : inactive_classes}" %>
+        <%= link_to "NEWEST", items_path(key: params[:key], old_key: params[:old_key]), class: "#{base_classes} #{current_year.nil? ? active_classes : inactive_classes}" %>
 
         <% years_by_decade.each do |decade, years| %>
           <% is_active_decade = years.include?(current_year) %>
@@ -53,7 +53,7 @@
                  data-transition-leave-start="transform opacity-100 scale-100"
                  data-transition-leave-end="transform opacity-0 scale-95">
               <% years.each do |year| %>
-                <%= link_to "#{year} <span class='text-xs opacity-50 ml-1 font-normal'>(#{@year_counts[year]})</span>".html_safe, items_path(year: year, old_key: params[:old_key]), class: "block px-4 py-2 text-sm whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white #{current_year == year ? 'bg-indigo-50 dark:bg-slate-700 font-bold text-indigo-700 dark:text-indigo-300' : ''}" %>
+                <%= link_to "#{year} <span class='text-xs opacity-50 ml-1 font-normal'>(#{@year_counts[year]})</span>".html_safe, items_path(year: year, key: params[:key], old_key: params[:old_key]), class: "block px-4 py-2 text-sm whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white #{current_year == year ? 'bg-indigo-50 dark:bg-slate-700 font-bold text-indigo-700 dark:text-indigo-300' : ''}" %>
               <% end %>
             </div>
           </div>
@@ -70,10 +70,10 @@
               current_month = params[:month].presence&.to_i
             %>
 
-            <%= link_to params[:year], items_path(year: params[:year], old_key: params[:old_key]), class: "#{month_base_classes} #{current_month.nil? ? month_active_classes : month_inactive_classes}" %>
+            <%= link_to params[:year], items_path(year: params[:year], key: params[:key], old_key: params[:old_key]), class: "#{month_base_classes} #{current_month.nil? ? month_active_classes : month_inactive_classes}" %>
 
             <% @months.each do |month| %>
-                <%= link_to "#{month} <span class='opacity-60 ml-0.5 font-normal'>(#{@month_counts[month]})</span>".html_safe, items_path(year: params[:year], month: month, old_key: params[:old_key]), class: "#{month_base_classes} #{current_month == month ? month_active_classes : month_inactive_classes}" %>
+                <%= link_to "#{month} <span class='opacity-60 ml-0.5 font-normal'>(#{@month_counts[month]})</span>".html_safe, items_path(year: params[:year], month: month, key: params[:key], old_key: params[:old_key]), class: "#{month_base_classes} #{current_month == month ? month_active_classes : month_inactive_classes}" %>
             <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
## Summary

- アーティスト作品一覧ページ（`/items?key=...`）から年月絞り込みを行うとアーティスト条件が外れてしまう問題を修正

## 原因

`app/views/items/index.html.erb` の年月リンク生成で `old_key` パラメータは引き継いでいたが、`key` パラメータが漏れていた。

## 修正内容

以下4箇所の `items_path(...)` に `key: params[:key]` を追加：
- NEWESTリンク（28行目）
- 年リンク（56行目）
- 年表示リンク（73行目）
- 月リンク（76行目）

## Test plan

- [ ] `/items?key={アーティストkey}` でアーティスト作品一覧を表示
- [ ] 年（decade）ドロップダウンから年を選択 → アーティスト条件が維持されること
- [ ] 月リンクをクリック → アーティスト条件が維持されること
- [ ] NEWESTリンクをクリック → アーティスト条件が維持されること
- [ ] `old_key` パラメータ利用時も同様に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)