### PR TITLE
feat: バンド追加オートコンプリートで完全一致・前方一致を優先表示

### DIFF
--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -29,7 +29,17 @@ class UnitsController < ApplicationController
       return
     end
 
+    conn = ActiveRecord::Base.connection
+    quoted_exact = conn.quote(q)
+    quoted_prefix = conn.quote("#{q}%")
     units = Unit.kept.where('name ILIKE :q OR name_kana ILIKE :q', q: "%#{q}%")
+                .order(Arel.sql(<<~SQL.squish))
+                  CASE
+                    WHEN name = #{quoted_exact} OR name_kana = #{quoted_exact} THEN 0
+                    WHEN name ILIKE #{quoted_prefix} OR name_kana ILIKE #{quoted_prefix} THEN 1
+                    ELSE 2
+                  END
+                SQL
                 .order(name_kana: :asc)
                 .limit(10)
                 .pluck(:name, :name_kana, :key)


### PR DESCRIPTION
## Summary

- `units#search` のソート順に `CASE` 式を追加し、完全一致 → 前方一致 → 部分一致の順で優先表示
- `conn.quote` を使用して SQL インジェクション対策済み
- 同一優先度内は `name_kana` 昇順を維持

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)