### PR TITLE
feat: 経歴インポート時にtweetプラグインを除去する

### DIFF
--- a/app/services/base_wikipage_importer.rb
+++ b/app/services/base_wikipage_importer.rb
@@ -57,6 +57,14 @@ class BaseWikipageImporter
     content.lines.reject { |line| line.strip.match?(/\A[*-]+\z/) }.join.strip
   end
 
+  def strip_career_plugins(content)
+    return content if content.nil?
+
+    CAREER_STRIP_PLUGINS.reduce(content) do |text, plugin|
+      text.gsub(/\{\{#{Regexp.escape(plugin)}\s+[^}]*\}\}/i, '')
+    end
+  end
+
   def parse_youtube_tags(owner)
     return unless @wiki_content
 
@@ -247,6 +255,9 @@ class BaseWikipageImporter
 
   # categoryプラグインを除去するセクション名（前方一致）
   SECTIONS_STRIP_CATEGORY_PLUGIN = %w[個人情報 プロフィール].freeze
+
+  # 経歴テキストから除去するプラグイン名
+  CAREER_STRIP_PLUGINS = %w[tweet tweets].freeze
 
   def parse_sections(owner)
     return unless @wiki_content

--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -237,7 +237,7 @@ class PersonImporter < BaseWikipageImporter
   def parse_career_history(person)
     return unless @wiki_content =~ /!!経歴\s*\n(.+?)(?=\n!!|\z)/m
 
-    career_section = Regexp.last_match(1).strip
+    career_section = strip_career_plugins(Regexp.last_match(1).strip)
     person.old_history = career_section
     person.save!
 

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -347,7 +347,7 @@ class WikipageImporter < BaseWikipageImporter
       old_member_key = parts[2]
       sns_account = parts[3]
 
-      inline_history = inline_history_text&.strip
+      inline_history = strip_career_plugins(inline_history_text&.strip)
       inline_history = nil if inline_history.blank?
 
       part_str = part_str&.strip


### PR DESCRIPTION
## Summary

- `CAREER_STRIP_PLUGINS = %w[tweet tweets].freeze` 定数を `BaseWikipageImporter` に追加
- `strip_career_plugins` メソッドを実装し、定数に列挙したプラグインを一括除去
- 個人ページの経歴（`PersonImporter#parse_career_history`）に適用
- ユニットページのメンバーインライン経歴（`WikipageImporter#parse_members`）に適用

## Test plan

- [ ] `tweet` / `tweets` プラグインを含む経歴を持つ個人ページを再インポートし、`old_history` に残らないことを確認
- [ ] ユニットページのメンバーの `inline_history` に tweet プラグインが含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)