### PR TITLE
feat: 年表のTrendマーカーをTrend詳細ページへのリンクにする

### DIFF
--- a/app/components/timeline_row_component.html.erb
+++ b/app/components/timeline_row_component.html.erb
@@ -32,13 +32,14 @@
       <% next unless marker[:year] >= @year_min && marker[:year] <= @year_max %>
       <% is_debut = major_debut_marker?(marker) %>
       <% color = marker_color(marker[:phenomenon]) %>
-      <div class="absolute flex justify-center <%= is_debut ? 'items-start' : 'items-center' %>"
-           data-marker-type="<%= marker[:phenomenon] %>"
-           style="left: <%= marker_x(marker) %>px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: default;"
-           data-tooltip="<%= @unit.name %>&#10;<%= marker[:title] %>（<%= marker[:date] %>）"
-           data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
-           role="img"
-           aria-label="<%= @unit.name %> <%= marker[:title] %>: <%= marker[:date] %>">
+      <%= link_to trend_path(marker[:id]),
+            class: "absolute flex justify-center #{is_debut ? 'items-start' : 'items-center'}",
+            "data-marker-type": marker[:phenomenon],
+            style: "left: #{marker_x(marker)}px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: pointer;",
+            "data-tooltip": "#{@unit.name}\n#{marker[:title]}（#{marker[:date]}）",
+            "data-action": "mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide",
+            role: "link",
+            "aria-label": "#{@unit.name} #{marker[:title]}: #{marker[:date]}" do %>
         <% if is_debut %>
           <span style="display: flex; flex-direction: column; align-items: center; pointer-events: none; padding-top: 2px; height: 34px;">
             <span style="display: block; width: 10px; height: 10px; background-color: <%= color %>; border-radius: 50%; flex-shrink: 0;"></span>
@@ -47,7 +48,7 @@
         <% else %>
           <span style="display: block; width: 4px; height: 24px; background-color: <%= color %>; border-radius: 1px; pointer-events: none;"></span>
         <% end %>
-      </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/ClassLength
 class TimelineController < ApplicationController
   TARGET_TAG_NAMES = %w[メジャー メジャーで解散].freeze
-  CACHE_KEY = 'timeline/major_units/v2'
+  CACHE_KEY = 'timeline/major_units/v3'
   CACHE_TTL = 1.hour
 
   VALID_ZOOMS = { '2' => 48 }.freeze
@@ -70,7 +70,7 @@ class TimelineController < ApplicationController
           next unless unit_id_set.include?(uid)
 
           (trend_markers[uid] ||= []) << {
-            year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
+            id: trend.id, year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
             title: strip_wiki_links(trend.title), phenomenon: trend.unit_phenomenon
           }
         end
@@ -104,7 +104,7 @@ class TimelineController < ApplicationController
         next unless u['unit_id'].to_i == unit.id
 
         markers << {
-          year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
+          id: trend.id, year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
           title: strip_wiki_links(trend.title), phenomenon: trend.unit_phenomenon
         }
       end

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -4,7 +4,7 @@ export default class extends Controller {
   static targets = ["input", "suggestions"]
 
   static STORAGE_KEY = "timeline_added_bands"
-  static HTML_CACHE_PREFIX = "timeline_unit_html_v3_"
+  static HTML_CACHE_PREFIX = "timeline_unit_html_v4_"
 
   connect() {
     this.debounceTimer = null


### PR DESCRIPTION
## Summary

- 年表上のTrendマーカー（縦線）をクリックすると対応するTrend詳細ページ（`/trends/:id`）に遷移するようにした
- `TimelineController` の trend_markers ハッシュに `id` フィールドを追加（`index` / `unit` 両アクション）
- `TimelineRowComponent` のマーカー要素を `<div>` から `link_to trend_path(marker[:id])` に変更
- サーバーサイドキャッシュキーを `v2` → `v3` にバンプ（`id` フィールド追加に伴う無効化）
- JS の `sessionStorage` キャッシュプレフィックスを `v3_` → `v4_` にバンプ（任意追加バンドの古いキャッシュ無効化）

## Test plan

- [ ] 年表を開き、Trendマーカーをクリックして対応するTrend詳細ページに遷移することを確認
- [ ] 任意追加バンドのマーカーも同様にリンクになっていることを確認
- [ ] ホバー時のツールチップが引き続き表示されることを確認
- [ ] 凡例による表示フィルタリングが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)