### PR TITLE
feat: Trend更新後の遷移先を編集画面に変更し「更新しました」メッセージを表示

### DIFF
--- a/app/controllers/admin/trends_controller.rb
+++ b/app/controllers/admin/trends_controller.rb
@@ -64,7 +64,7 @@ module Admin
 
     def update
       if @trend.update(trend_params)
-        redirect_to admin_trends_path, notice: 'Trend updated successfully.'
+        redirect_to edit_admin_trend_path(@trend), notice: 'Trendを更新しました。'
       else
         @related_units = Unit.where(id: (@trend.units || []).map { |u| u['unit_id'] }).index_by(&:id)
         @related_people = Person.where(id: (@trend.people || []).map { |p| p['person_id'] }).index_by(&:id)

--- a/app/views/admin/trends/edit.html.erb
+++ b/app/views/admin/trends/edit.html.erb
@@ -5,6 +5,12 @@
       <%= link_to "Back", admin_trends_path, class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
     </div>
 
+    <% if notice %>
+      <div class="mb-4 p-4 rounded bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200" role="alert">
+        <%= notice %>
+      </div>
+    <% end %>
+
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
       <%= render "form", trend: @trend %>
     </div>


### PR DESCRIPTION
## Summary
- Trend編集保存後のリダイレクト先を一覧画面（`admin_trends_path`）から編集画面（`edit_admin_trend_path`）に変更
- 更新成功時のflashメッセージを「Trendを更新しました。」に変更
- 編集画面にflashメッセージ（notice）の表示エリアを追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] Trend編集フォームを保存後、編集画面にリダイレクトされること
- [ ] 編集画面に「Trendを更新しました。」メッセージが表示されること

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)