### PR TITLE
perf: Render メモリ使用量削減（優先度高の設定変更）issue #482

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -78,6 +78,6 @@ test:
 production:
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 2 } %>
   url: <%= ENV["DATABASE_URL"] %>
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.logger   = ActiveSupport::TaggedLogging.logger($stdout)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!).
-  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'warn')
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = '/up'

--- a/render.yaml
+++ b/render.yaml
@@ -22,5 +22,11 @@ services:
           property: connectionString
       - key: RAILS_MASTER_KEY
         sync: false
+      - key: WEB_CONCURRENCY
+        value: 1
+      - key: RAILS_MAX_THREADS
+        value: 2
+      - key: MALLOC_ARENA_MAX
+        value: 2
     region: singapore
     plan: free # Web service has a free tier.


### PR DESCRIPTION
## Summary

- `render.yaml` に `WEB_CONCURRENCY=1`, `RAILS_MAX_THREADS=2`, `MALLOC_ARENA_MAX=2` を追加
- `config/database.yml` の production コネクションプールのデフォルト値を 5→2 に削減（`RAILS_MAX_THREADS` に合わせる）
- `config/environments/production.rb` のデフォルトログレベルを `info`→`warn` に変更

## 背景

issue #482 の対策のうち「優先度高（設定変更のみ）」を実施。参考記事の実績ではこれだけでピークメモリを約 75% 削減（1,907 MB → 476 MB）。

## Test plan

- [ ] Render デプロイ後にメモリ使用量のモニタリングを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)