### PR TITLE
feat: 年表の活動期間プロットを月単位に変更

### DIFF
--- a/app/components/timeline_row_component.html.erb
+++ b/app/components/timeline_row_component.html.erb
@@ -17,14 +17,10 @@
        style="width: <%= chart_width %>px; height: 36px; <%= row_grid_style %>">
     <%# 活動期間バー %>
     <% @unit.activity_periods.each do |period| %>
-      <% from_year = parse_year(period.from) %>
-      <% next unless from_year %>
-      <% to_year   = parse_year(period.to) || @year_max %>
-      <% from_year = clamp_year(from_year, @year_min, @year_max) %>
-      <% to_year   = clamp_year(to_year,   @year_min, @year_max) %>
-      <% next if from_year > to_year %>
+      <% dims = bar_dimensions(period) %>
+      <% next unless dims %>
       <div class="absolute rounded transition-opacity"
-           style="background-color: <%= bar_color %>; left: <%= bar_left(from_year) %>px; width: <%= bar_width(from_year, to_year) %>px; top: 10px; height: 16px; opacity: 0.85;"
+           style="background-color: <%= bar_color %>; left: <%= dims[:left] %>px; width: <%= dims[:width] %>px; top: 10px; height: 16px; opacity: 0.85;"
            data-tooltip="<%= @unit.name %>&#10;<%= period.from %> 〜 <%= period.to.presence || '現在' %><%= period.label.present? ? " (#{period.label})" : "" %>"
            data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
            role="img"

--- a/app/components/timeline_row_component.rb
+++ b/app/components/timeline_row_component.rb
@@ -20,9 +20,16 @@ class TimelineRowComponent < ViewComponent::Base
   def five_year_offset = (5 - @year_min % 5) % 5 * @year_px
 
   def row_grid_style
-    gradient = "repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, " \
-               "rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px)"
-    "background-image: #{gradient}; background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
+    five_year = "repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, " \
+                "rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px)"
+
+    return "background-image: #{five_year}; background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;" unless @year_px > 24
+
+    one_year = "repeating-linear-gradient(to right, transparent, transparent #{@year_px - 1}px, " \
+               "rgba(113,113,122,0.15) #{@year_px - 1}px, rgba(113,113,122,0.15) #{@year_px}px)"
+    "background-image: #{five_year}, #{one_year}; " \
+    "background-size: #{grid_span}px 100%, #{@year_px}px 100%; " \
+    "background-position: #{five_year_offset}px 0, 0 0;"
   end
 
   def tag_names = @unit.tag_index_items.map { |ti| ti.tag_index.name }
@@ -31,15 +38,44 @@ class TimelineRowComponent < ViewComponent::Base
   def row_type       = major_disbanded? ? 'major-disbanded' : 'major'
 
   def earliest_year
-    @unit.activity_periods.filter_map { |p| parse_year(p.from) }.min || 9999
+    @unit.activity_periods.filter_map do |p|
+      y = parse_year(p.from)
+      y + (parse_month(p.from) - 1) / 12.0 if y
+    end.min || 9999
   end
 
   def markers_for_unit
     @debut_markers[@unit.id] || []
   end
 
-  def bar_left(from_year)            = (from_year - @year_min) * @year_px
-  def bar_width(from_year, to_year)  = [((to_year - from_year + 1) * @year_px), @year_px / 2].max
+  def bar_left(from_year, from_month = 1)
+    months_from_start = (from_year - @year_min) * 12 + (from_month - 1)
+    (months_from_start * @year_px / 12.0).round(2)
+  end
+
+  def bar_width(from_year, from_month, to_year, to_month)
+    start_months = (from_year - @year_min) * 12 + (from_month - 1)
+    end_months   = (to_year   - @year_min) * 12 + to_month
+    width = (end_months - start_months) * @year_px / 12.0
+    [width, @year_px / 2.0].max.round(2)
+  end
+
+  def bar_dimensions(period)
+    from_year = parse_year(period.from)
+    return nil unless from_year
+
+    from_month  = parse_month(period.from)
+    to_year     = parse_year(period.to) || @year_max
+    to_month    = period.to.present? ? parse_month(period.to) : 12
+
+    from_year_c = clamp_year(from_year, @year_min, @year_max)
+    to_year_c   = clamp_year(to_year,   @year_min, @year_max)
+    from_month  = 1  if from_year_c > from_year
+    to_month    = 12 if to_year_c < to_year
+    return nil if from_year_c > to_year_c
+
+    { left: bar_left(from_year_c, from_month), width: bar_width(from_year_c, from_month, to_year_c, to_month) }
+  end
 
   def marker_x(marker)
     (@year_min.zero? ? 0 : (marker[:year] - @year_min)) * @year_px +
@@ -56,5 +92,12 @@ class TimelineRowComponent < ViewComponent::Base
     return nil if str.blank?
 
     str.to_s.split('/').first.to_i.then { |y| y >= 1970 ? y : nil }
+  end
+
+  def parse_month(str)
+    return 1 if str.blank?
+
+    parts = str.to_s.split('/')
+    parts.length >= 2 ? parts[1].to_i.clamp(1, 12) : 1
   end
 end

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -29,10 +29,13 @@ class TimelineController < ApplicationController
       year_min = all_years.min || Time.current.year
       year_max = Time.current.year
 
-      # 活動開始年の昇順でソート（同年はかな順）
+      # 活動開始年月の昇順でソート（同年月はかな順）
       units.sort_by! do |unit|
-        earliest = unit.activity_periods.map { |p| parse_year(p.from) }.compact.min || 9999
-        [earliest, unit.name_kana.to_s]
+        earliest = unit.activity_periods.filter_map do |p|
+          y = parse_year(p.from)
+          [y, parse_month(p.from)] if y
+        end.min || [9999, 1]
+        [*earliest, unit.name_kana.to_s]
       end
 
       # 有効なバーが1本も描けないユニットを除外
@@ -120,4 +123,12 @@ class TimelineController < ApplicationController
     str.to_s.split('/').first.to_i.then { |y| y >= 1970 ? y : nil }
   end
   helper_method :parse_year
+
+  def parse_month(str)
+    return 1 if str.blank?
+
+    parts = str.to_s.split('/')
+    parts.length >= 2 ? parts[1].to_i.clamp(1, 12) : 1
+  end
+  helper_method :parse_month
 end

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -147,8 +147,8 @@ export default class extends Controller {
       tmp.innerHTML = html.trim()
       const row = tmp.firstElementChild
       if (!row) return
-      const startYear = parseInt(row.dataset.startYear, 10)
-      const after = Array.from(rows.children).find(r => parseInt(r.dataset.startYear, 10) > startYear)
+      const startYear = parseFloat(row.dataset.startYear)
+      const after = Array.from(rows.children).find(r => parseFloat(r.dataset.startYear) > startYear)
       after ? rows.insertBefore(row, after) : rows.appendChild(row)
       if (scroll) row.scrollIntoView({ behavior: "smooth", block: "center" })
       row.dataset.rowType = "added"

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -117,7 +117,8 @@
         <div class="relative flex-shrink-0" style="width: <%= chart_width %>px; height: 32px;">
           <% @year_range.each_with_index do |year, i| %>
             <% left = i * year_px %>
-            <% if year % 5 == 0 %>
+            <% show_label = year % 5 == 0 || year_px > 24 %>
+            <% if show_label %>
               <span class="absolute text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap"
                     style="left: <%= left %>px; top: 2px; transform: translateX(-50%);">
                 <%= year %>


### PR DESCRIPTION
## Summary
- `parse_month` を追加し、`"2010/05"` 形式から月を取得
- `bar_left` / `bar_width` を月単位のピクセル計算に変更（`bar_dimensions` ヘルパーに集約）
- `earliest_year` を小数値（例: `2010.42` = 2010年6月）に変更し、JS の挿入ソートも `parseFloat` で月単位に対応
- コントローラーのソートキーを `[year, month, name_kana]` に変更
- 拡大モード（zoom=2）でヘッダーの年ラベルを毎年表示、行背景に1年グリッド線を追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 標準モードで活動期間バーが月単位で描画されること（例: `"2010/06"` 開始のバーが6月分ずれること）
- [ ] 拡大モードで年グリッドと年ラベルが毎年表示されること
- [ ] バンド追加検索で同年のバンドが月順で挿入されること

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)