### PR TITLE
feat: Trends#showビューにadmin向けEditボタンをヘッダーに追加

### DIFF
--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -1,6 +1,11 @@
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
-    <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30">
+    <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30 relative">
+      <% if defined?(logged_in?) && logged_in? %>
+        <div class="absolute top-4 right-4">
+          <%= link_to "Edit", edit_admin_trend_path(@trend), class: "px-3 py-1 bg-white/10 hover:bg-white/20 text-amber-900/80 hover:text-amber-900 text-xs font-bold rounded border border-amber-900/20 backdrop-blur-sm transition" %>
+        </div>
+      <% end %>
       <div class="flex items-center gap-3 text-sm text-amber-900 font-mono mb-2 font-bold">
         <% date_path, date_label = if @trend.month_unknown?
                                       [yearly_path(year: @trend.date.year), @trend.date.strftime('%Y')]
@@ -89,9 +94,6 @@
       <% end %>
 
       <div class="mt-12 pt-8 border-t border-slate-100 dark:border-slate-700">
-        <% if defined?(logged_in?) && logged_in? %>
-          <%= link_to "Edit", edit_admin_trend_path(@trend), class: "text-sm font-bold text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors mr-4" %>
-        <% end %>
         <%= link_to "Back to Trends", trends_path, class: "text-sm font-bold text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors" %>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- プロフィールページのヘッダー右上パターン（`absolute top-4 right-4`）と同様に、Trends#show のアンバーヘッダー内に Edit ボタンを追加
- `logged_in?` が真の場合（admin権限）のみ表示
- フッターの重複していた Edit リンクを削除

## Test plan
- [ ] admin でログイン → Trends#show でヘッダー右上に Edit ボタンが表示されること
- [ ] 非ログイン状態 → Edit ボタンが表示されないこと
- [ ] Edit ボタンをクリック → 編集画面に遷移すること

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)