### PR TITLE
style: デザインをスタイリッシュに刷新 (#371)

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -4,59 +4,60 @@
 @source "../../components";
 
 @theme {
-  --color-unit: #6366f1;
-  --color-person: #ec4899;
+  --color-unit: #2563eb;
+  --color-person: #e11d48;
+  --color-brand: #f59e0b;
 }
 
 @layer base {
   body {
-    @apply bg-linear-to-br from-slate-50 to-slate-200 dark:from-slate-900 dark:to-slate-800 text-slate-900 dark:text-slate-100 min-h-screen antialiased font-sans;
+    @apply bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 min-h-screen antialiased font-sans;
   }
 }
 
 @layer components {
   .markdown-content {
-    color: #334155;
+    color: #3f3f46;
     line-height: 1.75;
-    h1 { font-size: 2em; font-weight: 700; margin: 0.5em 0; line-height: 1.25; color: #0f172a; }
-    h2 { font-size: 1.5em; font-weight: 700; margin: 1.25em 0 0.5em; line-height: 1.3; color: #0f172a; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.3em; }
-    h3 { font-size: 1.25em; font-weight: 600; margin: 1em 0 0.4em; line-height: 1.35; color: #1e293b; }
-    h4, h5 { font-size: 1.05em; font-weight: 600; margin: 0.8em 0 0.3em; color: #1e293b; }
-    h6 { font-size: 0.875em; font-weight: 600; margin: 0.8em 0 0.3em; color: #64748b; }
+    h1 { font-size: 2em; font-weight: 900; margin: 0.5em 0; line-height: 1.25; color: #09090b; letter-spacing: -0.02em; }
+    h2 { font-size: 1.5em; font-weight: 700; margin: 1.25em 0 0.5em; line-height: 1.3; color: #09090b; border-bottom: 1px solid #e4e4e7; padding-bottom: 0.3em; }
+    h3 { font-size: 1.25em; font-weight: 600; margin: 1em 0 0.4em; line-height: 1.35; color: #18181b; }
+    h4, h5 { font-size: 1.05em; font-weight: 600; margin: 0.8em 0 0.3em; color: #18181b; }
+    h6 { font-size: 0.875em; font-weight: 600; margin: 0.8em 0 0.3em; color: #71717a; }
     p { margin: 0.875em 0; }
     ul { list-style-type: disc; padding-left: 1.75em; margin: 0.75em 0; }
     ol { list-style-type: decimal; padding-left: 1.75em; margin: 0.75em 0; }
     li { margin: 0.25em 0; }
     li > ul, li > ol { margin: 0.25em 0; }
-    a { color: #6366f1; text-decoration: underline; }
-    a:hover { color: #4f46e5; }
-    strong { font-weight: 700; color: #1e293b; }
+    a { color: #d97706; text-decoration: underline; }
+    a:hover { color: #b45309; }
+    strong { font-weight: 700; color: #18181b; }
     em { font-style: italic; }
-    code { font-family: ui-monospace, monospace; font-size: 0.875em; background-color: #f1f5f9; color: #0f172a; padding: 0.1em 0.35em; border-radius: 0.25em; }
-    pre { background-color: #0f172a; color: #e2e8f0; padding: 1em 1.25em; border-radius: 0.75em; overflow-x: auto; margin: 1em 0; }
+    code { font-family: ui-monospace, monospace; font-size: 0.875em; background-color: #f4f4f5; color: #09090b; padding: 0.1em 0.35em; border-radius: 0.25em; }
+    pre { background-color: #09090b; color: #e4e4e7; padding: 1em 1.25em; border-radius: 0.375em; overflow-x: auto; margin: 1em 0; }
     pre code { background: none; padding: 0; color: inherit; font-size: 0.875em; }
-    blockquote { border-left: 4px solid #6366f1; padding: 0.5em 1em; margin: 1em 0; color: #475569; background-color: #f8fafc; border-radius: 0 0.5em 0.5em 0; font-style: italic; }
-    hr { border: none; border-top: 1px solid #e2e8f0; margin: 1.5em 0; }
+    blockquote { border-left: 3px solid #f59e0b; padding: 0.5em 1em; margin: 1em 0; color: #52525b; background-color: #fafafa; border-radius: 0 0.25em 0.25em 0; font-style: italic; }
+    hr { border: none; border-top: 1px solid #e4e4e7; margin: 1.5em 0; }
     table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; }
-    th { background-color: #f8fafc; font-weight: 600; text-align: left; padding: 0.5em 0.75em; border: 1px solid #e2e8f0; color: #475569; }
-    td { padding: 0.5em 0.75em; border: 1px solid #e2e8f0; }
-    tr:nth-child(even) td { background-color: #f8fafc; }
-    img { max-width: 100%; height: auto; border-radius: 0.5em; margin: 0.5em 0; }
+    th { background-color: #f4f4f5; font-weight: 600; text-align: left; padding: 0.5em 0.75em; border: 1px solid #e4e4e7; color: #52525b; }
+    td { padding: 0.5em 0.75em; border: 1px solid #e4e4e7; }
+    tr:nth-child(even) td { background-color: #fafafa; }
+    img { max-width: 100%; height: auto; border-radius: 0.25em; margin: 0.5em 0; }
   }
 
   @variant dark {
     .markdown-content {
-      color: #cbd5e1;
-      h1, h2, h3, h4, h5 { color: #f1f5f9; }
-      h2 { border-bottom-color: #334155; }
-      h6 { color: #94a3b8; }
-      strong { color: #f1f5f9; }
-      code { background-color: #1e293b; color: #e2e8f0; }
-      blockquote { border-left-color: #6366f1; color: #94a3b8; background-color: #1e293b; }
-      hr { border-top-color: #334155; }
-      th { background-color: #1e293b; border-color: #334155; color: #94a3b8; }
-      td { border-color: #334155; }
-      tr:nth-child(even) td { background-color: #1e293b; }
+      color: #a1a1aa;
+      h1, h2, h3, h4, h5 { color: #fafafa; }
+      h2 { border-bottom-color: #27272a; }
+      h6 { color: #71717a; }
+      strong { color: #fafafa; }
+      code { background-color: #18181b; color: #e4e4e7; }
+      blockquote { border-left-color: #f59e0b; color: #71717a; background-color: #18181b; }
+      hr { border-top-color: #27272a; }
+      th { background-color: #18181b; border-color: #27272a; color: #71717a; }
+      td { border-color: #27272a; }
+      tr:nth-child(even) td { background-color: #18181b; }
     }
   }
 

--- a/app/components/basic_attributes_component.html.erb
+++ b/app/components/basic_attributes_component.html.erb
@@ -1,47 +1,47 @@
 <section>
-  <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">Basic Information</h2>
+  <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-500 mb-6 border-b border-zinc-200 dark:border-zinc-800 pb-2">Basic Information</h2>
   <dl class="grid gap-4">
     <% if @resource.is_a?(Person) %>
       <% if @resource.parts.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-          <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Parts</dt>
-          <dd class="text-[0.9375rem] font-bold text-slate-800 dark:text-slate-200 text-right"><%= @resource.parts.map(&:humanize).join(", ") %></dd>
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+          <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Parts</dt>
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100 text-right"><%= @resource.parts.map(&:humanize).join(", ") %></dd>
         </div>
       <% end %>
 
       <% if @resource.birthday.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-          <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Birthday</dt>
-          <dd class="text-[0.9375rem] font-bold text-slate-800 dark:text-slate-200">
-            <%= link_to @resource.birthday_display, birthday_date_path(month: @resource.birthday.month, day: @resource.birthday.day), class: "hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+          <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Birthday</dt>
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100">
+            <%= link_to @resource.birthday_display, birthday_date_path(month: @resource.birthday.month, day: @resource.birthday.day), class: "hover:text-amber-600 dark:hover:text-amber-400 transition-colors" %>
           </dd>
         </div>
       <% end %>
 
       <% if @resource.blood.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-          <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Blood Type</dt>
-          <dd class="text-[0.9375rem] font-bold text-slate-800 dark:text-slate-200 text-right"><%= @resource.blood %></dd>
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+          <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Blood Type</dt>
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100 text-right"><%= @resource.blood %></dd>
         </div>
       <% end %>
       <% if @resource.hometown.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-          <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Hometown</dt>
-          <dd class="text-[0.9375rem] font-bold text-slate-800 dark:text-slate-200 text-right"><%= @resource.hometown %></dd>
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+          <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Hometown</dt>
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100 text-right"><%= @resource.hometown %></dd>
         </div>
       <% end %>
     <% elsif @resource.is_a?(Unit) %>
       <% if @resource.unit_type.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-          <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Unit Type</dt>
-          <dd class="text-[0.9375rem] font-bold text-slate-800 dark:text-slate-200"><%= @resource.unit_type %></dd>
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+          <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Unit Type</dt>
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100"><%= @resource.unit_type %></dd>
         </div>
       <% end %>
 
       <% if @resource.activity_periods.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-          <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">活動時期</dt>
-          <dd class="text-[0.9375rem] font-bold text-slate-800 dark:text-slate-200 text-right">
+        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+          <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">活動時期</dt>
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100 text-right">
             <% @resource.activity_periods.each do |period| %>
               <div><%= period.from %> 〜 <%= period.to.presence || '現在' %></div>
             <% end %>
@@ -51,18 +51,18 @@
     <% end %>
 
     <% if @resource.status.present? %>
-      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-        <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Status</dt>
-        <dd><span class="bg-slate-100 dark:bg-slate-700 px-3 py-1 rounded-full text-xs font-bold text-slate-600 dark:text-slate-300"><%= @resource.status_text %></span></dd>
+      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+        <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Status</dt>
+        <dd><span class="bg-zinc-100 dark:bg-zinc-800 px-3 py-1 rounded text-xs font-bold text-zinc-600 dark:text-zinc-300"><%= @resource.status_text %></span></dd>
       </div>
     <% end %>
 
     <% if @resource.tag_indices.present? %>
-      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-slate-100 dark:border-slate-700 pb-3 last:border-0">
-        <dt class="text-sm font-semibold text-slate-500 dark:text-slate-400">Tags</dt>
+      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+        <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">Tags</dt>
         <dd class="text-right flex flex-wrap justify-end gap-2">
           <% @resource.tag_indices.order(:name).each do |tag| %>
-            <%= link_to tag.name, index_show_path(tag.id), class: "inline-block bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-300 px-2 py-0.5 rounded text-xs font-bold hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors" %>
+            <%= link_to tag.name, index_show_path(tag.id), class: "inline-block bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 px-2 py-0.5 rounded text-xs font-bold hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors" %>
           <% end %>
         </dd>
       </div>

--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -1,7 +1,7 @@
-<div class="group flex bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden hover:shadow-lg transition-shadow">
+<div class="group flex bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden hover:border-zinc-400 dark:hover:border-zinc-600 transition-colors">
   <!-- 画像（左側） -->
   <% if @item.image_url.present? %>
-    <div class="relative shrink-0 w-40 h-40 bg-slate-50 dark:bg-slate-900">
+    <div class="relative shrink-0 w-40 h-40 bg-zinc-50 dark:bg-zinc-950">
       <% if @item.link_url.present? %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer" do %>
           <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-40 h-40 object-cover hover:opacity-90 transition-opacity">
@@ -19,8 +19,8 @@
       <% end %>
     </div>
   <% else %>
-    <div class="relative shrink-0 w-40 h-40 bg-slate-100 dark:bg-slate-700 flex items-center justify-center">
-      <span class="text-slate-400 dark:text-slate-500 text-sm">画像なし</span>
+    <div class="relative shrink-0 w-40 h-40 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">
+      <span class="text-zinc-400 dark:text-zinc-500 text-sm">画像なし</span>
       <% if @item.link_url.present? %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer",
             style: "position:absolute; bottom:8px; left:50%; transform:translateX(-50%);",
@@ -41,7 +41,7 @@
       <!-- タイトル -->
       <div>
         <%= link_to item_path(@item), class: "block" do %>
-          <h3 class="font-bold text-slate-800 dark:text-slate-100 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;"><%= @item.title %></h3>
+          <h3 class="font-bold text-zinc-900 dark:text-zinc-100 hover:text-amber-600 dark:hover:text-amber-400 transition-colors overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;"><%= @item.title %></h3>
         <% end %>
       </div>
 
@@ -52,9 +52,9 @@
             <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
             <% artist_path = artist_profile_path(artist_data) %>
             <% if artist_path %>
-              <%= link_to artist_label, artist_path, class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors border border-indigo-200 dark:border-indigo-700" %>
+              <%= link_to artist_label, artist_path, class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-amber-50 text-amber-700 hover:bg-amber-100 dark:bg-amber-900/20 dark:text-amber-300 dark:hover:bg-amber-900/40 transition-colors border border-amber-200 dark:border-amber-800" %>
             <% else %>
-              <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-gray-50 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600"><%= artist_label %></span>
+              <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-zinc-100 text-zinc-600 border border-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"><%= artist_label %></span>
             <% end %>
           <% end %>
         </div>
@@ -63,7 +63,7 @@
 
     <!-- 発売日（下部固定） -->
     <div class="pt-2">
-      <span class="text-slate-400 dark:text-slate-500 font-mono text-sm font-bold">
+      <span class="text-zinc-400 dark:text-zinc-500 font-mono text-sm font-bold">
         <%= @item.release_date.strftime('%Y/%m/%d') %> 発売
       </span>
     </div>

--- a/app/components/person_card_component.html.erb
+++ b/app/components/person_card_component.html.erb
@@ -14,8 +14,8 @@
         <% end %>
       </h3>
       <% if @person.aliases.any? %>
-        <span class="text-sm text-slate-400 dark:text-slate-500 opacity-60 mx-1 group-hover:text-person dark:group-hover:text-person group-hover:opacity-80 transition-all">/</span>
-        <span class="text-sm text-slate-600 dark:text-slate-300 group-hover:text-person dark:group-hover:text-person group-hover:opacity-80 transition-all">
+        <span class="text-sm text-zinc-400 dark:text-zinc-500 opacity-60 mx-1 group-hover:text-person dark:group-hover:text-person group-hover:opacity-80 transition-all">/</span>
+        <span class="text-sm text-zinc-600 dark:text-zinc-300 group-hover:text-person dark:group-hover:text-person group-hover:opacity-80 transition-all">
           <% @person.aliases.each_with_index do |a, i| %>
             <%= " / " if i > 0 %><% if a.kana.present? %><ruby><%= a.name %><rt><%= a.kana %></rt></ruby><% else %><%= a.name %><% end %>
           <% end %>
@@ -28,7 +28,7 @@
       <% recent_histories = @person.parse_old_history.last(3) %>
       <% if recent_histories.present? %>
         <% recent_histories.each do |recent_history| %>
-          <div class="mt-2 pl-3 text-xs text-slate-500 dark:text-slate-400">
+          <div class="mt-2 pl-3 text-xs text-zinc-500 dark:text-zinc-400">
             <% recent_history.each_with_index do |item, index| %>
               <% if index > 0 %>
                 <span class="mx-1">、</span>
@@ -39,7 +39,7 @@
               <% end %>
               <% if item[:notes].present? %>
                 <% item[:notes].each do |note| %>
-                  <span class="text-xs bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded ml-1"><%= note %></span>
+                  <span class="text-xs bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded ml-1"><%= note %></span>
                 <% end %>
               <% end %>
             <% end %>
@@ -49,7 +49,7 @@
     <% end %>
 
     <% if @show_details %>
-      <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 flex justify-between items-center text-[0.65rem] font-bold text-slate-400 dark:text-slate-500">
+      <div class="mt-4 pt-4 border-t border-zinc-100 dark:border-zinc-800 flex justify-between items-center text-[0.65rem] font-bold text-zinc-400 dark:text-zinc-600 tracking-widest uppercase">
         <span class="uppercase tracking-widest">Update</span>
         <span><%= @person.updated_at.strftime("%Y.%m.%d") %></span>
       </div>

--- a/app/components/person_card_component.rb
+++ b/app/components/person_card_component.rb
@@ -12,8 +12,8 @@ class PersonCardComponent < ViewComponent::Base
   private
 
   def card_classes
-    'group block bg-slate-50 dark:bg-slate-900/50 border border-slate-100 dark:border-slate-700 ' \
-    'hover:border-person hover:scale-[1.02] transition-all relative overflow-hidden p-4 rounded-lg'
+    'group block bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 ' \
+    'hover:border-person dark:hover:border-person hover:scale-[1.01] transition-all relative overflow-hidden p-4 rounded-lg'
   end
 
   def icon_padding_classes
@@ -25,10 +25,10 @@ class PersonCardComponent < ViewComponent::Base
   end
 
   def name_classes
-    'font-bold text-slate-800 dark:text-slate-200 group-hover:text-person transition-colors'
+    'font-bold text-zinc-900 dark:text-zinc-100 group-hover:text-person transition-colors'
   end
 
   def kana_classes
-    'text-xs text-slate-500 dark:text-slate-400 group-hover:text-person transition-colors'
+    'text-xs text-zinc-500 dark:text-zinc-500 group-hover:text-person transition-colors'
   end
 end

--- a/app/components/profile_header_component.html.erb
+++ b/app/components/profile_header_component.html.erb
@@ -1,6 +1,6 @@
-<header class="p-6 md:p-8 text-center text-white relative <%= bg_class %>">
+<header class="p-8 md:p-10 text-center text-white relative <%= bg_class %> border-b border-white/10">
   <div class="flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1 mb-1">
-    <h1 class="text-3xl md:text-4xl font-black tracking-tight">
+    <h1 class="text-3xl md:text-4xl font-black tracking-tight letter-spacing-tight">
       <% if name_kana.present? %>
         <ruby><%= name %><rt class="text-sm font-medium opacity-90"><%= name_kana %></rt></ruby>
       <% else %>
@@ -19,11 +19,11 @@
   <% if helpers.respond_to?(:logged_in?) && helpers.logged_in? %>
     <% if @resource.is_a?(Person) %>
       <div class="absolute top-4 right-4">
-        <%= link_to "Edit", helpers.edit_admin_person_path(@resource), class: "px-3 py-1 bg-white/20 hover:bg-white/30 text-white text-xs font-bold rounded backdrop-blur-sm transition" %>
+        <%= link_to "Edit", helpers.edit_admin_person_path(@resource), class: "px-3 py-1 bg-white/10 hover:bg-white/20 text-white/80 hover:text-white text-xs font-bold rounded border border-white/20 backdrop-blur-sm transition" %>
       </div>
     <% elsif @resource.is_a?(Unit) %>
       <div class="absolute top-4 right-4">
-        <%= link_to "Edit", helpers.edit_admin_unit_path(@resource), class: "px-3 py-1 bg-white/20 hover:bg-white/30 text-white text-xs font-bold rounded backdrop-blur-sm transition" %>
+        <%= link_to "Edit", helpers.edit_admin_unit_path(@resource), class: "px-3 py-1 bg-white/10 hover:bg-white/20 text-white/80 hover:text-white text-xs font-bold rounded border border-white/20 backdrop-blur-sm transition" %>
       </div>
     <% end %>
   <% end %>

--- a/app/components/profile_header_component.rb
+++ b/app/components/profile_header_component.rb
@@ -8,7 +8,11 @@ class ProfileHeaderComponent < ViewComponent::Base
   private
 
   def bg_class
-    @resource.is_a?(Unit) ? 'bg-unit' : 'bg-person'
+    if @resource.is_a?(Unit)
+      'bg-gradient-to-br from-blue-950 via-blue-900 to-blue-800'
+    else
+      'bg-gradient-to-br from-rose-950 via-rose-900 to-rose-800'
+    end
   end
 
   def name

--- a/app/components/section_component.html.erb
+++ b/app/components/section_component.html.erb
@@ -1,9 +1,9 @@
 <section class="mt-8 mb-12">
-  <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
+  <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-500 mb-6 border-b border-zinc-200 dark:border-zinc-800 pb-2">
     <%= @section.name %>
   </h2>
-  
-  <div class="text-sm text-slate-700 dark:text-slate-300 leading-relaxed wiki-content">
+
+  <div class="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed wiki-content">
     <%= format_wiki_content(@section.wiki_text) %>
   </div>
 </section>

--- a/app/components/unit_card_component.html.erb
+++ b/app/components/unit_card_component.html.erb
@@ -1,4 +1,4 @@
-<%= link_to profile_path(@unit.key), class: "group block bg-slate-50 dark:bg-slate-900/50 p-6 rounded-2xl border border-slate-100 dark:border-slate-700 hover:border-unit hover:scale-[1.02] transition-all relative overflow-hidden" do %>
+<%= link_to profile_path(@unit.key), class: "group block bg-white dark:bg-zinc-900 p-6 rounded-lg border border-zinc-200 dark:border-zinc-800 hover:border-unit dark:hover:border-unit hover:scale-[1.01] transition-all relative overflow-hidden" do %>
   <div class="absolute top-0 right-0 p-3 opacity-10 group-hover:opacity-20 group-hover:text-unit transition-all">
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-16 h-16">
       <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
@@ -6,16 +6,16 @@
   </div>
   <div class="relative z-10">
     <div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-      <h3 class="text-lg font-black text-slate-800 dark:text-slate-200 group-hover:text-unit transition-colors">
+      <h3 class="text-lg font-black text-zinc-900 dark:text-zinc-100 group-hover:text-unit transition-colors">
         <% if @unit.name_kana.present? %>
-          <ruby><%= @unit.name %><rt class="font-bold text-slate-400 dark:text-slate-500 group-hover:text-unit dark:group-hover:text-unit transition-colors"><%= @unit.name_kana %></rt></ruby>
+          <ruby><%= @unit.name %><rt class="font-bold text-zinc-400 dark:text-zinc-500 group-hover:text-unit dark:group-hover:text-unit transition-colors"><%= @unit.name_kana %></rt></ruby>
         <% else %>
           <%= @unit.name %>
         <% end %>
       </h3>
       <% if @unit.aliases.any? %>
-        <span class="text-sm text-slate-400 dark:text-slate-500 opacity-60 mx-1 group-hover:text-unit dark:group-hover:text-unit group-hover:opacity-80 transition-all">/</span>
-        <span class="text-sm text-slate-600 dark:text-slate-300 group-hover:text-unit dark:group-hover:text-unit group-hover:opacity-80 transition-all">
+        <span class="text-sm text-zinc-400 dark:text-zinc-500 opacity-60 mx-1 group-hover:text-unit dark:group-hover:text-unit group-hover:opacity-80 transition-all">/</span>
+        <span class="text-sm text-zinc-600 dark:text-zinc-300 group-hover:text-unit dark:group-hover:text-unit group-hover:opacity-80 transition-all">
           <% @unit.aliases.each_with_index do |a, i| %>
             <%= " / " if i > 0 %><% if a.kana.present? %><ruby><%= a.name %><rt><%= a.kana %></rt></ruby><% else %><%= a.name %><% end %>
           <% end %>
@@ -23,17 +23,17 @@
       <% end %>
     </div>
     <% if @unit.unit_type.present? %>
-      <p class="text-xs font-bold text-slate-400 dark:text-slate-500 mt-1 uppercase tracking-wider"><%= @unit.unit_type %></p>
+      <p class="text-xs font-bold text-zinc-400 dark:text-zinc-500 mt-1 uppercase tracking-widest"><%= @unit.unit_type %></p>
     <% end %>
     <% if @unit.activity_periods.present? %>
-      <div class="mt-3 text-xs text-slate-600 dark:text-slate-300">
+      <div class="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
         <% @unit.activity_periods.each do |period| %>
           <div><%= period.from %> 〜 <%= period.to.presence || '現在' %></div>
         <% end %>
       </div>
     <% end %>
     <% if @show_details %>
-      <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-700 flex justify-between items-center text-[0.65rem] font-bold text-slate-400 dark:text-slate-500">
+      <div class="mt-4 pt-4 border-t border-zinc-100 dark:border-zinc-800 flex justify-between items-center text-[0.65rem] font-bold text-zinc-400 dark:text-zinc-600 tracking-widest uppercase">
         <span class="uppercase tracking-widest">Update</span>
         <span><%= @unit.updated_at.strftime("%Y.%m.%d") %></span>
       </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,17 +1,17 @@
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
-  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+  <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+    <div class="bg-amber-500 px-5 py-6 md:px-8 text-center">
+      <h1 class="text-3xl font-black text-zinc-900 flex items-center justify-center gap-3">
+        <span>ITEMS</span>
+        <span class="text-amber-900/50 text-lg font-bold"><%= @pagy.count %> records</span>
+      </h1>
+      <% if @artist %>
+        <div class="mt-2 text-xl font-bold text-zinc-800">
+          for <%= link_to @artist.name, profile_path(key: @artist.key), class: "hover:text-zinc-900 transition-colors underline decoration-zinc-700/50 underline-offset-4" %>
+        </div>
+      <% end %>
+    </div>
     <div class="p-5 md:p-8">
-      <header class="mb-8 text-center flex flex-col items-center">
-        <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">
-          <span class="text-indigo-600 dark:text-indigo-400">ITEMS</span>
-          <span class="text-slate-300 dark:text-slate-600 text-lg font-bold"><%= @pagy.count %> records</span>
-        </h1>
-        <% if @artist %>
-          <div class="mt-2 text-xl font-bold text-slate-600 dark:text-slate-400">
-            for <%= link_to @artist.name, profile_path(key: @artist.key), class: "hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors underline decoration-slate-300 dark:decoration-slate-600 underline-offset-4" %>
-          </div>
-        <% end %>
-      </header>
 
       <div class="flex flex-wrap gap-2 mb-6">
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,8 +1,8 @@
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
-  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+  <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <!-- ヘッダー（タイトル） -->
-    <div class="bg-slate-50 dark:bg-slate-900 px-5 py-5 md:px-8 border-b border-slate-100 dark:border-slate-700">
-      <h1 class="text-xl font-black text-slate-800 dark:text-slate-100 leading-snug text-center">
+    <div class="bg-amber-500 px-5 py-5 md:px-8 border-b border-amber-600/30">
+      <h1 class="text-xl font-black text-zinc-900 leading-snug text-center">
         <%= @item.title %>
       </h1>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,8 +28,8 @@
     </style>
   </head>
 
-  <body class="bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
-    <nav class="bg-white shadow dark:bg-gray-800 relative z-10">
+  <body class="bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
+    <nav class="bg-white/95 dark:bg-zinc-950/95 border-b border-zinc-200 dark:border-zinc-800 relative z-10 backdrop-blur-sm">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <div class="flex">
@@ -41,7 +41,7 @@
             <!-- Search Form (Desktop) - Next to logo -->
             <%= form_with url: search_path, method: :get, local: true, class: "hidden sm:flex items-center ml-6" do |f| %>
               <div class="relative">
-                <%= f.text_field :q, placeholder: "Search...", class: "search-input-responsive bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg pl-10 py-2 pr-2 text-sm text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 placeholder:text-gray-400 placeholder:opacity-0 md:placeholder:opacity-100 focus:placeholder:opacity-100" %>
+                <%= f.text_field :q, placeholder: "Search...", class: "search-input-responsive bg-zinc-100 dark:bg-zinc-900 border border-zinc-300 dark:border-zinc-700 rounded pl-10 py-2 pr-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-1 focus:ring-amber-500 placeholder:text-zinc-400 placeholder:opacity-0 md:placeholder:opacity-100 focus:placeholder:opacity-100" %>
                 <button type="submit" class="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -50,25 +50,25 @@
               </div>
             <% end %>
             <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
-              <%= link_to units_path, title: "Units", class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" do %>
+              <%= link_to units_path, title: "Units", class: "border-transparent text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 inline-flex items-center px-1 pt-1 border-b-2 hover:border-amber-500 dark:hover:border-amber-500 text-sm font-medium transition-colors" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 sm:mr-1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 13.742a6.051 6.051 0 0 1 12 0c0 .94-.251 1.815-.695 2.571ZM10.5 8.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Zm0 1.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm6.75 3a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM17.25 10.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" />
                 </svg>
                 <span class="hidden lg:inline text-center">Units<br><span class="text-xs font-normal">バンド</span></span>
               <% end %>
-              <%= link_to people_path, title: "People", class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" do %>
+              <%= link_to people_path, title: "People", class: "border-transparent text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 inline-flex items-center px-1 pt-1 border-b-2 hover:border-amber-500 dark:hover:border-amber-500 text-sm font-medium transition-colors" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 sm:mr-1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
                 </svg>
                 <span class="hidden lg:inline text-center">People<br><span class="text-xs font-normal">個人</span></span>
               <% end %>
-              <%= link_to trends_path, title: "Trends", class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" do %>
+              <%= link_to trends_path, title: "Trends", class: "border-transparent text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 inline-flex items-center px-1 pt-1 border-b-2 hover:border-amber-500 dark:hover:border-amber-500 text-sm font-medium transition-colors" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 sm:mr-1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.307a11.95 11.95 0 0 1 5.814-5.519l2.74-1.22m0 0-5.94-2.28m5.94 2.28-2.28 5.941" />
                 </svg>
                 <span class="hidden lg:inline text-center">Trends<br><span class="text-xs font-normal">動向</span></span>
               <% end %>
-              <%= link_to items_path, title: "Items", class: "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium" do %>
+              <%= link_to items_path, title: "Items", class: "border-transparent text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 inline-flex items-center px-1 pt-1 border-b-2 hover:border-amber-500 dark:hover:border-amber-500 text-sm font-medium transition-colors" do %>
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 sm:mr-1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
                 </svg>
@@ -81,7 +81,7 @@
           <div class="hidden sm:ml-6 sm:flex sm:items-center">
             <% if logged_in? %>
               <div class="ml-3 relative admin-dropdown h-full flex items-center">
-                <div class="border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium cursor-pointer" title="<%= current_user.name %>">
+                <div class="border-transparent text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 inline-flex items-center px-1 pt-1 border-b-2 hover:border-amber-500 dark:hover:border-amber-500 text-sm font-medium cursor-pointer transition-colors" title="<%= current_user.name %>">
                   <!-- User icon (visible on sm-lg, hidden on xl+) -->
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 lg:hidden">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
@@ -93,66 +93,66 @@
                   </svg>
                 </div>
                 <!-- Dropdown menu code (omitted for brevity, keep existing) -->
-                <div class="admin-dropdown-menu hidden absolute right-0 top-full mt-0 w-48 rounded-md shadow-lg bg-white dark:bg-slate-800 ring-1 ring-black ring-opacity-5 z-50">
-                  <div class="py-1 border-b border-gray-100 dark:border-slate-700">
-                    <%= link_to admin_units_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                <div class="admin-dropdown-menu hidden absolute right-0 top-full mt-0 w-48 rounded border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 z-50">
+                  <div class="py-1 border-b border-zinc-100 dark:border-zinc-800">
+                    <%= link_to admin_units_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 13.742a6.051 6.051 0 0 1 12 0c0 .94-.251 1.815-.695 2.571ZM10.5 8.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Zm0 1.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm6.75 3a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM17.25 10.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" />
                       </svg>
                       Units
                     <% end %>
-                    <%= link_to admin_people_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_people_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
                       </svg>
                       People
                     <% end %>
-                    <%= link_to admin_index_groups_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_index_groups_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
                       </svg>
                       Index Groups
                     <% end %>
-                    <%= link_to admin_trends_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_trends_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.307a11.95 11.95 0 0 1 5.814-5.519l2.74-1.22m0 0-5.94-2.28m5.94 2.28-2.28 5.941" />
                       </svg>
                       Trends
                     <% end %>
-                    <%= link_to admin_external_sites_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_external_sites_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
                       </svg>
                       External Sites
                     <% end %>
-                    <%= link_to admin_items_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_items_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m9 9 10.5-3m0 6.553v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 1 1-.99-3.467l2.31-.66a2.25 2.25 0 0 0 1.632-2.163Zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 0 1-1.632 2.163l-1.32.377a1.803 1.803 0 0 1-.99-3.467l2.31-.66A2.25 2.25 0 0 0 9 15.553Z" />
                       </svg>
                       Items
                     <% end %>
-                    <%= link_to admin_custom_pages_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_custom_pages_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
                       </svg>
                       Pages
                     <% end %>
                   </div>
                   <div class="py-1">
-                    <%= link_to admin_users_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to admin_users_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
                       </svg>
                       Users
                     <% end %>
-                    <%= link_to edit_password_path, class: "group flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-700 whitespace-nowrap" do %>
-                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300">
+                    <%= link_to edit_password_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-amber-500 dark:text-zinc-500 dark:group-hover:text-amber-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 0 1 0 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 0 1 0-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281Z" />
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                       </svg>
                       Settings
                     <% end %>
-                    <%= button_to logout_path, method: :delete, class: "group flex w-full items-center px-4 py-2 text-sm text-red-600 hover:bg-gray-100 dark:text-red-400 dark:hover:bg-slate-700 whitespace-nowrap" do %>
+                    <%= button_to logout_path, method: :delete, class: "group flex w-full items-center px-4 py-2 text-sm text-red-600 hover:bg-zinc-50 dark:text-red-400 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-red-500 group-hover:text-red-600 dark:text-red-400 dark:group-hover:text-red-300">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75" />
                       </svg>
@@ -162,7 +162,7 @@
                 </div>
               </div>
             <% else %>
-              <%= link_to "Login", login_path, class: "text-indigo-600 hover:text-indigo-900 text-sm font-medium dark:text-indigo-400 dark:hover:text-indigo-300" %>
+              <%= link_to "Login", login_path, class: "text-amber-600 hover:text-amber-800 text-sm font-medium dark:text-amber-400 dark:hover:text-amber-300 transition-colors" %>
             <% end %>
           </div>
           
@@ -170,7 +170,7 @@
           <div class="flex items-center gap-2 sm:hidden">
             <!-- Left Hamburger: Common Navigation (Units, People, Trends, Items) -->
             <div data-controller="mobile-menu">
-              <button type="button" class="bg-white dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-controls="common-nav-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
+              <button type="button" class="bg-transparent inline-flex items-center justify-center p-2 rounded text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 focus:outline-none transition-colors" aria-controls="common-nav-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
                 <span class="sr-only">Open navigation menu</span>
                 <!-- Icon when menu is closed -->
                 <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconOpen">
@@ -183,12 +183,12 @@
               </button>
               
               <!-- Common Navigation Menu Panel -->
-              <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-gray-800 shadow-lg border-t border-gray-200 dark:border-gray-700" id="common-nav-menu" data-mobile-menu-target="menu">
+              <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800" id="common-nav-menu" data-mobile-menu-target="menu">
                 <!-- Search Form (Mobile) -->
-                <div class="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+                <div class="px-4 py-3 border-b border-zinc-200 dark:border-zinc-800">
                   <%= form_with url: search_path, method: :get, local: true, class: "flex gap-2" do |f| %>
-                    <%= f.text_field :q, placeholder: "Search...", class: "flex-1 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg px-4 py-2 text-sm text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-gray-400" %>
-                    <button type="submit" class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-lg transition-colors">
+                    <%= f.text_field :q, placeholder: "Search...", class: "flex-1 bg-zinc-100 dark:bg-zinc-900 border border-zinc-300 dark:border-zinc-700 rounded px-4 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-1 focus:ring-amber-500 transition-all placeholder:text-zinc-400" %>
+                    <button type="submit" class="bg-amber-500 hover:bg-amber-600 text-white px-4 py-2 rounded transition-colors">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
                       </svg>
@@ -196,7 +196,7 @@
                   <% end %>
                 </div>
                 <div class="pt-2 pb-3 space-y-1">
-                  <%= link_to units_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                  <%= link_to units_path, class: "border-transparent text-zinc-600 hover:bg-zinc-50 hover:border-amber-500 hover:text-amber-600 dark:text-zinc-300 dark:hover:bg-zinc-900 dark:hover:text-amber-400 block pl-3 pr-4 py-2 border-l-4 text-base font-medium transition-colors" do %>
                     <div class="flex items-center">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 13.742a6.051 6.051 0 0 1 12 0c0 .94-.251 1.815-.695 2.571ZM10.5 8.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5Zm0 1.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm6.75 3a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5ZM17.25 10.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" />
@@ -204,7 +204,7 @@
                       <span>Units <span class="text-sm font-normal text-gray-400 dark:text-gray-500">バンド</span></span>
                     </div>
                   <% end %>
-                  <%= link_to people_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                  <%= link_to people_path, class: "border-transparent text-zinc-600 hover:bg-zinc-50 hover:border-amber-500 hover:text-amber-600 dark:text-zinc-300 dark:hover:bg-zinc-900 dark:hover:text-amber-400 block pl-3 pr-4 py-2 border-l-4 text-base font-medium transition-colors" do %>
                     <div class="flex items-center">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
@@ -212,7 +212,7 @@
                       <span>People <span class="text-sm font-normal text-gray-400 dark:text-gray-500">個人</span></span>
                     </div>
                   <% end %>
-                  <%= link_to trends_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                  <%= link_to trends_path, class: "border-transparent text-zinc-600 hover:bg-zinc-50 hover:border-amber-500 hover:text-amber-600 dark:text-zinc-300 dark:hover:bg-zinc-900 dark:hover:text-amber-400 block pl-3 pr-4 py-2 border-l-4 text-base font-medium transition-colors" do %>
                     <div class="flex items-center">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.307a11.95 11.95 0 0 1 5.814-5.519l2.74-1.22m0 0-5.94-2.28m5.94 2.28-2.28 5.941" />
@@ -220,7 +220,7 @@
                       <span>Trends <span class="text-sm font-normal text-gray-400 dark:text-gray-500">動向</span></span>
                     </div>
                   <% end %>
-                  <%= link_to items_path, class: "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white block pl-3 pr-4 py-2 border-l-4 text-base font-medium" do %>
+                  <%= link_to items_path, class: "border-transparent text-zinc-600 hover:bg-zinc-50 hover:border-amber-500 hover:text-amber-600 dark:text-zinc-300 dark:hover:bg-zinc-900 dark:hover:text-amber-400 block pl-3 pr-4 py-2 border-l-4 text-base font-medium transition-colors" do %>
                     <div class="flex items-center">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-3">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
@@ -234,7 +234,7 @@
 
             <!-- Right Hamburger: Admin/User Menu -->
             <div data-controller="mobile-menu">
-              <button type="button" class="bg-white dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-controls="admin-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
+              <button type="button" class="bg-transparent inline-flex items-center justify-center p-2 rounded text-zinc-500 hover:text-amber-500 dark:text-zinc-400 dark:hover:text-amber-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 focus:outline-none transition-colors" aria-controls="admin-menu" aria-expanded="false" data-action="click->mobile-menu#toggle">
                 <span class="sr-only">Open user menu</span>
                 <!-- Icon when menu is closed -->
                 <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-mobile-menu-target="iconOpen">
@@ -247,12 +247,12 @@
               </button>
               
               <!-- Admin/User Menu Panel -->
-              <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-gray-800 shadow-lg border-t border-gray-200 dark:border-gray-700" id="admin-menu" data-mobile-menu-target="menu">
+              <div class="hidden absolute top-16 left-0 right-0 z-50 bg-white dark:bg-zinc-950 border-t border-zinc-200 dark:border-zinc-800" id="admin-menu" data-mobile-menu-target="menu">
                 <% if logged_in? %>
                   <div class="pt-4 pb-3">
                     <div class="flex items-center px-4">
                       <div class="flex-shrink-0">
-                        <div class="h-10 w-10 rounded-full bg-gray-300 flex items-center justify-center text-gray-700 font-bold">
+                        <div class="h-10 w-10 rounded-full bg-amber-100 dark:bg-amber-900 flex items-center justify-center text-amber-700 dark:text-amber-300 font-bold">
                           <%= current_user.name.first.upcase %>
                         </div>
                       </div>
@@ -262,34 +262,34 @@
                     </div>
                     <div class="mt-3 space-y-1">
                       <!-- Mobile Admin Links -->
-                      <%= link_to admin_units_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_units_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Units
                       <% end %>
-                      <%= link_to admin_people_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_people_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: People
                       <% end %>
-                      <%= link_to admin_index_groups_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_index_groups_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Index Groups
                       <% end %>
-                      <%= link_to admin_trends_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_trends_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Trends
                       <% end %>
-                      <%= link_to admin_external_sites_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_external_sites_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: External Sites
                       <% end %>
-                      <%= link_to admin_items_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_items_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Items
                       <% end %>
-                      <%= link_to admin_custom_pages_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_custom_pages_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Pages
                       <% end %>
-                      <%= link_to admin_users_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to admin_users_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Users
                       <% end %>
-                      <%= link_to edit_password_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" do %>
+                      <%= link_to edit_password_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Password Settings
                       <% end %>
-                      <%= button_to logout_path, method: :delete, class: "block w-full text-left px-4 py-2 text-base font-medium text-red-600 hover:text-red-800 hover:bg-gray-100 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-gray-700" do %>
+                      <%= button_to logout_path, method: :delete, class: "block w-full text-left px-4 py-2 text-base font-medium text-red-600 hover:text-red-800 hover:bg-zinc-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-zinc-900 transition-colors" do %>
                         Logout
                       <% end %>
                     </div>
@@ -297,7 +297,7 @@
                 <% else %>
                   <div class="pt-4 pb-3">
                     <div class="space-y-1">
-                      <%= link_to "Login", login_path, class: "block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700" %>
+                      <%= link_to "Login", login_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" %>
                     </div>
                   </div>
                 <% end %>
@@ -314,7 +314,7 @@
       <%= yield %>
     </main>
     <% if @footer_page %>
-      <footer class="border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 mt-8">
+      <footer class="border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 mt-8">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div class="markdown-content text-sm">
             <%= markdown(@footer_page.body) %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,12 +1,12 @@
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
-  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+  <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+    <div class="bg-amber-500 px-5 py-6 md:px-8 text-center">
+      <h1 class="text-3xl font-black text-zinc-900 flex items-center justify-center gap-3">
+        <span>TRENDS</span>
+        <span class="text-amber-900/50 text-lg font-bold"><%= @pagy.count %> records</span>
+      </h1>
+    </div>
     <div class="p-5 md:p-8">
-      <header class="mb-8 text-center flex flex-col items-center">
-        <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">
-          <span class="text-indigo-600 dark:text-indigo-400">TRENDS</span>
-          <span class="text-slate-300 dark:text-slate-600 text-lg font-bold"><%= @pagy.count %> records</span>
-        </h1>
-      </header>
 
       <div class="flex flex-wrap gap-2 mb-6">
 

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -1,7 +1,7 @@
-<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
-  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
-    <div class="bg-slate-50 dark:bg-slate-900/30 p-6 md:p-8 border-b border-slate-100 dark:border-slate-700">
-      <div class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-400 font-mono mb-2 font-bold">
+<div class="flex justify-center items-start min-h-screen p-0 md:p-8">
+  <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+    <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30">
+      <div class="flex items-center gap-3 text-sm text-amber-900/70 font-mono mb-2 font-bold">
         <% date_path, date_label = if @trend.month_unknown?
                                       [yearly_path(year: @trend.date.year), @trend.date.strftime('%Y')]
                                     elsif @trend.day_unknown?
@@ -9,16 +9,16 @@
                                     else
                                       [daily_path(year: @trend.date.year, month: @trend.date.month, day: @trend.date.day), @trend.date.strftime('%Y/%m/%d')]
                                     end %>
-        <%= link_to date_label, date_path, class: "hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors" %>
+        <%= link_to date_label, date_path, class: "hover:text-zinc-900 transition-colors" %>
       </div>
-      <h1 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
+      <h1 class="text-2xl font-bold text-zinc-900">
         <% if @trend.units %>
           <% @trend.units.each do |unit_data| %>
             <% unit = @related_units&.dig(unit_data['unit_id']) %>
             <% if unit %>
-              <%= link_to unit.name, profile_path(unit.key), class: "inline-block px-3 py-1 rounded-md text-lg font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900/30 dark:text-indigo-300 dark:hover:bg-indigo-900/50 transition-colors mr-2 border border-indigo-200 dark:border-indigo-800 align-middle" %>
+              <%= link_to unit.name, profile_path(unit.key), class: "inline-block px-3 py-1 rounded-md text-lg font-semibold bg-zinc-900/15 text-zinc-900 hover:bg-zinc-900/25 transition-colors mr-2 border border-zinc-900/20 align-middle" %>
             <% elsif unit_data['name'].present? %>
-              <span class="inline-block px-3 py-1 rounded-md text-lg font-semibold bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400 mr-2 border border-slate-200 dark:border-slate-700 align-middle"><%= unit_data['name'] %></span>
+              <span class="inline-block px-3 py-1 rounded-md text-lg font-semibold bg-amber-600/30 text-zinc-800 mr-2 border border-amber-600/30 align-middle"><%= unit_data['name'] %></span>
             <% end %>
           <% end %>
         <% end %>


### PR DESCRIPTION
## Summary

- カラーパレットをzincベースに統一（slate → zinc）
- アクセントカラーをアンバー(`#f59e0b`)に変更（サイトバナーの配色に合わせる）
- ユニット色をネイビー(`#2563eb`)、アーティスト色をローズ(`#e11d48`)に変更
- ナビゲーションをシャドウなし・ボーダースタイルに変更
- プロフィールヘッダーのグラデーションを刷新（ユニット: ブルー系、アーティスト: ローズ系）
- TRENDSとITEMSページのヘッダー背景をアンバー(`bg-amber-500`)に変更

## Test plan

- [ ] ライトモードでのデザイン確認
- [ ] ダークモードでのデザイン確認
- [ ] TOPページ、アーティストプロフィール、ユニットプロフィールの表示確認
- [ ] TRENDS一覧・詳細ページの確認
- [ ] ITEMS一覧・詳細ページの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)