### PR TITLE
feat: 年表に任意バンド追加・Trendマーカー強調・ViewComponent化

### DIFF
--- a/app/components/timeline_row_component.html.erb
+++ b/app/components/timeline_row_component.html.erb
@@ -1,0 +1,53 @@
+<div class="group flex border-b border-zinc-200 dark:border-zinc-700"
+     data-start-year="<%= earliest_year %>"
+     data-row-type="<%= row_type %>">
+  <!-- バンド名（横スクロール固定） -->
+  <div class="flex-shrink-0 px-3 py-2 flex items-center
+              sticky left-0 z-10 bg-zinc-50 dark:bg-zinc-950
+              group-hover:bg-zinc-100 dark:group-hover:bg-zinc-900
+              border-r border-zinc-200 dark:border-zinc-700 transition-colors"
+       style="width: <%= TimelineRowComponent::NAME_COL_W %>px;">
+    <%= link_to @unit.name, profile_path(@unit.key),
+          class: "text-sm font-semibold text-indigo-600 dark:text-indigo-200 hover:underline truncate block w-full",
+          title: @unit.name %>
+  </div>
+  <!-- ガントバー + Trendマーカー -->
+  <div class="relative flex-shrink-0 bg-white dark:bg-zinc-950
+              group-hover:bg-zinc-50 dark:group-hover:bg-zinc-900 transition-colors"
+       style="width: <%= chart_width %>px; height: 36px; <%= row_grid_style %>">
+    <%# 活動期間バー %>
+    <% @unit.activity_periods.each do |period| %>
+      <% from_year = parse_year(period.from) %>
+      <% next unless from_year %>
+      <% to_year   = parse_year(period.to) || @year_max %>
+      <% from_year = clamp_year(from_year, @year_min, @year_max) %>
+      <% to_year   = clamp_year(to_year,   @year_min, @year_max) %>
+      <% next if from_year > to_year %>
+      <div class="absolute rounded transition-opacity"
+           style="background-color: <%= bar_color %>; left: <%= bar_left(from_year) %>px; width: <%= bar_width(from_year, to_year) %>px; top: 10px; height: 16px; opacity: 0.85;"
+           data-tooltip="<%= @unit.name %>&#10;<%= period.from %> 〜 <%= period.to.presence || '現在' %>"
+           data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
+           role="img"
+           aria-label="<%= @unit.name %> 活動期間: <%= period.from %> 〜 <%= period.to.presence || '現在' %>">
+      </div>
+    <% end %>
+    <%# Trendマーカー（縦線）%>
+    <% markers_for_unit.each do |marker| %>
+      <% next unless marker[:year] >= @year_min && marker[:year] <= @year_max %>
+      <% is_debut = debut_marker?(marker) %>
+      <div class="absolute"
+           data-marker-type="<%= is_debut ? 'debut' : 'trend' %>"
+           style="left: <%= marker_x(marker) %>px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: default; display: flex; align-items: center; justify-content: center;"
+           data-tooltip="<%= @unit.name %>&#10;<%= marker[:title] %>（<%= marker[:date] %>）"
+           data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
+           role="img"
+           aria-label="<%= @unit.name %> <%= marker[:title] %>: <%= marker[:date] %>">
+        <% if is_debut %>
+          <span style="display: block; width: 6px; height: 28px; background-color: #f59e0b; border-radius: 1px; pointer-events: none;"></span>
+        <% else %>
+          <span style="display: block; width: 4px; height: 24px; background-color: #fb7185; border-radius: 1px; pointer-events: none;"></span>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/timeline_row_component.rb
+++ b/app/components/timeline_row_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class TimelineRowComponent < ViewComponent::Base
+  with_collection_parameter :unit
+
+  YEAR_PX    = 24
+  NAME_COL_W = 176
+
+  def initialize(unit:, year_min:, year_max:, debut_markers:)
+    super()
+    @unit          = unit
+    @year_min      = year_min
+    @year_max      = year_max
+    @debut_markers = debut_markers
+  end
+
+  def chart_width   = (@year_max - @year_min + 1) * YEAR_PX
+  def grid_span     = YEAR_PX * 5
+  def five_year_offset = (5 - @year_min % 5) % 5 * YEAR_PX
+
+  def row_grid_style
+    "background-image: repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px); " \
+      "background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
+  end
+
+  def tag_names           = @unit.tag_index_items.map { |ti| ti.tag_index.name }
+  def has_major_disbanded = tag_names.include?('メジャーで解散')
+  def bar_color           = has_major_disbanded ? '#a855f7' : '#3b82f6'
+  def row_type            = has_major_disbanded ? 'major-disbanded' : 'major'
+
+  def earliest_year
+    @unit.activity_periods.filter_map { |p| parse_year(p.from) }.min || 9999
+  end
+
+  def markers_for_unit
+    @debut_markers[@unit.id] || []
+  end
+
+  def bar_left(from_year)  = (from_year - @year_min) * YEAR_PX
+  def bar_width(from_year, to_year) = [((to_year - from_year + 1) * YEAR_PX), YEAR_PX / 2].max
+
+  def marker_x(marker)
+    (@year_min == 0 ? 0 : (marker[:year] - @year_min)) * YEAR_PX +
+      ((marker[:month] || 1) - 1) * YEAR_PX / 12
+  end
+
+  def debut_marker?(marker)
+    marker[:debut] || marker[:title].to_s.include?('メジャーデビュー')
+  end
+
+  def clamp_year(year, min, max) = [[year, min].max, max].min
+  def parse_year(str)
+    return nil if str.blank?
+
+    str.to_s.split('/').first.to_i.then { |y| y >= 1970 ? y : nil }
+  end
+end

--- a/app/components/timeline_row_component.rb
+++ b/app/components/timeline_row_component.rb
@@ -14,19 +14,20 @@ class TimelineRowComponent < ViewComponent::Base
     @debut_markers = debut_markers
   end
 
-  def chart_width   = (@year_max - @year_min + 1) * YEAR_PX
-  def grid_span     = YEAR_PX * 5
+  def chart_width      = (@year_max - @year_min + 1) * YEAR_PX
+  def grid_span        = YEAR_PX * 5
   def five_year_offset = (5 - @year_min % 5) % 5 * YEAR_PX
 
   def row_grid_style
