### PR TITLE
feat: Claude Code スキル（merge-pr / release-pr）を追加

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: merge-pr
+description: mainブランチの最新タグを元に、feat/merge-{release_tag} ブランチを切ってdevelopへのPRを作成する
+---
+
+# Merge PR 作成
+
+以下の手順を **そのまま実行** してください。確認や提案は不要です。
+
+## 手順
+
+1. origin から最新情報を取得し、最新の release タグを取得する
+   ```
+   git fetch origin --tags
+   git tag --sort=-creatordate | head -1
+   ```
+   - タグは `v0.YYYY.MMDD` 形式（例: `v0.2026.0303`）
+   - ブランチ名用に先頭の `v` を除いた文字列を使う（例: `0.2026.0303`）
+
+2. `main` ブランチを最新化する
+   ```
+   git checkout main
+   git pull origin main
+   ```
+
+3. `feat/merge-{release_tag}` ブランチを作成する（main ベース）
+   ```
+   git checkout -b feat/merge-<release_tag>
+   ```
+
+4. リモートに push する
+   ```
+   git push origin feat/merge-<release_tag>
+   ```
+
+5. PR を作成する（ベースブランチは `develop`）
+   ```
+   gh pr create --base develop --title "feat/merge-<release_tag>" --body "## Merge release <release_tag> into develop"
+   ```
+
+6. 作成した PR の URL をユーザーに表示する

--- a/.claude/skills/release-pr/SKILL.md
+++ b/.claude/skills/release-pr/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: release-pr
+description: developブランチから release/0.yyyy.mmdd ブランチを切ってpushし、PRを作成する
+---
+
+# Release PR 作成
+
+以下の手順を **そのまま実行** してください。確認や提案は不要です。
+
+## 手順
+
+1. 今日の日付を取得して、ブランチ名を決定する
+   - フォーマット: `release/0.YYYY.MMDD`（例: `release/0.2026.0227`）
+   - Bash で `date +%Y.%m%d` を実行して取得する
+
+2. `develop` ブランチに切り替えて最新化する
+   ```
+   git checkout develop
+   git pull origin develop
+   ```
+
+3. リリースブランチを作成する
+   ```
+   git checkout -b release/0.<date>
+   ```
+
+4. リモートにpushする
+   ```
+   git push origin release/0.<date>
+   ```
+
+5. PRを作成する（ベースブランチは `main`）
+   ```
+   gh pr create --base main --title "release/0.<date>" --body "## Release 0.<date>"
+   ```
+
+6. 作成したPRのURLをユーザーに表示する


### PR DESCRIPTION
## 概要

Claude Code で使用するカスタムスキルを追加します。

- **merge-pr**: mainブランチの最新タグを元に `feat/merge-{release_tag}` ブランチを切って develop への PR を作成するスキル
- **release-pr**: develop ブランチから `release/0.yyyy.mmdd` ブランチを切って push し、PR を作成するスキル

🤖 Generated with [Claude Code](https://claude.com/claude-code)