### PR TITLE
feat: プロフィールページのセクションに編集ボタンを追加（issue #404）

### DIFF
--- a/app/components/section_component.html.erb
+++ b/app/components/section_component.html.erb
@@ -1,7 +1,12 @@
 <section class="mt-8 mb-12">
-  <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-500 mb-6 border-b border-zinc-200 dark:border-zinc-800 pb-2">
-    <%= @section.name %>
-  </h2>
+  <div class="flex items-center justify-between mb-6 border-b border-zinc-200 dark:border-zinc-800 pb-2">
+    <h2 class="text-xs font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-500">
+      <%= @section.name %>
+    </h2>
+    <% if @admin %>
+      <%= link_to "Edit", edit_admin_section_path(@section), class: "text-xs font-medium text-slate-400 hover:text-indigo-500 transition-colors" %>
+    <% end %>
+  </div>
 
   <div class="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed wiki-content">
     <% if @section.markdown.present? %>

--- a/app/components/section_component.rb
+++ b/app/components/section_component.rb
@@ -5,8 +5,9 @@ class SectionComponent < ViewComponent::Base
   include ApplicationHelper
   with_collection_parameter :section
 
-  def initialize(section:)
+  def initialize(section:, admin: false)
     super()
     @section = section
+    @admin = admin
   end
 end

--- a/app/views/admin/sections/edit.html.erb
+++ b/app/views/admin/sections/edit.html.erb
@@ -1,4 +1,18 @@
 <div class="container mx-auto px-2 py-4 max-w-4xl">
-  <h1 class="text-2xl font-bold mb-6 dark:text-white">セクション編集: <%= @section.name %></h1>
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold dark:text-white">セクション編集: <%= @section.name %></h1>
+    <% if @section.discarded? %>
+      <%= button_to "復元",
+            undiscard_admin_section_path(@section),
+            method: :patch,
+            class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-green-700 bg-green-100 hover:bg-green-200 dark:text-green-300 dark:bg-green-900/50 dark:hover:bg-green-900 rounded-md transition-colors" %>
+    <% else %>
+      <%= button_to "削除",
+            admin_section_path(@section),
+            method: :delete,
+            onclick: "return confirm('本当に削除しますか？')",
+            class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-100 hover:bg-red-200 dark:text-red-300 dark:bg-red-900/50 dark:hover:bg-red-900 rounded-md transition-colors" %>
+    <% end %>
+  </div>
   <%= render "form", section: @section, sectionable: @sectionable %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -100,8 +100,8 @@
             <% end %>
           <% end %>
 
-          <% if @resource.sections.exists? %>
-            <%= render SectionComponent.with_collection(@resource.sections.order(:sort_order)) %>
+          <% if @resource.sections.kept.exists? %>
+            <%= render SectionComponent.with_collection(@resource.sections.kept.order(:sort_order), admin: defined?(logged_in?) && logged_in?) %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- adminユーザー向けに、プロフィールページのセクション表示に編集リンクを追加
- `SectionComponent` に `admin:` パラメータを追加し、admin 時にセクションヘッダーへ Edit リンクを表示
- `profiles/show.html.erb` で `.kept` スコープを使用し、削除済みセクションを非表示に修正
- セクション編集画面に論理削除ボタン（削除済みの場合は復元ボタン）を追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] adminでログイン時、プロフィールページのセクションに「Edit」リンクが表示されること
- [ ] 非ログイン時、「Edit」リンクが表示されないこと
- [ ] 論理削除したセクションがプロフィールページに表示されないこと
- [ ] セクション編集画面から「削除」ボタンで論理削除できること
- [ ] 削除済みセクションの編集画面に「復元」ボタンが表示されること

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)