### PR TITLE
feat: 年表の任意追加バンド復元をバッチリクエストに変更 (issue #499)

### DIFF
--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -120,7 +120,57 @@ class TimelineController < ApplicationController
     render component, layout: false
   end
 
+  def units
+    keys = Array(params[:keys]).first(20)
+    return render json: {} if keys.empty?
+
+    cached = Rails.cache.read(CACHE_KEY)
+    year_min = params[:ym].to_i.positive? ? params[:ym].to_i : (cached&.dig(:year_min) || Time.current.year)
+    year_max = cached&.dig(:year_max) || Time.current.year
+
+    units = Unit.kept.where(key: keys)
+    return render json: {} if units.empty?
+
+    trend_markers = fetch_trend_markers(units.map(&:id))
+
+    result = {}
+    units.each do |u|
+      component = TimelineRowComponent.new(
+        unit: u, year_min: year_min, year_max: year_max,
+        trend_markers: { u.id => trend_markers[u.id] || [] }
+      )
+      result[u.key] = render_to_string(component, layout: false)
+    end
+
+    render json: result
+  end
+
   private
+
+  def fetch_trend_markers(unit_ids)
+    unit_id_set = unit_ids.to_set
+    markers = {}
+    Trend
+      .where(active: true)
+      .where.not(unit_phenomenon: nil)
+      .where(
+        'units @> ANY(ARRAY[?]::jsonb[])',
+        unit_ids.map { |uid| [{ unit_id: uid }].to_json }
+      )
+      .select(:id, :date, :title, :units, :unit_phenomenon)
+      .each do |trend|
+        (trend.units || []).each do |u|
+          uid = u['unit_id'].to_i
+          next unless unit_id_set.include?(uid)
+
+          (markers[uid] ||= []) << {
+            id: trend.id, year: trend.date.year, month: trend.date.month, date: trend.date.to_s,
+            title: strip_wiki_links(trend.title), phenomenon: trend.unit_phenomenon
+          }
+        end
+      end
+    markers
+  end
 
   # Wiki記法リンクをラベルテキストに置換 [[A|B]]→A, [A|B]→A, [[A]]→A
   def strip_wiki_links(str)

--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -32,6 +32,8 @@ export default class extends Controller {
     this._updateToggleAllBtn()
     this._initStickyLegend()
     this._initRowObserver()
+    const initialZoom = this.hasWidgetTarget ? (this.widgetTarget.dataset.zoom || "1") : "1"
+    this._applyZoom(initialZoom, false)
     this._onPopState = (e) => {
       const zoom = e.state?.zoom || new URLSearchParams(location.search).get("zoom") || "1"
       this._applyZoom(zoom, false)

--- a/app/javascript/controllers/timeline_controller.js
+++ b/app/javascript/controllers/timeline_controller.js
@@ -112,7 +112,6 @@ export default class extends Controller {
     const yearPx = this.constructor.ZOOM_YEAR_PX[zoom] || "24px"
 
     widget.style.setProperty("--year-px", yearPx)
-    widget.style.setProperty("--year-grid-fine-alpha", zoom === "2" ? "0.15" : "0")
     widget.dataset.zoom = zoom
 
     widget.querySelectorAll(".timeline-year-label-minor").forEach(el => {

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
     if (urlBands !== null) {
       // URLパラメータあり（共有URL）→ localStorageを上書きせずURLの値で復元
       const keys = urlBands ? urlBands.split(",").filter(Boolean) : []
-      keys.forEach(key => this.addUnit(key, key, { scroll: false }))
+      this._restoreKeys(keys)
     } else {
       this._restoreFromStorage()
     }
@@ -115,28 +115,19 @@ export default class extends Controller {
     }
   }
 
+  // ユーザー操作による1件追加
   async addUnit(key, name, { scroll = true } = {}) {
     this.hideSuggestions()
     this.inputTarget.value = ""
     const unitUrl = this.inputTarget.dataset.unitUrl
     try {
       const cacheKey = this._cacheKeyPrefix + "_" + key
-      let html = sessionStorage.getItem(cacheKey)
-      if (html) {
-        const probe = document.createElement("div")
-        probe.innerHTML = html.trim()
-        if (!probe.firstElementChild?.dataset.startYear) {
-          sessionStorage.removeItem(cacheKey)
-          html = null
-        }
-      }
+      let html = this._getValidCache(cacheKey)
       if (!html) {
         try {
           const url = new URL(unitUrl, window.location.origin)
           url.searchParams.set("key", key)
-          const res = await fetch(url.toString(), {
-            headers: { "Accept": "text/html" }
-          })
+          const res = await fetch(url.toString(), { headers: { "Accept": "text/html" } })
           if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
           html = await res.text()
           sessionStorage.setItem(cacheKey, html)
@@ -145,53 +136,9 @@ export default class extends Controller {
           return
         }
       }
-      const rows = document.getElementById("timeline-rows-inner") || document.getElementById("timeline-rows")
-      if (!rows) return
       this.addedKeys.add(key)
       this._saveToStorage()
-      const tmp = document.createElement("div")
-      tmp.innerHTML = html.trim()
-      const row = tmp.firstElementChild
-      if (!row) return
-      const startYear = parseFloat(row.dataset.startYear)
-      const after = Array.from(rows.children).find(r => parseFloat(r.dataset.startYear) > startYear)
-      after ? rows.insertBefore(row, after) : rows.appendChild(row)
-      if (scroll) {
-        row.scrollIntoView({ behavior: "smooth", block: "center" })
-        requestAnimationFrame(() => {
-          const bars = row.querySelectorAll("div.absolute.rounded")
-          if (!bars.length) return
-          const lefts = Array.from(bars).map(b => {
-            const v = parseFloat(b.style.left)
-            return isNaN(v) ? Infinity : v
-          })
-          const minLeft = Math.min(...lefts)
-          const body = document.getElementById("timeline-rows")
-          if (body && isFinite(minLeft)) body.scrollLeft = Math.max(0, minLeft - 20)
-        })
-      }
-      row.dataset.rowType = "added"
-      const hiddenTypes = JSON.parse(localStorage.getItem("timeline_hidden_types") || "[]")
-      if (hiddenTypes.includes("added")) row.classList.add("hidden")
-      row.querySelectorAll("div.absolute.rounded").forEach(bar => {
-        bar.style.backgroundColor = "#22c55e"
-      })
-      const nameCell = row.querySelector("div[style*='width']")
-      if (nameCell) {
-        nameCell.classList.add("timeline-added-name-cell")
-        const btn = document.createElement("button")
-        btn.type = "button"
-        btn.textContent = "✕"
-        btn.setAttribute("aria-label", "行を削除")
-        btn.className = "flex-shrink-0 ml-1 text-xs text-zinc-400 hover:text-red-500 leading-none"
-        btn.addEventListener("click", () => {
-          this.addedKeys.delete(key)
-          this._saveToStorage()
-          sessionStorage.removeItem(this._cacheKeyPrefix + "_" + key)
-          row.remove()
-        })
-        nameCell.appendChild(btn)
-      }
+      this._insertRow(key, html, { scroll })
     } catch (e) {
       console.error("timeline-search addUnit error:", e)
     }
@@ -224,8 +171,112 @@ export default class extends Controller {
     localStorage.setItem(this.constructor.STORAGE_KEY, JSON.stringify([...this.addedKeys]))
   }
 
+  // キャッシュから HTML を取得。data-start-year がなければ無効とみなしキャッシュ削除
+  _getValidCache(cacheKey) {
+    const html = sessionStorage.getItem(cacheKey)
+    if (!html) return null
+    const probe = document.createElement("div")
+    probe.innerHTML = html.trim()
+    if (!probe.firstElementChild?.dataset.startYear) {
+      sessionStorage.removeItem(cacheKey)
+      return null
+    }
+    return html
+  }
+
+  // DOM への行挿入・スタイル適用・削除ボタン付与
+  _insertRow(key, html, { scroll = false } = {}) {
+    const rows = document.getElementById("timeline-rows-inner") || document.getElementById("timeline-rows")
+    if (!rows) return
+    const tmp = document.createElement("div")
+    tmp.innerHTML = html.trim()
+    const row = tmp.firstElementChild
+    if (!row) return
+
+    const startYear = parseFloat(row.dataset.startYear)
+    const after = Array.from(rows.children).find(r => parseFloat(r.dataset.startYear) > startYear)
+    after ? rows.insertBefore(row, after) : rows.appendChild(row)
+
+    if (scroll) {
+      row.scrollIntoView({ behavior: "smooth", block: "center" })
+      requestAnimationFrame(() => {
+        const bars = row.querySelectorAll("div.absolute.rounded")
+        if (!bars.length) return
+        const lefts = Array.from(bars).map(b => {
+          const v = parseFloat(b.style.left)
+          return isNaN(v) ? Infinity : v
+        })
+        const minLeft = Math.min(...lefts)
+        const body = document.getElementById("timeline-rows")
+        if (body && isFinite(minLeft)) body.scrollLeft = Math.max(0, minLeft - 20)
+      })
+    }
+
+    row.dataset.rowType = "added"
+    const hiddenTypes = JSON.parse(localStorage.getItem("timeline_hidden_types") || "[]")
+    if (hiddenTypes.includes("added")) row.classList.add("hidden")
+    row.querySelectorAll("div.absolute.rounded").forEach(bar => {
+      bar.style.backgroundColor = "#22c55e"
+    })
+
+    const nameCell = row.querySelector("div[style*='width']")
+    if (nameCell) {
+      nameCell.classList.add("timeline-added-name-cell")
+      const btn = document.createElement("button")
+      btn.type = "button"
+      btn.textContent = "✕"
+      btn.setAttribute("aria-label", "行を削除")
+      btn.className = "flex-shrink-0 ml-1 text-xs text-zinc-400 hover:text-red-500 leading-none"
+      btn.addEventListener("click", () => {
+        this.addedKeys.delete(key)
+        this._saveToStorage()
+        sessionStorage.removeItem(this._cacheKeyPrefix + "_" + key)
+        row.remove()
+      })
+      nameCell.appendChild(btn)
+    }
+  }
+
+  // キーの配列を復元（共有URL・localStorage 両方から使用）
+  async _restoreKeys(keys) {
+    if (!keys.length) return
+
+    // キャッシュ済みをまず即挿入
+    const uncached = []
+    for (const key of keys) {
+      const html = this._getValidCache(this._cacheKeyPrefix + "_" + key)
+      if (html) {
+        this.addedKeys.add(key)
+        this._insertRow(key, html)
+      } else {
+        uncached.push(key)
+      }
+    }
+
+    if (!uncached.length) return
+
+    // 未キャッシュ分を1リクエストでバッチ取得
+    try {
+      const unitsUrl = this.inputTarget.dataset.unitsUrl
+      const url = new URL(unitsUrl, window.location.origin)
+      uncached.forEach(key => url.searchParams.append("keys[]", key))
+      const res = await fetch(url.toString(), { headers: { "Accept": "application/json" } })
+      if (!res.ok) return
+      const htmlMap = await res.json()
+      for (const key of uncached) {
+        const html = htmlMap[key]
+        if (!html) continue
+        sessionStorage.setItem(this._cacheKeyPrefix + "_" + key, html)
+        this.addedKeys.add(key)
+        this._insertRow(key, html)
+      }
+    } catch (e) {
+      console.error("timeline-search _restoreKeys error:", e)
+    }
+  }
+
   _restoreFromStorage() {
     const saved = JSON.parse(localStorage.getItem(this.constructor.STORAGE_KEY) || "[]")
-    saved.forEach(key => this.addUnit(key, key, { scroll: false }))
+    this._restoreKeys(saved)
   }
 }

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -177,7 +177,7 @@
           <% @year_range.each_with_index do |year, i| %>
             <% is_decade = year % 10 == 0 %>
             <% is_major  = year % 5 == 0 %>
-            <% color_cls = is_decade ? 'text-zinc-700 dark:text-zinc-200 font-medium' : 'text-zinc-500 dark:text-zinc-400' %>
+            <% color_cls = is_decade ? 'text-zinc-700 dark:text-zinc-200 font-bold' : 'text-zinc-500 dark:text-zinc-400' %>
             <span class="absolute text-xs whitespace-nowrap <%= color_cls %> <%= is_major ? '' : 'timeline-year-label-minor hidden' %>"
                   style="left: calc(var(--year-px) * <%= i %>); top: 2px; transform: translateX(-50%);"
                   <% unless is_major %>aria-hidden="true"<% end %>>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -125,6 +125,7 @@
                placeholder="バンドを追加..."
                autocomplete="off"
                data-unit-url="<%= timeline_unit_path(ym: @year_min) %>"
+               data-units-url="<%= timeline_units_path(ym: @year_min) %>"
                data-search-url="<%= search_units_path %>"
                class="w-full px-3 py-1.5 text-sm border border-zinc-300 dark:border-zinc-600 rounded
                       bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -175,8 +175,10 @@
         <!-- 年ラベル -->
         <div class="relative flex-shrink-0" style="width: calc(var(--year-px) * <%= n_years %>); height: 32px;">
           <% @year_range.each_with_index do |year, i| %>
-            <% is_major = year % 5 == 0 %>
-            <span class="absolute text-xs text-zinc-500 dark:text-zinc-400 whitespace-nowrap <%= is_major ? '' : 'timeline-year-label-minor hidden' %>"
+            <% is_decade = year % 10 == 0 %>
+            <% is_major  = year % 5 == 0 %>
+            <% color_cls = is_decade ? 'text-zinc-700 dark:text-zinc-200 font-medium' : 'text-zinc-500 dark:text-zinc-400' %>
+            <span class="absolute text-xs whitespace-nowrap <%= color_cls %> <%= is_major ? '' : 'timeline-year-label-minor hidden' %>"
                   style="left: calc(var(--year-px) * <%= i %>); top: 2px; transform: translateX(-50%);"
                   <% unless is_major %>aria-hidden="true"<% end %>>
               <%= year %>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -152,7 +152,7 @@
   %>
   <div id="timeline-widget"
        class="rounded border border-zinc-200 dark:border-zinc-700"
-       style="--year-px: <%= @year_px %>px; --year-grid-fine-alpha: <%= @year_px > 24 ? '0.15' : '0' %>;"
+       style="--year-px: <%= @year_px %>px; --year-grid-fine-alpha: 0.15;"
        data-zoom="<%= @zoom %>"
        data-timeline-target="widget"
        data-year-px-default="<%= @year_px %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,8 @@ Rails.application.routes.draw do
 
   # Timeline
   get 'timeline', to: 'timeline#index'
-  get 'timeline/unit', to: 'timeline#unit'
+  get 'timeline/unit',  to: 'timeline#unit'
+  get 'timeline/units', to: 'timeline#units'
 
   # Cross-search
   get 'search', to: 'search#index'


### PR DESCRIPTION
## Summary

- `GET /timeline/units?keys[]=a&keys[]=b&ym=YEAR_MIN` バッチエンドポイントを追加
- `_restoreFromStorage` を N リクエスト → 1リクエストに変更
- sessionStorage キャッシュ済みバンドはリクエストなしで即挿入
- 行挿入・スタイル・削除ボタンのロジックを `_insertRow` に抽出し `addUnit` と共用

## 動作フロー

```
_restoreFromStorage / _restoreKeys(keys)
  ├─ キャッシュ済み → 即 _insertRow（リクエスト不要）
  └─ 未キャッシュ → /timeline/units?keys[]=... で1回バッチ取得
                      → sessionStorage に保存 → _insertRow
```

## Test plan

- [ ] `bin/rails test` が全件パスすること
- [ ] 複数バンドを保存後にページリロードし、1リクエストで全バンドが復元される
- [ ] sessionStorage キャッシュがある場合はリクエストが発生しない
- [ ] ユーザー操作による1件追加（`addUnit`）が引き続き正常動作する
- [ ] 追加バンドの削除ボタンが機能し、キャッシュも削除される

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)