### PR TITLE
fix: 年表の凡例表示切り替えがリロード後にズレるバグを修正

### DIFF
--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -17,9 +17,11 @@ export default class extends Controller {
     if (this.hiddenTypes.has(type)) {
       this.hiddenTypes.delete(type)
       item.classList.remove("opacity-40", "line-through")
+      item.setAttribute("aria-pressed", "false")
     } else {
       this.hiddenTypes.add(type)
       item.classList.add("opacity-40", "line-through")
+      item.setAttribute("aria-pressed", "true")
     }
     this._applyVisibility(type)
     localStorage.setItem(this.constructor.LEGEND_STORAGE_KEY, JSON.stringify([...this.hiddenTypes]))
@@ -29,7 +31,10 @@ export default class extends Controller {
     this.hiddenTypes.forEach(type => {
       this._applyVisibility(type)
       const btn = this.element.querySelector(`[data-type='${type}']`)
-      if (btn) btn.classList.add("opacity-40", "line-through")
+      if (btn) {
+        btn.classList.add("opacity-40", "line-through")
+        btn.setAttribute("aria-pressed", "true")
+      }
     })
   }
 

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -166,6 +166,8 @@ export default class extends Controller {
         })
       }
       row.dataset.rowType = "added"
+      const hiddenTypes = JSON.parse(localStorage.getItem("timeline_hidden_types") || "[]")
+      if (hiddenTypes.includes("added")) row.classList.add("hidden")
       row.querySelectorAll("div.absolute.rounded").forEach(bar => {
         bar.style.backgroundColor = "#22c55e"
       })


### PR DESCRIPTION
## Summary
- `timeline_search_controller.addUnit()` で行を DOM に追加する際、`timeline_hidden_types` を確認して `added` タイプが非表示設定なら `.hidden` を付与するよう修正（race condition の解消）
- `timeline_controller` の `toggleType()` / `_restoreLegend()` で `aria-pressed` 属性を正しく更新するよう修正

## 背景
`timeline_controller.connect()` が先に実行されて `_restoreLegend()` が `added` 行を非表示にしようとするが、この時点では DOM に存在しない。その後 `timeline_search_controller._restoreFromStorage()` が async で行を追加するが `.hidden` クラスが付かずに表示される。結果として凡例ボタンは「非表示」スタイルなのに実際の行が見えているズレが発生していた。

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 任意追加バンドを追加した状態で「任意追加バンド」凡例を非表示にし、リロード後もズレなく非表示になっていること
- [ ] ズーム切り替え後も凡例の表示状態が正しく復元されること
- [ ] スクリーンリーダーで aria-pressed が表示状態と一致していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)