### PR TITLE
feat: 年表のズームをCSS変数で制御しサーバーリクエストを削減 (issue #497)

### DIFF
--- a/app/components/timeline_row_component.html.erb
+++ b/app/components/timeline_row_component.html.erb
@@ -14,13 +14,13 @@
   <!-- ガントバー + Trendマーカー -->
   <div class="relative flex-shrink-0 bg-white dark:bg-zinc-950
               group-hover:bg-zinc-50 dark:group-hover:bg-zinc-900 transition-colors"
-       style="width: <%= chart_width %>px; height: 36px; <%= row_grid_style %>">
+       style="width: calc(var(--year-px) * <%= chart_width_factor %>); height: 36px; <%= row_grid_style %>">
     <%# 活動期間バー %>
     <% @unit.activity_periods.each do |period| %>
       <% dims = bar_dimensions(period) %>
       <% next unless dims %>
       <div class="absolute rounded transition-opacity"
-           style="background-color: <%= bar_color %>; left: <%= dims[:left] %>px; width: <%= dims[:width] %>px; top: 10px; height: 16px; opacity: 0.85;"
+           style="background-color: <%= bar_color %>; left: calc(var(--year-px) * <%= dims[:left] %>); width: calc(var(--year-px) * <%= dims[:width] %>); top: 10px; height: 16px; opacity: 0.85;"
            data-tooltip="<%= @unit.name %>&#10;<%= period.from %> 〜 <%= period.to.presence || '現在' %><%= period.label.present? ? " (#{period.label})" : "" %>"
            data-action="mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide"
            role="img"
@@ -35,7 +35,7 @@
       <%= link_to trend_path(marker[:id]),
             class: "absolute flex justify-center #{is_debut ? 'items-start' : 'items-center'}",
             "data-marker-type": marker[:phenomenon],
-            style: "left: #{marker_x(marker)}px; top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: pointer;",
+            style: "left: calc(var(--year-px) * #{marker_x_factor(marker)}); top: 0; width: 12px; height: 36px; transform: translateX(-50%); z-index: 1; cursor: pointer;",
             "data-tooltip": "#{@unit.name}\n#{marker[:title]}（#{marker[:date]}）",
             "data-action": "mouseenter->timeline#show mousemove->timeline#move mouseleave->timeline#hide",
             role: "link",

--- a/app/components/timeline_row_component.rb
+++ b/app/components/timeline_row_component.rb
@@ -3,8 +3,7 @@
 class TimelineRowComponent < ViewComponent::Base
   with_collection_parameter :unit
 
-  DEFAULT_YEAR_PX = 24
-  NAME_COL_W      = 176
+  NAME_COL_W = 176
 
   PHENOMENON_COLORS = {
     'announcement' => '#e879f9',
@@ -23,30 +22,31 @@ class TimelineRowComponent < ViewComponent::Base
     'other' => '#71717a'
   }.freeze
 
-  def initialize(unit:, year_min:, year_max:, trend_markers:, year_px: DEFAULT_YEAR_PX)
+  def initialize(unit:, year_min:, year_max:, trend_markers:)
     super()
     @unit          = unit
     @year_min      = year_min
     @year_max      = year_max
     @trend_markers = trend_markers
-    @year_px       = year_px
   end
 
-  def chart_width      = (@year_max - @year_min + 1) * @year_px
-  def grid_span        = @year_px * 5
-  def five_year_offset = (5 - @year_min % 5) % 5 * @year_px
+  # バー領域の幅係数（年数）
+  def chart_width_factor = @year_max - @year_min + 1
 
+  # 最初の5年グリッドまでのオフセット係数（年数）
+  def five_year_offset_factor = (5 - @year_min % 5) % 5
+
+  # グリッド背景: CSS変数 --year-px に依存、1年グリッドは --year-grid-fine-alpha で制御
   def row_grid_style
-    five_year = "repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, " \
-                "rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px)"
-
-    return "background-image: #{five_year}; background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;" unless @year_px > 24
-
-    one_year = "repeating-linear-gradient(to right, transparent, transparent #{@year_px - 1}px, " \
-               "rgba(113,113,122,0.15) #{@year_px - 1}px, rgba(113,113,122,0.15) #{@year_px}px)"
+    offset    = five_year_offset_factor
+    five_year = 'repeating-linear-gradient(to right, transparent, transparent calc(var(--year-px) * 5 - 2px), ' \
+                'rgba(113,113,122,0.35) calc(var(--year-px) * 5 - 2px), rgba(113,113,122,0.35) calc(var(--year-px) * 5))'
+    one_year  = 'repeating-linear-gradient(to right, transparent, transparent calc(var(--year-px) - 1px), ' \
+                'rgba(113,113,122,var(--year-grid-fine-alpha,0)) calc(var(--year-px) - 1px), ' \
+                'rgba(113,113,122,var(--year-grid-fine-alpha,0)) var(--year-px))'
     "background-image: #{five_year}, #{one_year}; " \
-    "background-size: #{grid_span}px 100%, #{@year_px}px 100%; " \
-    "background-position: #{five_year_offset}px 0, 0 0;"
+    'background-size: calc(var(--year-px) * 5) 100%, var(--year-px) 100%; ' \
+    "background-position: calc(var(--year-px) * #{offset}) 0, 0 0;"
   end
 
   def bar_color = '#3b82f6'
@@ -71,16 +71,18 @@ class TimelineRowComponent < ViewComponent::Base
     marker[:phenomenon].to_s == 'major_debut'
   end
 
-  def bar_left(from_year, from_month = 1)
+  # バー左端の係数（年数単位、year_px を乗じると px になる）
+  def bar_left_factor(from_year, from_month = 1)
     months_from_start = (from_year - @year_min) * 12 + (from_month - 1)
-    (months_from_start * @year_px / 12.0).round(2)
+    (months_from_start / 12.0).round(4)
   end
 
-  def bar_width(from_year, from_month, to_year, to_month)
+  # バー幅の係数（年数単位）
+  def bar_width_factor(from_year, from_month, to_year, to_month)
     start_months = (from_year - @year_min) * 12 + (from_month - 1)
     end_months   = (to_year   - @year_min) * 12 + to_month
-    width = (end_months - start_months) * @year_px / 12.0
-    [width, @year_px / 2.0].max.round(2)
+    factor = (end_months - start_months) / 12.0
+    [factor, 0.5].max.round(4)
   end
 
   def bar_dimensions(period)
@@ -97,12 +99,12 @@ class TimelineRowComponent < ViewComponent::Base
     to_month    = 12 if to_year_c < to_year
     return nil if from_year_c > to_year_c
 
-    { left: bar_left(from_year_c, from_month), width: bar_width(from_year_c, from_month, to_year_c, to_month) }
+    { left: bar_left_factor(from_year_c, from_month), width: bar_width_factor(from_year_c, from_month, to_year_c, to_month) }
   end
 
-  def marker_x(marker)
-    (@year_min.zero? ? 0 : (marker[:year] - @year_min)) * @year_px +
-      ((marker[:month] || 1) - 1) * @year_px / 12
+  # マーカー位置の係数（年数単位）
+  def marker_x_factor(marker)
+    ((marker[:year] - @year_min) + ((marker[:month] || 1) - 1) / 12.0).round(4)
   end
 
   def clamp_year(year, min, max) = [[year, min].max, max].min

--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -92,7 +92,7 @@ class TimelineController < ApplicationController
 
   def unit
     cached = Rails.cache.read(CACHE_KEY)
-    year_min = cached&.dig(:year_min) || Time.current.year
+    year_min = params[:ym].to_i.positive? ? params[:ym].to_i : (cached&.dig(:year_min) || Time.current.year)
     year_max = cached&.dig(:year_max) || Time.current.year
 
     unit = Unit.kept.find_by(key: params[:key])
@@ -113,10 +113,9 @@ class TimelineController < ApplicationController
       end
     end
 
-    year_px = VALID_ZOOMS.fetch(params[:zoom].to_s, DEFAULT_YEAR_PX)
     component = TimelineRowComponent.new(
       unit: unit, year_min: year_min, year_max: year_max,
-      trend_markers: { unit.id => markers }, year_px: year_px
+      trend_markers: { unit.id => markers }
     )
     render component, layout: false
   end

--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -1,9 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["header", "body", "tooltip", "legendContainer", "markerLegend", "toggleAllMarkersBtn", "shareBtn", "shareBtnLabel"]
+  static targets = ["header", "body", "tooltip", "legendContainer", "markerLegend", "toggleAllMarkersBtn", "shareBtn", "shareBtnLabel", "widget", "zoomBtn"]
 
   static LEGEND_STORAGE_KEY = "timeline_hidden_types"
+  static ZOOM_YEAR_PX = { "1": "24px", "2": "48px" }
 
   // major_debut 以外はデフォルト非表示（初回訪問時のみ適用）
   static DEFAULT_HIDDEN_PHENOMENA = [
@@ -31,11 +32,17 @@ export default class extends Controller {
     this._updateToggleAllBtn()
     this._initStickyLegend()
     this._initRowObserver()
+    this._onPopState = (e) => {
+      const zoom = e.state?.zoom || new URLSearchParams(location.search).get("zoom") || "1"
+      this._applyZoom(zoom, false)
+    }
+    window.addEventListener("popstate", this._onPopState)
   }
 
   disconnect() {
     this._legendObserver?.disconnect()
     this._rowObserver?.disconnect()
+    window.removeEventListener("popstate", this._onPopState)
   }
 
   toggleType(event) {
@@ -91,6 +98,51 @@ export default class extends Controller {
     this._updateToggleAllBtn()
     this._fromUrl = false
     localStorage.setItem(this.constructor.LEGEND_STORAGE_KEY, JSON.stringify([...this.hiddenTypes]))
+  }
+
+  setZoom(event) {
+    this._applyZoom(event.currentTarget.dataset.zoomValue, true)
+  }
+
+  _applyZoom(zoom, pushState) {
+    if (!this.hasWidgetTarget) return
+    const widget = this.widgetTarget
+    const yearPx = this.constructor.ZOOM_YEAR_PX[zoom] || "24px"
+
+    widget.style.setProperty("--year-px", yearPx)
+    widget.style.setProperty("--year-grid-fine-alpha", zoom === "2" ? "0.15" : "0")
+    widget.dataset.zoom = zoom
+
+    widget.querySelectorAll(".timeline-year-label-minor").forEach(el => {
+      el.classList.toggle("hidden", zoom !== "2")
+      el.toggleAttribute("aria-hidden", zoom !== "2")
+    })
+
+    if (this.hasZoomBtnTarget) {
+      this.zoomBtnTargets.forEach(btn => {
+        const active = btn.dataset.zoomValue === zoom
+        btn.classList.toggle("bg-indigo-600", active)
+        btn.classList.toggle("border-indigo-600", active)
+        btn.classList.toggle("text-white", active)
+        btn.classList.toggle("font-medium", active)
+        btn.classList.toggle("border-zinc-300", !active)
+        btn.classList.toggle("dark:border-zinc-600", !active)
+        btn.classList.toggle("text-zinc-600", !active)
+        btn.classList.toggle("dark:text-zinc-400", !active)
+        btn.setAttribute("aria-current", active ? "true" : "false")
+      })
+    }
+
+    if (pushState) {
+      const params = new URLSearchParams(location.search)
+      if (zoom === "1") {
+        params.delete("zoom")
+      } else {
+        params.set("zoom", zoom)
+      }
+      const qs = params.toString()
+      history.pushState({ zoom }, "", `${location.pathname}${qs ? "?" + qs : ""}`)
+    }
   }
 
   async share() {

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -4,6 +4,7 @@ export default class extends Controller {
   static targets = ["input", "suggestions"]
 
   static STORAGE_KEY = "timeline_added_bands"
+  static HTML_CACHE_PREFIX = "timeline_unit_html_v6_"
 
   connect() {
     this.debounceTimer = null
@@ -105,23 +106,44 @@ export default class extends Controller {
     this.suggestionsTarget.classList.remove("hidden")
   }
 
+  get _cacheKeyPrefix() {
+    try {
+      const params = new URL(this.inputTarget.dataset.unitUrl, window.location.origin).searchParams
+      return this.constructor.HTML_CACHE_PREFIX + (params.get("ym") || "")
+    } catch {
+      return this.constructor.HTML_CACHE_PREFIX
+    }
+  }
+
   async addUnit(key, name, { scroll = true } = {}) {
     this.hideSuggestions()
     this.inputTarget.value = ""
     const unitUrl = this.inputTarget.dataset.unitUrl
     try {
-      let html
-      try {
-        const url = new URL(unitUrl, window.location.origin)
-        url.searchParams.set("key", key)
-        const res = await fetch(url.toString(), {
-          headers: { "Accept": "text/html" }
-        })
-        if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
-        html = await res.text()
-      } catch {
-        alert(`「${name}」の追加に失敗しました`)
-        return
+      const cacheKey = this._cacheKeyPrefix + "_" + key
+      let html = sessionStorage.getItem(cacheKey)
+      if (html) {
+        const probe = document.createElement("div")
+        probe.innerHTML = html.trim()
+        if (!probe.firstElementChild?.dataset.startYear) {
+          sessionStorage.removeItem(cacheKey)
+          html = null
+        }
+      }
+      if (!html) {
+        try {
+          const url = new URL(unitUrl, window.location.origin)
+          url.searchParams.set("key", key)
+          const res = await fetch(url.toString(), {
+            headers: { "Accept": "text/html" }
+          })
+          if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
+          html = await res.text()
+          sessionStorage.setItem(cacheKey, html)
+        } catch {
+          alert(`「${name}」の追加に失敗しました`)
+          return
+        }
       }
       const rows = document.getElementById("timeline-rows-inner") || document.getElementById("timeline-rows")
       if (!rows) return
@@ -165,6 +187,7 @@ export default class extends Controller {
         btn.addEventListener("click", () => {
           this.addedKeys.delete(key)
           this._saveToStorage()
+          sessionStorage.removeItem(this._cacheKeyPrefix + "_" + key)
           row.remove()
         })
         nameCell.appendChild(btn)

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -8,14 +8,7 @@
 <% content_for :main_px, "px-3 sm:px-6" %>
 <% content_for :main_max_w, "w-full" %>
 
-<%
-  year_px          = @year_px      # 1年あたりのピクセル幅（24 or 48）
-  chart_width      = (@year_max - @year_min + 1) * year_px
-  name_col_w       = 176   # w-44 = 11rem = 176px
-  grid_span        = year_px * 5   # 5年分のピクセル幅
-  five_year_offset = (5 - @year_min % 5) % 5 * year_px  # 最初の5年ラインまでのオフセット
-  grid_style       = "background-image: repeating-linear-gradient(to right, transparent, transparent #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span - 2}px, rgba(113,113,122,0.35) #{grid_span}px); background-size: #{grid_span}px 100%; background-position: #{five_year_offset}px 0;"
-%>
+<% n_years = @year_max - @year_min + 1 %>
 
 <div data-controller="timeline">
 
@@ -27,12 +20,18 @@
     <div class="flex items-center gap-3">
       <div class="flex items-center gap-1 text-sm" role="group" aria-label="表示幅の切り替え">
         <span class="mr-1 text-zinc-500 dark:text-zinc-400 text-xs">表示幅:</span>
-        <%= link_to "標準", timeline_path(zoom: "1"),
-              class: "px-2.5 py-1 rounded border transition-colors #{@zoom == '1' ? 'bg-indigo-600 border-indigo-600 text-white font-medium' : 'border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'}",
-              aria: { current: @zoom == "1" ? "true" : nil } %>
-        <%= link_to "拡大", timeline_path(zoom: "2"),
-              class: "px-2.5 py-1 rounded border transition-colors #{@zoom == '2' ? 'bg-indigo-600 border-indigo-600 text-white font-medium' : 'border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800'}",
-              aria: { current: @zoom == "2" ? "true" : nil } %>
+        <button type="button"
+                data-action="click->timeline#setZoom"
+                data-zoom-value="1"
+                data-timeline-target="zoomBtn"
+                aria-current="<%= @zoom == '1' ? 'true' : nil %>"
+                class="px-2.5 py-1 rounded border transition-colors <%= @zoom == '1' ? 'bg-indigo-600 border-indigo-600 text-white font-medium' : 'border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800' %>">標準</button>
+        <button type="button"
+                data-action="click->timeline#setZoom"
+                data-zoom-value="2"
+                data-timeline-target="zoomBtn"
+                aria-current="<%= @zoom == '2' ? 'true' : nil %>"
+                class="px-2.5 py-1 rounded border transition-colors <%= @zoom == '2' ? 'bg-indigo-600 border-indigo-600 text-white font-medium' : 'border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800' %>">拡大</button>
       </div>
       <button type="button"
               class="flex items-center gap-1.5 px-2.5 py-1 rounded border text-sm border-zinc-300 dark:border-zinc-600 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
@@ -125,7 +124,7 @@
         <input type="text"
                placeholder="バンドを追加..."
                autocomplete="off"
-               data-unit-url="<%= timeline_unit_path(zoom: @zoom == '2' ? '2' : nil, ym: @year_min) %>"
+               data-unit-url="<%= timeline_unit_path(ym: @year_min) %>"
                data-search-url="<%= search_units_path %>"
                class="w-full px-3 py-1.5 text-sm border border-zinc-300 dark:border-zinc-600 rounded
                       bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100
@@ -151,7 +150,11 @@
     - ヘッダ行は sticky top-16 でビューポートに固定
   %>
   <div id="timeline-widget"
-       class="rounded border border-zinc-200 dark:border-zinc-700">
+       class="rounded border border-zinc-200 dark:border-zinc-700"
+       style="--year-px: <%= @year_px %>px; --year-grid-fine-alpha: <%= @year_px > 24 ? '0.15' : '0' %>;"
+       data-zoom="<%= @zoom %>"
+       data-timeline-target="widget"
+       data-year-px-default="<%= @year_px %>">
 
     <!-- カスタムツールチップ -->
     <div data-timeline-target="tooltip"
@@ -165,26 +168,24 @@
         <!-- コーナーセル -->
         <div class="flex-shrink-0 px-3 py-2 text-sm font-medium text-zinc-600 dark:text-zinc-300
                     sticky left-0 z-10 bg-zinc-100 dark:bg-zinc-800 border-r border-zinc-200 dark:border-zinc-700"
-             style="width: var(--timeline-name-col-w, <%= name_col_w %>px);">
+             style="width: var(--timeline-name-col-w, 176px);">
           バンド
         </div>
         <!-- 年ラベル -->
-        <div class="relative flex-shrink-0" style="width: <%= chart_width %>px; height: 32px;">
+        <div class="relative flex-shrink-0" style="width: calc(var(--year-px) * <%= n_years %>); height: 32px;">
           <% @year_range.each_with_index do |year, i| %>
-            <% left = i * year_px %>
-            <% show_label = year % 5 == 0 || year_px > 24 %>
-            <% if show_label %>
-              <span class="absolute text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap"
-                    style="left: <%= left %>px; top: 2px; transform: translateX(-50%);">
-                <%= year %>
-              </span>
-            <% end %>
-            <span class="absolute bottom-0 bg-zinc-300 dark:bg-zinc-600 <%= year % 5 == 0 ? 'h-2 w-px' : 'h-1 w-px' %>"
-                  style="left: <%= left %>px;"
+            <% is_major = year % 5 == 0 %>
+            <span class="absolute text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap <%= is_major ? '' : 'timeline-year-label-minor hidden' %>"
+                  style="left: calc(var(--year-px) * <%= i %>); top: 2px; transform: translateX(-50%);"
+                  <% unless is_major %>aria-hidden="true"<% end %>>
+              <%= year %>
+            </span>
+            <span class="absolute bottom-0 bg-zinc-300 dark:bg-zinc-600 <%= is_major ? 'h-2 w-px' : 'h-1 w-px' %>"
+                  style="left: calc(var(--year-px) * <%= i %>);"
                   aria-hidden="true"></span>
           <% end %>
           <span class="absolute bottom-0 h-2 w-px bg-zinc-300 dark:bg-zinc-600"
-                style="left: <%= chart_width %>px;"
+                style="left: calc(var(--year-px) * <%= n_years %>);"
                 aria-hidden="true"></span>
         </div>
       </div>
@@ -197,8 +198,8 @@
          id="timeline-rows">
       <%# flex行コンテナは親幅に縮小されるため border-b がチャート全幅まで伸びない。
           min-width を明示したラッパーで scrollWidth を固定する。 %>
-      <div id="timeline-rows-inner" style="min-width: calc(var(--timeline-name-col-w, <%= name_col_w %>px) + <%= chart_width %>px);">
-        <%= render TimelineRowComponent.with_collection(@units, year_min: @year_min, year_max: @year_max, trend_markers: @trend_markers, year_px: @year_px) %>
+      <div id="timeline-rows-inner" style="min-width: calc(var(--timeline-name-col-w, 176px) + var(--year-px) * <%= n_years %>);">
+        <%= render TimelineRowComponent.with_collection(@units, year_min: @year_min, year_max: @year_max, trend_markers: @trend_markers) %>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- `TimelineRowComponent` の位置計算を `year_px` 非依存の係数に変更し、`calc(var(--year-px) * N)` 形式で出力
- ズーム切り替えは CSS 変数 `--year-px` の書き換えのみで完結（フルページリロード・サーバーリクエスト不要）
- 任意追加バンドの HTML がズーム非依存になったため sessionStorage キャッシュを復活（v6）
- ズーム状態は URL に `history.pushState` で反映（ブラウザ履歴・共有 URL に対応）
- `unit` アクションから `zoom` パラメータを除去し、`ym` パラメータを `year_min` の優先ソースに変更

## 変更の詳細

| ファイル | 変更内容 |
|---|---|
| `timeline_row_component.rb` | `year_px` パラメータ削除。バー/マーカー位置を係数（年単位）で返すメソッドに変更 |
| `timeline_row_component.html.erb` | ピクセル値 → `calc(var(--year-px) * N)` |
| `index.html.erb` | `#timeline-widget` に `--year-px` CSS 変数をセット、ズームボタンを JS 駆動に変更 |
| `timeline_controller.rb` | `unit` アクションの zoom 除去、`ym` 優先 |
| `timeline_controller.js` | `setZoom` アクション追加、`_applyZoom` で CSS 変数・ボタン状態・URL を更新 |
| `timeline_search_controller.js` | zoom なし、sessionStorage キャッシュ復活（v6、ym ベースのキー） |

## Test plan

- [ ] 標準表示でバー・マーカーが正しい位置に表示される
- [ ] 「拡大」ボタンでズームが切り替わり、リロードなしでバーが2倍幅になる
- [ ] 拡大時に1年グリッド・年ラベルが表示される
- [ ] URL が `?zoom=2` に更新され、ブラウザの戻る/進むが機能する
- [ ] 任意追加バンドが標準・拡大どちらでも正しく表示される
- [ ] ページリロード後も zoom 状態が URL から正しく復元される
- [ ] 共有ボタンが現在の zoom 状態を含む URL を生成する

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)