### PR TITLE
feat: ユニットの activity_period 編集機能を追加

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -114,7 +114,8 @@ module Admin
       params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key, :note,
                                    links_attributes: %i[id text url active sort_order _destroy],
                                    name_logs_attributes: %i[name name_kana],
-                                   aliases_attributes: %i[name kana])
+                                   aliases_attributes: %i[name kana],
+                                   activity_periods_attributes: %i[from to label])
     end
   end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -76,6 +76,12 @@ class Unit < ApplicationRecord
     (activity_period || []).map { |h| OpenStruct.new(h) }
   end
 
+  def activity_periods_attributes=(attributes)
+    self.activity_period = attributes.values.reject { |a| a['from'].blank? && a['to'].blank? }.map do |a|
+      { 'from' => a['from'].presence, 'to' => a['to'].presence, 'label' => a['label'].presence }
+    end
+  end
+
   def name_logs_attributes=(attributes)
     self.name_log = attributes.values.map do |attrs|
       next if attrs['name'].blank?

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -101,6 +101,33 @@
   </div>
 
   <div>
+    <h3 class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">活動時期 (Activity Period)</h3>
+    <div class="space-y-4">
+      <%
+        periods_for_form = unit.activity_periods
+        periods_for_form << OpenStruct.new(from: "", to: "")
+      %>
+      <%= form.fields_for :activity_periods, periods_for_form do |period_form| %>
+        <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-end">
+          <div class="flex-1 w-full">
+            <%= period_form.label :from, "From", class: "block text-xs font-medium text-gray-700 dark:text-gray-300" %>
+            <%= period_form.text_field :from, placeholder: "例: 2010.01", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+          </div>
+          <div class="flex-1 w-full">
+            <%= period_form.label :to, "To", class: "block text-xs font-medium text-gray-700 dark:text-gray-300" %>
+            <%= period_form.text_field :to, placeholder: "例: 2015.06（活動中なら空欄）", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+          </div>
+          <div class="flex-1 w-full">
+            <%= period_form.label :label, "Label", class: "block text-xs font-medium text-gray-700 dark:text-gray-300" %>
+            <%= period_form.text_field :label, placeholder: "例: 活動休止前", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+          </div>
+        </div>
+      <% end %>
+      <div class="text-xs text-gray-500">※ From・To ともに空の行は保存時に削除されます</div>
+    </div>
+  </div>
+
+  <div>
     <%= form.label :old_wiki_text, "Old Wiki Text", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <%= form.text_area :old_wiki_text, rows: 10, readonly: true, class: "mt-1 block w-full rounded-md border-gray-300 bg-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono text-gray-600 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-400 cursor-not-allowed" %>
     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">移行元のWikiテキスト (Read Only)</p>


### PR DESCRIPTION
## Summary
- Unit モデルに `activity_periods_attributes=` セッターを追加（from / to / label を保存）
- admin ユニット編集フォームに「活動時期」セクションを追加
- strong params に `activity_periods_attributes` を許可

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] admin でユニットを編集し、活動時期の追加・編集・削除が正常に保存されること
- [ ] from・to ともに空の行が保存時に除外されること
- [ ] label を省略した場合も正常に保存されること

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)