### PR TITLE
feat: 個人情報・プロフィールセクションのcategoryプラグインを除去してインポート

### DIFF
--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -50,6 +50,13 @@ class BaseWikipageImporter
     @wiki_content = @wiki_content&.lines&.reject { |line| line.strip.start_with?('//') }&.join
   end
 
+  def strip_category_plugin(section_name, content)
+    return content unless SECTIONS_STRIP_CATEGORY_PLUGIN.any? { |prefix| section_name.start_with?(prefix) }
+
+    content = content.gsub(/\{\{category\s+[^}]*\}\}/i, '')
+    content.lines.reject { |line| line.strip.match?(/\A[*-]+\z/) }.join.strip
+  end
+
   def parse_youtube_tags(owner)
     return unless @wiki_content
 
@@ -276,11 +283,7 @@ class BaseWikipageImporter
 
       next if is_excluded
 
-      # 「個人情報」「プロフィール」セクションは categoryプラグインを除去
-      if SECTIONS_STRIP_CATEGORY_PLUGIN.any? { |prefix| section_name.start_with?(prefix) }
-        section_content = section_content.gsub(/\{\{category\s+[^}]*\}\}/i, '')
-        section_content = section_content.lines.reject { |line| line.strip.match?(/\A[*\-]+\z/) }.join.strip
-      end
+      section_content = strip_category_plugin(section_name, section_content)
 
       # wiki_text が空の場合は除外
       next if section_content.blank?


### PR DESCRIPTION
## Summary
- `個人情報`・`プロフィール` セクションのインポート時に `{{category ...}}` プラグイン記法を除去するよう対応
- 除去後に `*` や `-` のみの行も合わせて削除
- `個人情報` を除外セクションリストから外し、categoryプラグインを除去したうえでインポート対象に変更

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 個人情報・プロフィールセクションを持つwikipageをインポートし、categoryプラグインが除去されて保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)