### PR TITLE
feat: /date/* の年の範囲を 1970〜現在+10年に制限し、範囲外は 404 を返す

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,4 +32,12 @@ class ApplicationController < ActionController::Base
 
     redirect_to login_path, alert: 'ログインしてください'
   end
+
+  def valid_year?(year)
+    year >= 1970 && year <= Date.today.year + 10
+  end
+
+  def render_not_found
+    render file: Rails.root.join('public/404.html'), status: :not_found, layout: false
+  end
 end

--- a/app/controllers/daily_controller.rb
+++ b/app/controllers/daily_controller.rb
@@ -4,6 +4,8 @@ class DailyController < ApplicationController
   def show
     @year_agnostic = params[:year].nil?
 
+    return render_not_found if !@year_agnostic && !valid_year?(params[:year].to_i)
+
     @date = parse_date_params
     return redirect_to root_path, alert: '日付の形式が正しくありません' unless @date
 

--- a/app/controllers/monthly_controller.rb
+++ b/app/controllers/monthly_controller.rb
@@ -2,6 +2,8 @@
 
 class MonthlyController < ApplicationController
   def show
+    return render_not_found unless valid_year?(params[:year].to_i)
+
     @date = parse_date_params
     return redirect_to root_path, alert: '日付の形式が正しくありません' unless @date
 

--- a/app/controllers/yearly_controller.rb
+++ b/app/controllers/yearly_controller.rb
@@ -9,7 +9,7 @@ class YearlyController < ApplicationController
 
   def show
     @year = parse_year_param
-    return redirect_to root_path, alert: '年の形式が正しくありません' unless @year
+    return render_not_found unless @year
 
     @monthly_trend_counts = calculate_monthly_trend_counts(@year)
     @month_unknown_trends = fetch_month_unknown_trends(@year)
@@ -20,7 +20,7 @@ class YearlyController < ApplicationController
 
   def parse_year_param
     year = params[:year].to_i
-    return nil if year <= 0 || year > 9999
+    return nil unless valid_year?(year)
 
     year
   rescue ArgumentError


### PR DESCRIPTION
## Summary
- `/date/:year`・`/date/:year/:month`・`/date/:year/:month/:day` で有効な年の範囲を 1970〜現在の年の10年後に制限
- 範囲外の年にアクセスした場合は `public/404.html` を status 404 で返す（開発・本番どちらでも動作）
- `/date/-/:month/:day`（年を指定しないバースデー形式）はチェック対象外のため従来通り有効
- `ApplicationController` に `valid_year?` および `render_not_found` ヘルパーを追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `/date/1969` `/date/2100` などの範囲外 URL で 404 ページが表示されること
- [ ] `/date/1970` `/date/2026` などの範囲内 URL が正常に表示されること
- [ ] `/date/-/3/22` が引き続き正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)