### PR TITLE
fix: ユニットメンバーの wiki記法 [[表示名|ページ名]] を正しく解析する

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -435,13 +435,11 @@ class WikipageImporter < BaseWikipageImporter
   def register_old_format_member(unit, part_str, name_str, old_member_key, member_status, order_in_period)
     # rubocop:enable Metrics/ParameterLists
     # "旧名→[[表示名|ページ名]]" 形式: 表示名を name_str、ページ名を old_member_key として取り出す
-    if name_str.include?('[[')
-      if (m = name_str.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/))
-        wiki_page_key = m[2].strip
-        clean = extract_name_from_wiki_link(name_str)
-        name_str = clean.split('→').last.strip
-        old_member_key = wiki_page_key unless old_member_key.present?
-      end
+    if (m = name_str.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/))
+      wiki_page_key = m[2].strip
+      clean = extract_name_from_wiki_link(name_str)
+      name_str = clean.split('→').last.strip
+      old_member_key = wiki_page_key unless old_member_key.present?
     end
 
     if old_member_key.present?

--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -491,12 +491,10 @@ class WikipageImporterV2 < WikipageImporter
 
       # "旧名→[[表示名|ページ名]]" 形式: 表示名を name_str、ページ名を old_member_key として取り出す
       wiki_page_key = nil
-      if name_str.include?('[[')
-        if (m = name_str.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/))
-          wiki_page_key = m[2].strip
-          clean = extract_name_from_wiki_link(name_str)
-          name_str = clean.split('→').last.strip
-        end
+      if (m = name_str.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/))
+        wiki_page_key = m[2].strip
+        clean = extract_name_from_wiki_link(name_str)
+        name_str = clean.split('→').last.strip
       end
 
       old_member_key = URI.encode_www_form_component((wiki_page_key || name_str).encode('EUC-JP'))


### PR DESCRIPTION
## Summary
- `old_member_regex3` にマッチする `旧名→[[表示名|ページ名]]` 形式において、wiki 記法が処理されず `person_name` / `old_person_key` に生の文字列が残るバグを修正
- `[[XXXX|YYYY]]` の XXXX（表示名）を `name_str`（person_name）、YYYY（ページ名）を `old_member_key`（old_person_key）として正しく取り出すよう対応
- `WikipageImporter`（UnitPerson）と `WikipageImporterV2`（SnapshotPerson）の両方に適用

## Test plan
- [ ] `/hinawana` を再インポートして Vocal メンバーの `person_name` が `わたる`、`old_person_key` が `崎山ワタル`（EUC-JP encoded）になることを確認
- [ ] `snapshot_people` も同様に正しく作成されることを確認
- [ ] wiki 記法を含まない通常の `old_member_regex3` ケースに影響がないことを確認

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)