### PR TITLE
fix: 名前パース時に全角スペース（U+3000）を除去する (issue #412)

### DIFF
--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -285,6 +285,11 @@ class PersonImporter < BaseWikipageImporter
     Unit.find_by(old_key: unit_name)
   end
 
+  # String#strip は ASCII 空白のみを除去するため、全角スペース（U+3000）も合わせて除去する
+  def full_strip(str)
+    str.gsub(/\A[\s　]+|[\s　]+\z/, '')
+  end
+
   def extract_name_from_wiki_link(str)
     # Handle [[Display|Link]] or [[Link]]
     if str =~ /\[\[(?:([^|\]]+)\|)?([^\]]+)\]\]/
@@ -318,20 +323,20 @@ class PersonImporter < BaseWikipageImporter
     name_log_entries = []
 
     if first_line&.include?('→')
-      arrow_parts = first_line.split('→').map(&:strip)
+      arrow_parts = first_line.split('→').map { |s| full_strip(s) }
 
       # Extract aliases from the last arrow part (e.g. "新名（よみ）、英語名（えいごな）")
-      last_pieces = arrow_parts.last.to_s.split('、').map(&:strip)
+      last_pieces = arrow_parts.last.to_s.split('、').map { |s| full_strip(s) }
       aliases = parse_alias_parts(last_pieces[1..])
       arrow_parts[-1] = last_pieces.first.to_s if last_pieces.size > 1
 
       parsed_names = arrow_parts.map do |part|
         if part =~ /\{\{rb\s+(.+?),\s*(.+?)\}\}/
-          raw_name = Regexp.last_match(1).strip
-          { name: extract_name_from_wiki_link(raw_name), name_kana: Regexp.last_match(2).strip }
+          raw_name = full_strip(Regexp.last_match(1))
+          { name: extract_name_from_wiki_link(raw_name), name_kana: full_strip(Regexp.last_match(2)) }
         elsif part =~ /^(.+?)\s*[（(](.+)[）)]$/
-          raw_name = Regexp.last_match(1).strip
-          { name: extract_name_from_wiki_link(raw_name), name_kana: Regexp.last_match(2).strip }
+          raw_name = full_strip(Regexp.last_match(1))
+          { name: extract_name_from_wiki_link(raw_name), name_kana: full_strip(Regexp.last_match(2)) }
         else
           { name: extract_name_from_wiki_link(part), name_kana: nil }
         end


### PR DESCRIPTION
## Summary
- `→` 区切りの名前履歴をパースする際、`String#strip` が全角スペース（U+3000）を除去しないため名前の先頭に全角スペースが残る問題を修正
- `full_strip` ヘルパーメソッドを追加し、ASCII 空白と全角スペースの両方を除去するようにした
- 対象箇所: `→` 分割後の各パーツ、`{{rb}}` 記法・`（よみ）` 形式の名前・よみ抽出時

## Test plan
- [ ] `zero-1222`（零）など、`→ 　名前（よみ）` 形式を含む wiki ページを再インポートして名前に全角スペースが含まれないことを確認

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)