-    "background-image: repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px); " \
-      "background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
+    gradient = "repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, " \
+               "rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px)"
+    "background-image: #{gradient}; background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
   end
 
-  def tag_names           = @unit.tag_index_items.map { |ti| ti.tag_index.name }
-  def has_major_disbanded = tag_names.include?('メジャーで解散')
-  def bar_color           = has_major_disbanded ? '#a855f7' : '#3b82f6'
-  def row_type            = has_major_disbanded ? 'major-disbanded' : 'major'
+  def tag_names = @unit.tag_index_items.map { |ti| ti.tag_index.name }
+  def major_disbanded? = tag_names.include?('メジャーで解散')
+  def bar_color      = major_disbanded? ? '#a855f7' : '#3b82f6'
+  def row_type       = major_disbanded? ? 'major-disbanded' : 'major'
 
   def earliest_year
     @unit.activity_periods.filter_map { |p| parse_year(p.from) }.min || 9999
@@ -36,11 +37,11 @@ class TimelineRowComponent < ViewComponent::Base
     @debut_markers[@unit.id] || []
   end
 
-  def bar_left(from_year)  = (from_year - @year_min) * YEAR_PX
-  def bar_width(from_year, to_year) = [((to_year - from_year + 1) * YEAR_PX), YEAR_PX / 2].max
+  def bar_left(from_year)            = (from_year - @year_min) * YEAR_PX
+  def bar_width(from_year, to_year)  = [((to_year - from_year + 1) * YEAR_PX), YEAR_PX / 2].max
 
   def marker_x(marker)
-    (@year_min == 0 ? 0 : (marker[:year] - @year_min)) * YEAR_PX +
+    (@year_min.zero? ? 0 : (marker[:year] - @year_min)) * YEAR_PX +
       ((marker[:month] || 1) - 1) * YEAR_PX / 12
   end
 
@@ -49,6 +50,7 @@ class TimelineRowComponent < ViewComponent::Base
   end
 
   def clamp_year(year, min, max) = [[year, min].max, max].min
+
   def parse_year(str)
     return nil if str.blank?
 

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -53,7 +53,7 @@ class TimelineController < ApplicationController
           uid = u['unit_id'].to_i
           next unless unit_id_set.include?(uid)
 
-          (debut_markers[uid] ||= []) << { year: trend.date.year, date: trend.date.to_s, title: trend.title }
+          (debut_markers[uid] ||= []) << { year: trend.date.year, month: trend.date.month, date: trend.date.to_s, title: strip_wiki_links(trend.title), debut: trend.title.include?('メジャーデビュー') }
         end
       end
 
@@ -79,19 +79,20 @@ class TimelineController < ApplicationController
     markers = []
     Trend.where(active: true).select(:id, :date, :title, :units).each do |trend|
       (trend.units || []).each do |u|
-        markers << { year: trend.date.year, date: trend.date.to_s, title: trend.title } if u['unit_id'].to_i == unit.id
+        markers << { year: trend.date.year, month: trend.date.month, date: trend.date.to_s, title: strip_wiki_links(trend.title), debut: trend.title.include?('メジャーデビュー') } if u['unit_id'].to_i == unit.id
       end
     end
 
-    render partial: 'row', locals: {
-      unit:,
-      year_min:,
-      year_max:,
-      debut_markers: { unit.id => markers }
-    }
+    render TimelineRowComponent.new(unit: unit, year_min: year_min, year_max: year_max, debut_markers: { unit.id => markers })
   end
 
   private
+
+  # Wiki記法リンクをラベルテキストに置換 [[A|B]]→A, [A|B]→A, [[A]]→A
+  def strip_wiki_links(str)
+    str.gsub(/\[{1,2}([^|\]]+)(?:\|[^\]]+)?\]{1,2}/, '\1')
+  end
+  helper_method :strip_wiki_links
 
   # 1970年未満は不正データとみなして nil を返す
   def parse_year(str)

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -68,6 +68,32 @@ class TimelineController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
+  def unit
+    cached = Rails.cache.read(CACHE_KEY)
+    year_min = cached&.dig(:year_min) || Time.current.year
+    year_max = cached&.dig(:year_max) || Time.current.year
+
+    unit = Unit.kept.preload(tag_index_items: :tag_index).find_by(key: params[:key])
+    return head :not_found unless unit
+
+    debut_trends = Trend.where('title LIKE ?', '%メジャーデビュー%')
+                        .where(active: true)
+                        .select(:id, :date, :title, :units)
+    markers = []
+    debut_trends.each do |trend|
+      (trend.units || []).each do |u|
+        markers << { year: trend.date.year, date: trend.date.to_s, title: trend.title } if u['unit_id'].to_i == unit.id
+      end
+    end
+
+    render partial: 'row', locals: {
+      unit:,
+      year_min:,
+      year_max:,
+      debut_markers: { unit.id => markers }
+    }
+  end
+
   private
 
   # 1970年未満は不正データとみなして nil を返す

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -76,11 +76,8 @@ class TimelineController < ApplicationController
     unit = Unit.kept.preload(tag_index_items: :tag_index).find_by(key: params[:key])
     return head :not_found unless unit
 
-    debut_trends = Trend.where('title LIKE ?', '%メジャーデビュー%')
-                        .where(active: true)
-                        .select(:id, :date, :title, :units)
     markers = []
-    debut_trends.each do |trend|
+    Trend.where(active: true).select(:id, :date, :title, :units).each do |trend|
       (trend.units || []).each do |u|
         markers << { year: trend.date.year, date: trend.date.to_s, title: trend.title } if u['unit_id'].to_i == unit.id
       end

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -53,7 +53,10 @@ class TimelineController < ApplicationController
           uid = u['unit_id'].to_i
           next unless unit_id_set.include?(uid)
 
-          (debut_markers[uid] ||= []) << { year: trend.date.year, month: trend.date.month, date: trend.date.to_s, title: strip_wiki_links(trend.title), debut: trend.title.include?('メジャーデビュー') }
+          (debut_markers[uid] ||= []) << {
+            year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
+            title: strip_wiki_links(trend.title), debut: trend.title.include?('メジャーデビュー')
+          }
         end
       end
 
