### PR TITLE
fix: 年表の任意追加バンドが初期表示でズレる問題を修正 (issue #495)

### DIFF
--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -4,7 +4,6 @@ export default class extends Controller {
   static targets = ["input", "suggestions"]
 
   static STORAGE_KEY = "timeline_added_bands"
-  static HTML_CACHE_PREFIX = "timeline_unit_html_v5_"
 
   connect() {
     this.debounceTimer = null
@@ -106,47 +105,23 @@ export default class extends Controller {
     this.suggestionsTarget.classList.remove("hidden")
   }
 
-  get _cacheVersion() {
-    try {
-      const params = new URL(this.inputTarget.dataset.unitUrl, window.location.origin).searchParams
-      return `${params.get("zoom") || "1"}_${params.get("ym") || ""}`
-    } catch {
-      return "1"
-    }
-  }
-
   async addUnit(key, name, { scroll = true } = {}) {
     this.hideSuggestions()
     this.inputTarget.value = ""
     const unitUrl = this.inputTarget.dataset.unitUrl
     try {
-      const cacheKey = this.constructor.HTML_CACHE_PREFIX + this._cacheVersion + "_" + key
-      const fetchHtml = async () => {
+      let html
+      try {
         const url = new URL(unitUrl, window.location.origin)
         url.searchParams.set("key", key)
         const res = await fetch(url.toString(), {
           headers: { "Accept": "text/html" }
         })
         if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
-        return res.text()
-      }
-      let html = sessionStorage.getItem(cacheKey)
-      if (html) {
-        const probe = document.createElement("div")
-        probe.innerHTML = html.trim()
-        if (!probe.firstElementChild?.dataset.startYear) {
-          sessionStorage.removeItem(cacheKey)
-          html = null
-        }
-      }
-      if (!html) {
-        try {
-          html = await fetchHtml()
-          sessionStorage.setItem(cacheKey, html)
-        } catch {
-          alert(`「${name}」の追加に失敗しました`)
-          return
-        }
+        html = await res.text()
+      } catch {
+        alert(`「${name}」の追加に失敗しました`)
+        return
       }
       const rows = document.getElementById("timeline-rows-inner") || document.getElementById("timeline-rows")
       if (!rows) return
@@ -190,7 +165,6 @@ export default class extends Controller {
         btn.addEventListener("click", () => {
           this.addedKeys.delete(key)
           this._saveToStorage()
-          sessionStorage.removeItem(this.constructor.HTML_CACHE_PREFIX + key)
           row.remove()
         })
         nameCell.appendChild(btn)


### PR DESCRIPTION
## Summary

- `timeline_search_controller.js` の `sessionStorage` HTML キャッシュを廃止
- バンド追加のたびにサーバーから HTML を取得するよう変更
- 削除ボタンの壊れた `sessionStorage.removeItem`（バージョン部分が抜けていてヒットしない）も合わせて削除

## 根本原因

1. `unit` アクションのキャッシュ失効時に `year_min` が現在年にフォールバックし、バー位置が全てズレた HTML が生成・キャッシュされた
2. zoom 切り替えでキャッシュキーが変わるため拡大時は再取得され正常に見えていた
3. 削除時のキャッシュ削除キーにバージョン（`_cacheVersion`）が含まれていなかったため実際には削除されていなかった

## Test plan

- [ ] `/timeline` で任意バンドを追加し、標準表示でタイムラインバー・マーカーが正しく表示される
- [ ] 拡大表示でも同様に正常表示される
- [ ] 追加したバンドを削除し、再度追加して正常に表示される
- [ ] ページリロード後に localStorage から復元されたバンドが正常に表示される

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)