### PR TITLE
perf: Redisキャッシュにデフォルトexpires_inを設定しメモリ蓄積を防止 (#444)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,7 @@ Rails.application.configure do
 
   config.cache_store = :redis_cache_store, {
     url: ENV['REDIS_URL'],
+    expires_in: 1.hour,
     error_handler: lambda { |method:, exception:, returning: nil| # rubocop:disable Lint/UnusedBlockArgument
       Rails.logger.error "RedisCache error (#{method}): #{exception.class}: #{exception.message}"
     }


### PR DESCRIPTION
## Summary

- `config/environments/production.rb` の `redis_cache_store` に `expires_in: 1.hour` を追加
- Render.com 無料プランのRedisは容量が限られており、TTLなしのキャッシュが蓄積し続けるとメモリ不足になる
- `UnitGraphBuilder` など個別に `expires_in` を指定している箇所はそちらが優先されるため影響なし

Closes #444

## Test plan

- [ ] テスト71件すべてパス済み
- [ ] デプロイ後、Redisメモリ使用量が安定することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)