@@ -79,7 +82,12 @@ class TimelineController < ApplicationController
     markers = []
     Trend.where(active: true).select(:id, :date, :title, :units).each do |trend|
       (trend.units || []).each do |u|
-        markers << { year: trend.date.year, month: trend.date.month, date: trend.date.to_s, title: strip_wiki_links(trend.title), debut: trend.title.include?('メジャーデビュー') } if u['unit_id'].to_i == unit.id
+        next unless u['unit_id'].to_i == unit.id
+
+        markers << {
+          year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
+          title: strip_wiki_links(trend.title), debut: trend.title.include?('メジャーデビュー')
+        }
       end
     end
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -39,3 +39,6 @@ application.register("unit-graph", UnitGraphController)
 
 import TimelineController from "controllers/timeline_controller"
 application.register("timeline", TimelineController)
+
+import TimelineSearchController from "controllers/timeline_search_controller"
+application.register("timeline-search", TimelineSearchController)

--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -3,8 +3,12 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["header", "body", "tooltip"]
 
+  static LEGEND_STORAGE_KEY = "timeline_hidden_types"
+
   connect() {
-    this.hiddenTypes = new Set()
+    const saved = JSON.parse(localStorage.getItem(this.constructor.LEGEND_STORAGE_KEY) || "[]")
+    this.hiddenTypes = new Set(saved)
+    this._restoreLegend()
   }
 
   toggleType(event) {
@@ -18,6 +22,15 @@ export default class extends Controller {
       item.classList.add("opacity-40", "line-through")
     }
     this._applyVisibility(type)
+    localStorage.setItem(this.constructor.LEGEND_STORAGE_KEY, JSON.stringify([...this.hiddenTypes]))
+  }
+
+  _restoreLegend() {
+    this.hiddenTypes.forEach(type => {
+      this._applyVisibility(type)
+      const btn = this.element.querySelector(`[data-type='${type}']`)
+      if (btn) btn.classList.add("opacity-40", "line-through")
+    })
   }
 
   _applyVisibility(type) {

--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -22,15 +22,9 @@ export default class extends Controller {
 
   _applyVisibility(type) {
     const hidden = this.hiddenTypes.has(type)
-    if (type === "debut") {
-      this.bodyTarget.querySelectorAll("[data-marker-type='debut']").forEach(el => {
-        el.classList.toggle("hidden", hidden)
-      })
-    } else {
-      this.bodyTarget.querySelectorAll(`[data-row-type='${type}']`).forEach(row => {
-        row.classList.toggle("hidden", hidden)
-      })
-    }
+    this.bodyTarget.querySelectorAll(`[data-row-type='${type}']`).forEach(row => {
+      row.classList.toggle("hidden", hidden)
+    })
   }
 
   syncHeader() {

--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -3,6 +3,36 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["header", "body", "tooltip"]
 
+  connect() {
+    this.hiddenTypes = new Set()
+  }
+
+  toggleType(event) {
+    const item = event.currentTarget
+    const type = item.dataset.type
+    if (this.hiddenTypes.has(type)) {
+      this.hiddenTypes.delete(type)
+      item.classList.remove("opacity-40", "line-through")
+    } else {
+      this.hiddenTypes.add(type)
+      item.classList.add("opacity-40", "line-through")
+    }
+    this._applyVisibility(type)
+  }
+
+  _applyVisibility(type) {
+    const hidden = this.hiddenTypes.has(type)
+    if (type === "debut") {
+      this.bodyTarget.querySelectorAll("[data-marker-type='debut']").forEach(el => {
+        el.classList.toggle("hidden", hidden)
+      })
+    } else {
+      this.bodyTarget.querySelectorAll(`[data-row-type='${type}']`).forEach(row => {
+        row.classList.toggle("hidden", hidden)
+      })
+    }
+  }
+
   syncHeader() {
     this.headerTarget.scrollLeft = this.bodyTarget.scrollLeft
   }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -123,7 +123,19 @@ export default class extends Controller {
         bar.style.backgroundColor = "#22c55e"
       })
       const nameCell = row.querySelector("div[style*='width']")
-      if (nameCell) nameCell.style.backgroundColor = "rgba(34,197,94,0.12)"
+      if (nameCell) {
+        nameCell.style.backgroundColor = "rgba(34,197,94,0.12)"
+        const btn = document.createElement("button")
+        btn.type = "button"
+        btn.textContent = "✕"
+        btn.setAttribute("aria-label", "行を削除")
+        btn.className = "flex-shrink-0 ml-1 text-xs text-zinc-400 hover:text-red-500 leading-none"
+        btn.addEventListener("click", () => {
+          this.addedKeys.delete(key)
+          row.remove()
+        })
+        nameCell.appendChild(btn)
+      }
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -3,12 +3,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["input", "suggestions"]
 
+  static STORAGE_KEY = "timeline_added_bands"
+
   connect() {
     this.debounceTimer = null
     this.addedKeys = new Set()
     this.selectedIndex = -1
     this.handleClickOutside = this._onClickOutside.bind(this)
     document.addEventListener("click", this.handleClickOutside)
+    this._restoreFromStorage()
   }
 
   disconnect() {
@@ -110,6 +113,7 @@ export default class extends Controller {
       const rows = document.getElementById("timeline-rows")
       if (!rows) return
       this.addedKeys.add(key)
+      this._saveToStorage()
       const tmp = document.createElement("div")
       tmp.innerHTML = html.trim()
       const row = tmp.firstElementChild
@@ -132,6 +136,7 @@ export default class extends Controller {
         btn.className = "flex-shrink-0 ml-1 text-xs text-zinc-400 hover:text-red-500 leading-none"
         btn.addEventListener("click", () => {
           this.addedKeys.delete(key)
+          this._saveToStorage()
           row.remove()
         })
         nameCell.appendChild(btn)
@@ -162,5 +167,14 @@ export default class extends Controller {
 
   _onClickOutside(event) {
     if (!this.element.contains(event.target)) this.hideSuggestions()
+  }
+
+  _saveToStorage() {
+    localStorage.setItem(this.constructor.STORAGE_KEY, JSON.stringify([...this.addedKeys]))
+  }
+
+  _restoreFromStorage() {
+    const saved = JSON.parse(localStorage.getItem(this.constructor.STORAGE_KEY) || "[]")
+    saved.forEach(key => this.addUnit(key, key))
   }
 }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -124,7 +124,7 @@ export default class extends Controller {
       })
       const nameCell = row.querySelector("div[style*='width']")
       if (nameCell) {
-        nameCell.style.backgroundColor = "rgba(34,197,94,0.12)"
+        nameCell.style.backgroundColor = "#dcfce7"
         const btn = document.createElement("button")
         btn.type = "button"
         btn.textContent = "✕"

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -118,9 +118,7 @@ export default class extends Controller {
       const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
       row.scrollIntoView({ behavior: "smooth", block: "center" })
-      row.style.transition = "background-color 1.5s ease"
-      row.style.backgroundColor = "rgba(99,102,241,0.15)"
-      setTimeout(() => { row.style.backgroundColor = "" }, 1500)
+      row.style.borderLeft = "3px solid rgba(99,102,241,0.6)"
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -117,6 +117,7 @@ export default class extends Controller {
       const startYear = parseInt(row.dataset.startYear, 10)
       const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
+      row.scrollIntoView({ behavior: "smooth", block: "center" })
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -118,6 +118,9 @@ export default class extends Controller {
       const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
       row.scrollIntoView({ behavior: "smooth", block: "center" })
+      row.style.transition = "background-color 1.5s ease"
+      row.style.backgroundColor = "rgba(99,102,241,0.15)"
+      setTimeout(() => { row.style.backgroundColor = "" }, 1500)
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -119,8 +119,11 @@ export default class extends Controller {
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
       row.scrollIntoView({ behavior: "smooth", block: "center" })
       row.dataset.rowType = "added"
+      row.querySelectorAll("div.absolute.rounded").forEach(bar => {
+        bar.style.backgroundColor = "#22c55e"
+      })
       const nameCell = row.querySelector("div[style*='width']")
-      if (nameCell) nameCell.style.backgroundColor = "rgba(99,102,241,0.12)"
+      if (nameCell) nameCell.style.backgroundColor = "rgba(34,197,94,0.12)"
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -118,7 +118,8 @@ export default class extends Controller {
       const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
       row.scrollIntoView({ behavior: "smooth", block: "center" })
-      row.style.borderLeft = "3px solid rgba(99,102,241,0.6)"
+      const nameCell = row.querySelector("div[style*='width']")
+      if (nameCell) nameCell.style.backgroundColor = "rgba(99,102,241,0.12)"
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -1,0 +1,144 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "suggestions"]
+
+  connect() {
+    this.debounceTimer = null
+    this.addedKeys = new Set()
+    this.selectedIndex = -1
+    this.handleClickOutside = this._onClickOutside.bind(this)
+    document.addEventListener("click", this.handleClickOutside)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.handleClickOutside)
+    clearTimeout(this.debounceTimer)
+  }
+
+  suggest() {
+    clearTimeout(this.debounceTimer)
+    const q = this.inputTarget.value.trim()
+    if (q.length < 2) {
+      this.hideSuggestions()
+      return
+    }
+    this.debounceTimer = setTimeout(() => this.fetchSuggestions(q), 200)
+  }
+
+  keydown(event) {
+    if (this.suggestionsTarget.classList.contains("hidden")) return
+    const items = this.suggestionsTarget.querySelectorAll("li[data-key]")
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        this.selectedIndex = Math.min(this.selectedIndex + 1, items.length - 1)
+        this.updateActive(items)
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this.selectedIndex = Math.max(this.selectedIndex - 1, 0)
+        this.updateActive(items)
+        break
+      case "Enter":
+        event.preventDefault()
+        if (this.selectedIndex >= 0 && items[this.selectedIndex]) {
+          items[this.selectedIndex].click()
+        }
+        break
+      case "Escape":
+        this.hideSuggestions()
+        break
+    }
+  }
+
+  async fetchSuggestions(q) {
+    const searchUrl = this.inputTarget.dataset.searchUrl
+    try {
+      const res = await fetch(`${searchUrl}?q=${encodeURIComponent(q)}`, {
+        headers: { "Accept": "application/json" }
+      })
+      if (!res.ok) return
+      const units = await res.json()
+      this.renderSuggestions(units)
+    } catch (e) {
+      console.error("timeline-search fetchSuggestions error:", e)
+    }
+  }
+
+  renderSuggestions(units) {
+    this.selectedIndex = -1
+    if (!units.length) {
+      this.hideSuggestions()
+      return
+    }
+
+    this.suggestionsTarget.innerHTML = units.map(u => {
+      const already = this.addedKeys.has(u.key)
+      const cls = already ? "opacity-50 cursor-default" : "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-700"
+      const badge = already ? `<span class="text-xs text-zinc-400 whitespace-nowrap">追加済み</span>` : ""
+      return `<li data-key="${this.esc(u.key)}" class="px-3 py-2 flex items-center justify-between gap-2 ${cls}">
+                <span class="truncate text-zinc-900 dark:text-zinc-100">${this.esc(u.name)}</span>${badge}
+              </li>`
+    }).join("")
+
+    this.suggestionsTarget.querySelectorAll("li[data-key]").forEach(li => {
+      if (!this.addedKeys.has(li.dataset.key)) {
+        li.addEventListener("click", () => {
+          const name = li.querySelector("span").textContent.trim()
+          this.addUnit(li.dataset.key, name)
+        })
+      }
+    })
+    this.suggestionsTarget.classList.remove("hidden")
+  }
+
+  async addUnit(key, name) {
+    this.hideSuggestions()
+    this.inputTarget.value = ""
+    const unitUrl = this.inputTarget.dataset.unitUrl
+    try {
+      const res = await fetch(`${unitUrl}?key=${encodeURIComponent(key)}`, {
+        headers: { "Accept": "text/html" }
+      })
+      if (!res.ok) {
+        alert(`「${name}」の追加に失敗しました`)
+        return
+      }
+      const html = await res.text()
+      const rows = document.getElementById("timeline-rows")
+      if (!rows) return
+      this.addedKeys.add(key)
+      const tmp = document.createElement("div")
+      tmp.innerHTML = html.trim()
+      const row = tmp.firstElementChild
+      if (row) rows.appendChild(row)
+    } catch (e) {
+      console.error("timeline-search addUnit error:", e)
+    }
+  }
+
+  hideSuggestions() {
+    this.suggestionsTarget.classList.add("hidden")
+    this.suggestionsTarget.innerHTML = ""
+    this.selectedIndex = -1
+  }
+
+  updateActive(items) {
+    items.forEach((li, i) => {
+      li.classList.toggle("bg-zinc-100", i === this.selectedIndex)
+      li.classList.toggle("dark:bg-zinc-700", i === this.selectedIndex)
+    })
+  }
+
+  esc(text) {
+    const div = document.createElement("div")
+    div.textContent = String(text)
+    return div.innerHTML
+  }
+
+  _onClickOutside(event) {
+    if (!this.element.contains(event.target)) this.hideSuggestions()
+  }
+}

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -118,6 +118,7 @@ export default class extends Controller {
       const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
       row.scrollIntoView({ behavior: "smooth", block: "center" })
+      row.dataset.rowType = "added"
       const nameCell = row.querySelector("div[style*='width']")
       if (nameCell) nameCell.style.backgroundColor = "rgba(99,102,241,0.12)"
     } catch (e) {

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -4,6 +4,7 @@ export default class extends Controller {
   static targets = ["input", "suggestions"]
 
   static STORAGE_KEY = "timeline_added_bands"
+  static HTML_CACHE_PREFIX = "timeline_unit_html_"
 
   connect() {
     this.debounceTimer = null
@@ -97,19 +98,24 @@ export default class extends Controller {
     this.suggestionsTarget.classList.remove("hidden")
   }
 
-  async addUnit(key, name) {
+  async addUnit(key, name, { scroll = true } = {}) {
     this.hideSuggestions()
     this.inputTarget.value = ""
     const unitUrl = this.inputTarget.dataset.unitUrl
     try {
-      const res = await fetch(`${unitUrl}?key=${encodeURIComponent(key)}`, {
-        headers: { "Accept": "text/html" }
-      })
-      if (!res.ok) {
-        alert(`「${name}」の追加に失敗しました`)
-        return
+      const cacheKey = this.constructor.HTML_CACHE_PREFIX + key
+      let html = sessionStorage.getItem(cacheKey)
+      if (!html) {
+        const res = await fetch(`${unitUrl}?key=${encodeURIComponent(key)}`, {
+          headers: { "Accept": "text/html" }
+        })
+        if (!res.ok) {
+          alert(`「${name}」の追加に失敗しました`)
+          return
+        }
+        html = await res.text()
+        sessionStorage.setItem(cacheKey, html)
       }
-      const html = await res.text()
       const rows = document.getElementById("timeline-rows")
       if (!rows) return
       this.addedKeys.add(key)
@@ -121,7 +127,7 @@ export default class extends Controller {
       const startYear = parseInt(row.dataset.startYear, 10)
       const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
-      row.scrollIntoView({ behavior: "smooth", block: "center" })
+      if (scroll) row.scrollIntoView({ behavior: "smooth", block: "center" })
       row.dataset.rowType = "added"
       row.querySelectorAll("div.absolute.rounded").forEach(bar => {
         bar.style.backgroundColor = "#22c55e"
@@ -137,6 +143,7 @@ export default class extends Controller {
         btn.addEventListener("click", () => {
           this.addedKeys.delete(key)
           this._saveToStorage()
+          sessionStorage.removeItem(this.constructor.HTML_CACHE_PREFIX + key)
           row.remove()
         })
         nameCell.appendChild(btn)
@@ -175,6 +182,6 @@ export default class extends Controller {
 
   _restoreFromStorage() {
     const saved = JSON.parse(localStorage.getItem(this.constructor.STORAGE_KEY) || "[]")
-    saved.forEach(key => this.addUnit(key, key))
+    saved.forEach(key => this.addUnit(key, key, { scroll: false }))
   }
 }

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -113,7 +113,10 @@ export default class extends Controller {
       const tmp = document.createElement("div")
       tmp.innerHTML = html.trim()
       const row = tmp.firstElementChild
-      if (row) rows.appendChild(row)
+      if (!row) return
+      const startYear = parseInt(row.dataset.startYear, 10)
+      const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
+      after ? rows.insertBefore(row, after) : rows.appendChild(row)
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }

--- a/app/views/timeline/_row.html.erb
+++ b/app/views/timeline/_row.html.erb
@@ -1,0 +1,60 @@
+<%
+  year_px     = 20
+  chart_width = (year_max - year_min + 1) * year_px
+  name_col_w  = 176
+  grid_span        = year_px * 5
+  five_year_offset = (5 - year_min % 5) % 5 * year_px
+  row_grid_style   = "background-image: repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px); background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
+
+  tag_names           = unit.tag_index_items.map { |ti| ti.tag_index.name }
+  has_major_disbanded = tag_names.include?('メジャーで解散')
+  bar_color           = has_major_disbanded ? '#a855f7' : '#3b82f6'
+%>
+<div class="group flex border-b border-zinc-200 dark:border-zinc-700">
+  <!-- バンド名（横スクロール固定） -->
+  <div class="flex-shrink-0 px-3 py-2 flex items-center
+              sticky left-0 z-10 bg-zinc-50 dark:bg-zinc-950
+              group-hover:bg-zinc-100 dark:group-hover:bg-zinc-900
+              border-r border-zinc-200 dark:border-zinc-700 transition-colors"
+       style="width: <%= name_col_w %>px;">
+    <%= link_to unit.name, profile_path(unit.key),
+          class: "text-sm font-semibold text-indigo-600 dark:text-indigo-200 hover:underline truncate block w-full",
+          title: unit.name %>
+  </div>
+  <!-- ガントバー + デビューマーカー -->
+  <div class="relative flex-shrink-0 bg-white dark:bg-zinc-950
+              group-hover:bg-zinc-50 dark:group-hover:bg-zinc-900 transition-colors"
+       style="width: <%= chart_width %>px; height: 36px; <%= row_grid_style %>">
+    <%# 活動期間バー %>
+    <% unit.activity_periods.each do |period| %>
+      <% from_year = parse_year(period.from) %>
+      <% next unless from_year %>
+      <% to_year   = parse_year(period.to) || year_max %>
+      <% from_year = [from_year, year_min].max %>
+      <% to_year   = [to_year,   year_max].min %>
+      <% next if from_year > to_year %>
+      <% bar_left  = (from_year - year_min) * year_px %>
+      <% bar_width = [((to_year - from_year + 1) * year_px), year_px / 2].max %>
+      <div class="absolute rounded transition-opacity"
+           style="background-color: <%= bar_color %>; left: <%= bar_left %>px; width: <%= bar_width %>px; top: 10px; height: 16px; opacity: 0.85;"
+           data-tooltip="<%= unit.name %>&#10;<%= period.from %> 〜 <%= period.to.presence || '現在' %>"
+           data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
+           role="img"
+           aria-label="<%= unit.name %> 活動期間: <%= period.from %> 〜 <%= period.to.presence || '現在' %>">
+      </div>
+    <% end %>
+    <%# メジャーデビューマーカー（縦線）%>
+    <% (debut_markers[unit.id] || []).each do |marker| %>
+      <% next unless marker[:year] >= year_min && marker[:year] <= year_max %>
+      <% mx = (marker[:year] - year_min) * year_px + year_px / 2 %>
+      <div class="absolute"
+           style="left: <%= mx %>px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: default; display: flex; align-items: center; justify-content: center;"
+           data-tooltip="<%= unit.name %>&#10;<%= marker[:title] %>（<%= marker[:date] %>）"
+           data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
+           role="img"
+           aria-label="<%= unit.name %> <%= marker[:title] %>: <%= marker[:date] %>">
+        <span style="display: block; width: 6px; height: 28px; background-color: #f59e0b; border-radius: 1px; pointer-events: none;"></span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/timeline/_row.html.erb
+++ b/app/views/timeline/_row.html.erb
@@ -11,7 +11,9 @@
   bar_color           = has_major_disbanded ? '#a855f7' : '#3b82f6'
   earliest_year       = unit.activity_periods.filter_map { |p| parse_year(p.from) }.min || 9999
 %>
-<div class="group flex border-b border-zinc-200 dark:border-zinc-700" data-start-year="<%= earliest_year %>">
+<div class="group flex border-b border-zinc-200 dark:border-zinc-700"
+     data-start-year="<%= earliest_year %>"
+     data-row-type="<%= has_major_disbanded ? 'major-disbanded' : 'major' %>">
   <!-- バンド名（横スクロール固定） -->
   <div class="flex-shrink-0 px-3 py-2 flex items-center
               sticky left-0 z-10 bg-zinc-50 dark:bg-zinc-950
@@ -49,6 +51,7 @@
       <% next unless marker[:year] >= year_min && marker[:year] <= year_max %>
       <% mx = (marker[:year] - year_min) * year_px + year_px / 2 %>
       <div class="absolute"
+           data-marker-type="debut"
            style="left: <%= mx %>px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: default; display: flex; align-items: center; justify-content: center;"
            data-tooltip="<%= unit.name %>&#10;<%= marker[:title] %>（<%= marker[:date] %>）"
            data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"

--- a/app/views/timeline/_row.html.erb
+++ b/app/views/timeline/_row.html.erb
@@ -9,8 +9,9 @@
   tag_names           = unit.tag_index_items.map { |ti| ti.tag_index.name }
   has_major_disbanded = tag_names.include?('メジャーで解散')
   bar_color           = has_major_disbanded ? '#a855f7' : '#3b82f6'
+  earliest_year       = unit.activity_periods.filter_map { |p| parse_year(p.from) }.min || 9999
 %>
-<div class="group flex border-b border-zinc-200 dark:border-zinc-700">
+<div class="group flex border-b border-zinc-200 dark:border-zinc-700" data-start-year="<%= earliest_year %>">
   <!-- バンド名（横スクロール固定） -->
   <div class="flex-shrink-0 px-3 py-2 flex items-center
               sticky left-0 z-10 bg-zinc-50 dark:bg-zinc-950

--- a/app/views/timeline/_row.html.erb
+++ b/app/views/timeline/_row.html.erb
@@ -1,5 +1,5 @@
 <%
-  year_px     = 20
+  year_px     = 24
   chart_width = (year_max - year_min + 1) * year_px
   name_col_w  = 176
   grid_span        = year_px * 5
@@ -46,18 +46,23 @@
            aria-label="<%= unit.name %> 活動期間: <%= period.from %> 〜 <%= period.to.presence || '現在' %>">
       </div>
     <% end %>
-    <%# メジャーデビューマーカー（縦線）%>
+    <%# Trendマーカー（縦線）%>
     <% (debut_markers[unit.id] || []).each do |marker| %>
       <% next unless marker[:year] >= year_min && marker[:year] <= year_max %>
-      <% mx = (marker[:year] - year_min) * year_px + year_px / 2 %>
+      <% mx = (marker[:year] - year_min) * year_px + ((marker[:month] || 1) - 1) * year_px / 12 %>
+      <% is_debut = marker[:debut] || marker[:title].to_s.include?('メジャーデビュー') %>
       <div class="absolute"
-           data-marker-type="debut"
+           data-marker-type="<%= is_debut ? 'debut' : 'trend' %>"
            style="left: <%= mx %>px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: default; display: flex; align-items: center; justify-content: center;"
            data-tooltip="<%= unit.name %>&#10;<%= marker[:title] %>（<%= marker[:date] %>）"
            data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
            role="img"
            aria-label="<%= unit.name %> <%= marker[:title] %>: <%= marker[:date] %>">
-        <span style="display: block; width: 6px; height: 28px; background-color: #f59e0b; border-radius: 1px; pointer-events: none;"></span>
+        <% if is_debut %>
+          <span style="display: block; width: 6px; height: 28px; background-color: #f59e0b; border-radius: 1px; pointer-events: none;"></span>
+        <% else %>
+          <span style="display: block; width: 4px; height: 24px; background-color: #fb7185; border-radius: 1px; pointer-events: none;"></span>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -46,7 +46,7 @@
             data-type="added"
             aria-pressed="false"
             title="クリックで表示切替">
-      <span class="inline-block w-6 h-4 rounded" style="background-color: rgba(99,102,241,0.5);" aria-hidden="true"></span>
+      <span class="inline-block w-6 h-4 rounded" style="background-color: #22c55e;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">任意追加バンド</span>
     </button>
   </div>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -15,21 +15,35 @@
     <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">メジャーデビュー・メジャーで解散したバンドの活動時期</p>
   </div>
 
-  <!-- 凡例 -->
+  <!-- 凡例（クリックで表示切替） -->
   <div class="flex flex-wrap gap-4 mb-3 text-sm" role="note" aria-label="凡例">
-    <div class="flex items-center gap-2">
+    <button type="button"
+            class="flex items-center gap-2 cursor-pointer select-none transition-opacity"
+            data-action="click->timeline#toggleType"
+            data-type="major"
+            aria-pressed="false"
+            title="クリックで表示切替">
       <span class="inline-block w-6 h-4 rounded" style="background-color: #3b82f6;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">メジャー</span>
-    </div>
-    <div class="flex items-center gap-2">
+    </button>
+    <button type="button"
+            class="flex items-center gap-2 cursor-pointer select-none transition-opacity"
+            data-action="click->timeline#toggleType"
+            data-type="major-disbanded"
+            aria-pressed="false"
+            title="クリックで表示切替">
       <span class="inline-block w-6 h-4 rounded" style="background-color: #a855f7;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">メジャーで解散</span>
-    </div>
-
-    <div class="flex items-center gap-2">
+    </button>
+    <button type="button"
+            class="flex items-center gap-2 cursor-pointer select-none transition-opacity"
+            data-action="click->timeline#toggleType"
+            data-type="debut"
+            aria-pressed="false"
+            title="クリックで表示切替">
       <span class="inline-block" style="width: 3px; height: 16px; background-color: #f59e0b; border-radius: 1px;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">メジャーデビュー</span>
-    </div>
+    </button>
   </div>
 
   <!-- バンド追加検索 -->

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -40,6 +40,15 @@
       <span class="inline-block" style="width: 3px; height: 16px; background-color: #f59e0b; border-radius: 1px;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">メジャーデビュー</span>
     </div>
+    <button type="button"
+            class="flex items-center gap-2 cursor-pointer select-none transition-opacity"
+            data-action="click->timeline#toggleType"
+            data-type="added"
+            aria-pressed="false"
+            title="クリックで表示切替">
+      <span class="inline-block w-6 h-4 rounded" style="background-color: rgba(99,102,241,0.5);" aria-hidden="true"></span>
+      <span class="text-zinc-600 dark:text-zinc-400">任意追加バンド</span>
+    </button>
   </div>
 
   <!-- バンド追加検索 -->

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "年表 - メジャーバンド | Vkdby" %>
 
 <%
-  year_px          = 20    # 1年あたりのピクセル幅
+  year_px          = 24    # 1年あたりのピクセル幅
   chart_width      = (@year_max - @year_min + 1) * year_px
   name_col_w       = 176   # w-44 = 11rem = 176px
   grid_span        = year_px * 5   # 5年分のピクセル幅
@@ -125,9 +125,7 @@
          data-timeline-target="body"
          data-action="scroll->timeline#syncHeader"
          id="timeline-rows">
-      <% @units.each do |unit| %>
-        <%= render 'row', unit: unit, year_min: @year_min, year_max: @year_max, debut_markers: @debut_markers %>
-      <% end %>
+      <%= render TimelineRowComponent.with_collection(@units, year_min: @year_min, year_max: @year_max, debut_markers: @debut_markers) %>
     </div>
 
   </div>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -32,6 +32,31 @@
     </div>
   </div>
 
+  <!-- バンド追加検索 -->
+  <div class="mb-3 relative" data-controller="timeline-search">
+    <div class="flex gap-2">
+      <div class="relative flex-1 max-w-xs">
+        <input type="text"
+               placeholder="バンドを追加..."
+               autocomplete="off"
+               data-unit-url="<%= timeline_unit_path %>"
+               data-search-url="<%= search_units_path %>"
+               class="w-full px-3 py-1.5 text-sm border border-zinc-300 dark:border-zinc-600 rounded
+                      bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100
+                      placeholder-zinc-400 dark:placeholder-zinc-500
+                      focus:outline-none focus:ring-2 focus:ring-indigo-500"
+               data-timeline-search-target="input"
+               data-action="input->timeline-search#suggest keydown->timeline-search#keydown">
+        <!-- サジェストドロップダウン -->
+        <ul class="hidden absolute z-20 mt-1 w-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700
+                   rounded shadow-lg text-sm max-h-60 overflow-y-auto"
+            data-timeline-search-target="suggestions"
+            role="listbox"></ul>
+      </div>
+    </div>
+    <p class="mt-1 text-xs text-zinc-400 dark:text-zinc-500">追加したバンドはページをリロードすると消えます</p>
+  </div>
+
   <%#
     横スクロール同期:
     - #timeline-header: overflow-x:hidden + JS で scrollLeft を追随
@@ -39,7 +64,9 @@
     - ページ自体が縦スクロール（コンテナに height 制限なし）
     - ヘッダ行は sticky top-16 でビューポートに固定
   %>
-  <div data-controller="timeline" class="rounded border border-zinc-200 dark:border-zinc-700">
+  <div data-controller="timeline"
+       id="timeline-widget"
+       class="rounded border border-zinc-200 dark:border-zinc-700">
 
     <!-- カスタムツールチップ -->
     <div data-timeline-target="tooltip"
@@ -78,62 +105,10 @@
     <!-- データ行（横スクロール + バンド名列固定） -->
     <div class="overflow-x-auto"
          data-timeline-target="body"
-         data-action="scroll->timeline#syncHeader">
+         data-action="scroll->timeline#syncHeader"
+         id="timeline-rows">
       <% @units.each do |unit| %>
-        <%
-          tag_names = unit.tag_index_items.map { |ti| ti.tag_index.name }
-          has_major           = tag_names.include?('メジャー')
-          has_major_disbanded = tag_names.include?('メジャーで解散')
-          bar_color = has_major_disbanded ? '#a855f7' : '#3b82f6'
-        %>
-        <div class="group flex border-b border-zinc-200 dark:border-zinc-700">
-          <!-- バンド名（横スクロール固定） -->
-          <div class="flex-shrink-0 px-3 py-2 flex items-center
-                      sticky left-0 z-10 bg-zinc-50 dark:bg-zinc-950
-                      group-hover:bg-zinc-100 dark:group-hover:bg-zinc-900
-                      border-r border-zinc-200 dark:border-zinc-700 transition-colors"
-               style="width: <%= name_col_w %>px;">
-            <%= link_to unit.name, profile_path(unit.key),
-                  class: "text-sm font-semibold text-indigo-600 dark:text-indigo-200 hover:underline truncate block w-full",
-                  title: unit.name %>
-          </div>
-          <!-- ガントバー + デビューマーカー -->
-          <div class="relative flex-shrink-0 bg-white dark:bg-zinc-950
-                      group-hover:bg-zinc-50 dark:group-hover:bg-zinc-900 transition-colors"
-               style="width: <%= chart_width %>px; height: 36px; <%= grid_style %>">
-            <%# 活動期間バー %>
-            <% unit.activity_periods.each do |period| %>
-              <% from_year = parse_year(period.from) %>
-              <% next unless from_year %>
-              <% to_year   = parse_year(period.to) || @year_max %>
-              <% from_year = [from_year, @year_min].max %>
-              <% to_year   = [to_year,   @year_max].min %>
-              <% next if from_year > to_year %>
-              <% bar_left  = (from_year - @year_min) * year_px %>
-              <% bar_width = [((to_year - from_year + 1) * year_px), year_px / 2].max %>
-              <div class="absolute rounded transition-opacity"
-                   style="background-color: <%= bar_color %>; left: <%= bar_left %>px; width: <%= bar_width %>px; top: 10px; height: 16px; opacity: 0.85;"
-                   data-tooltip="<%= unit.name %>&#10;<%= period.from %> 〜 <%= period.to.presence || '現在' %>"
-                   data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
-                   role="img"
-                   aria-label="<%= unit.name %> 活動期間: <%= period.from %> 〜 <%= period.to.presence || '現在' %>">
-              </div>
-            <% end %>
-            <%# メジャーデビューマーカー（縦線）※バーの上に重ねる %>
-            <% (@debut_markers[unit.id] || []).each do |marker| %>
-              <% next unless marker[:year] >= @year_min && marker[:year] <= @year_max %>
-              <% mx = (marker[:year] - @year_min) * year_px + year_px / 2 %>
-              <div class="absolute"
-                   style="left: <%= mx %>px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: default; display: flex; align-items: center; justify-content: center;"
-                   data-tooltip="<%= unit.name %>&#10;<%= marker[:title] %>（<%= marker[:date] %>）"
-                   data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
-                   role="img"
-                   aria-label="<%= unit.name %> <%= marker[:title] %>: <%= marker[:date] %>">
-                <span style="display: block; width: 6px; height: 28px; background-color: #f59e0b; border-radius: 1px; pointer-events: none;"></span>
-              </div>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'row', unit: unit, year_min: @year_min, year_max: @year_max, debut_markers: @debut_markers %>
       <% end %>
     </div>
 

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -9,7 +9,8 @@
   grid_style       = "background-image: repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px); background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
 %>
 
-<div class="px-0 sm:px-2">
+<div class="px-0 sm:px-2" data-controller="timeline">
+
   <div class="mb-4">
     <h1 class="text-2xl font-bold text-zinc-900 dark:text-zinc-100">年表</h1>
     <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">メジャーデビュー・メジャーで解散したバンドの活動時期</p>
@@ -35,15 +36,10 @@
       <span class="inline-block w-6 h-4 rounded" style="background-color: #a855f7;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">メジャーで解散</span>
     </button>
-    <button type="button"
-            class="flex items-center gap-2 cursor-pointer select-none transition-opacity"
-            data-action="click->timeline#toggleType"
-            data-type="debut"
-            aria-pressed="false"
-            title="クリックで表示切替">
+    <div class="flex items-center gap-2">
       <span class="inline-block" style="width: 3px; height: 16px; background-color: #f59e0b; border-radius: 1px;" aria-hidden="true"></span>
       <span class="text-zinc-600 dark:text-zinc-400">メジャーデビュー</span>
-    </button>
+    </div>
   </div>
 
   <!-- バンド追加検索 -->
@@ -78,8 +74,7 @@
     - ページ自体が縦スクロール（コンテナに height 制限なし）
     - ヘッダ行は sticky top-16 でビューポートに固定
   %>
-  <div data-controller="timeline"
-       id="timeline-widget"
+  <div id="timeline-widget"
        class="rounded border border-zinc-200 dark:border-zinc-700">
 
     <!-- カスタムツールチップ -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
 
   # Timeline
   get 'timeline', to: 'timeline#index'
+  get 'timeline/unit', to: 'timeline#unit'
 
   # Cross-search
   get 'search', to: 'search#index'


### PR DESCRIPTION
## Summary
- 年表に任意バンドを検索して一時追加する機能を実装（localStorage永続化・sessionStorageキャッシュ）
- メジャーデビューTrendをamber太線、その他をrose細線で視覚的に区別
- Trendマーカーの横位置に月を反映（1年=24px）
- Wiki記法リンク（`[[A|B]]`等）をツールチップでラベルテキストに変換
- 凡例の表示状態をlocalStorageに保存・復元
- `_row.html.erb` パーシャルを `TimelineRowComponent`（ViewComponent）に移行し `with_collection` でレンダリング

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 年表ページが正常に表示されること
- [ ] バンド検索・追加・削除が動作すること
- [ ] ページリロード後に追加バンド・凡例状態が復元されること
- [ ] メジャーデビューマーカーがamber色、その他のTrendマーカーがrose色で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)