### PR TITLE
fix: import_old_trendsのダンプファイルを20260320版に更新

### DIFF
--- a/lib/tasks/import_old_trends.rake
+++ b/lib/tasks/import_old_trends.rake
@@ -5,7 +5,7 @@ namespace :import do
   task old_trends: :environment do
     require 'date'
 
-    file_path = Rails.root.join('trends_all_20260201.sql')
+    file_path = Rails.root.join('trends_all_20260320.sql')
     unless File.exist?(file_path)
       puts "File not found: #{file_path}"
       exit


### PR DESCRIPTION
## Summary
- 旧サイトからの再エクスポートファイル `trends_all_20260320.sql` に差し替え
- 旧ダンプ（20260201）では id=1478, 6907 の `target_date` が破損していた（`2008/11/31` → `2008/11/30`、`2018//07/0` → `2018/07/07`）

## Test plan
- [ ] `bundle exec rake import:old_trends` が正常に完了すること
- [ ] id=1478, 6907 の `target_date` が正しい値で保存されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)