### PR TITLE
feat: プレビュー環境対応 (issue #386)

### DIFF
--- a/.claude/skills/preview-pr/SKILL.md
+++ b/.claude/skills/preview-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: preview-pr
+description: 指定したブランチ（指定しない場合はカレントブランチ）をもとに、release/yyyy.mm.dd.preview ブランチを作成し、PRを作成する（マージ先はmain）
+---
+
+# Preview PR 作成
+
+以下の手順を **そのまま実行** してください。確認や提案は不要です。
+
+## 手順
+
+1. ベースブランチを決定する
+   - 引数でブランチが指定された場合はそれを使う
+   - 指定がない場合はカレントブランチ（`git branch --show-current`）を使う
+
+2. 今日の日付を取得して、ブランチ名を決定する
+   - フォーマット: `release/YYYY.MM.DD.preview`（例: `release/2026.03.07.preview`）
+   - Bash で `date +%Y.%m.%d` を実行して取得する
+
+3. ベースブランチに切り替えて最新化する
+   ```
+   git checkout <base_branch>
+   git pull origin <base_branch>
+   ```
+
+4. プレビューブランチを作成する
+   ```
+   git checkout -b release/<date>.preview
+   ```
+
+5. リモートにpushする
+   ```
+   git push origin release/<date>.preview
+   ```
+
+6. PRを作成する（ベースブランチは `main`、タイトルに `[render preview]` を含める）
+   ```
+   gh pr create --base main --title "[render preview] release/<date>.preview" --body "## Preview release/<date>.preview\n\nベースブランチ: <base_branch>"
+   ```
+
+7. 作成したPRのURLをユーザーに表示する

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,7 @@
+previews:
+  generation: automatic
+  expireAfterDays: 1
+
 databases:
   - name: vkdby-db
     databaseName: vkdby_production


### PR DESCRIPTION
## 概要

issue #386 の対応。

## 変更内容

### `/preview-pr` スキルの追加

`.claude/skills/preview-pr/SKILL.md` を追加。

- 指定ブランチ（未指定時はカレントブランチ）から `release/YYYY.MM.DD.preview` ブランチを作成
- PRタイトルに `[render preview]` を付与（Render.comのプレビュー環境を自動生成するトリガー）
- マージ先は `main`

### `render.yaml` にプレビュー有効期限を設定

```yaml
previews:
  generation: automatic
  expireAfterDays: 1
```

プレビュー環境の有効期限を1日に設定。最新コミットがpushされるたびにタイマーがリセットされる。

## 参考

- https://render.com/docs/preview-environments#automatic-expiration

Closes #386