### PR TITLE
feat: タイムラインで人物検索からバンドを一括追加 (issue #503)

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,6 +12,44 @@ class PeopleController < ApplicationController
     @pagy, @people = pagy(scope, limit: 60)
   end
 
+  def search
+    q = params[:q].to_s.strip
+    if q.length < 2
+      render json: []
+      return
+    end
+
+    conn = ActiveRecord::Base.connection
+    quoted_exact = conn.quote(q)
+    quoted_prefix = conn.quote("#{q}%")
+    people = Person.kept
+                   .where('name ILIKE :q OR name_kana ILIKE :q', q: "%#{q}%")
+                   .order(Arel.sql(<<~SQL.squish))
+                     CASE
+                       WHEN name = #{quoted_exact} OR name_kana = #{quoted_exact} THEN 0
+                       WHEN name ILIKE #{quoted_prefix} OR name_kana ILIKE #{quoted_prefix} THEN 1
+                       ELSE 2
+                     END
+                   SQL
+                   .order(name_kana: :asc)
+                   .limit(10)
+                   .pluck(:name, :name_kana, :key)
+                   .map { |name, name_kana, key| { name:, name_kana:, key: } }
+    render json: people
+  end
+
+  def units
+    person = Person.kept.find_by!(key: params[:key])
+    unit_keys = person.unit_people
+                      .joins(:unit)
+                      .merge(Unit.kept)
+                      .distinct
+                      .pluck('units.key')
+    render json: { unit_keys:, person_name: person.name }
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Person not found' }, status: :not_found
+  end
+
   def show
     @person = Person.kept.find_by!(key: params[:key])
     render json: @person

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -23,7 +23,7 @@ class PeopleController < ApplicationController
     quoted_exact = conn.quote(q)
     quoted_prefix = conn.quote("#{q}%")
     people = Person.kept
-                   .where('name ILIKE :q OR name_kana ILIKE :q', q: "%#{q}%")
+                   .where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q', q: "%#{q}%")
                    .order(Arel.sql(<<~SQL.squish))
                      CASE
                        WHEN name = #{quoted_exact} OR name_kana = #{quoted_exact} THEN 0

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -223,6 +223,7 @@ export default class extends Controller {
   }
 
   clearAll() {
+    if (!confirm("追加したバンドをすべて削除しますか？")) return
     const rows = document.getElementById("timeline-rows-inner") || document.getElementById("timeline-rows")
     if (rows) {
       Array.from(rows.querySelectorAll("[data-row-type='added']")).forEach(r => r.remove())

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "suggestions", "modeBtn"]
+  static targets = ["input", "suggestions", "modeBtn", "clearBtn"]
 
   static STORAGE_KEY = "timeline_added_bands"
   static HTML_CACHE_PREFIX = "timeline_unit_html_v6_"
@@ -213,6 +213,24 @@ export default class extends Controller {
 
   _saveToStorage() {
     localStorage.setItem(this.constructor.STORAGE_KEY, JSON.stringify([...this.addedKeys]))
+    this._updateClearBtn()
+  }
+
+  _updateClearBtn() {
+    if (this.hasClearBtnTarget) {
+      this.clearBtnTarget.classList.toggle("hidden", this.addedKeys.size === 0)
+    }
+  }
+
+  clearAll() {
+    const rows = document.getElementById("timeline-rows-inner") || document.getElementById("timeline-rows")
+    if (rows) {
+      Array.from(rows.querySelectorAll("[data-row-type='added']")).forEach(r => r.remove())
+    }
+    const prefix = this._cacheKeyPrefix
+    this.addedKeys.forEach(key => sessionStorage.removeItem(prefix + "_" + key))
+    this.addedKeys.clear()
+    this._saveToStorage()
   }
 
   // キャッシュから HTML を取得。data-start-year がなければ無効とみなしキャッシュ削除
@@ -317,6 +335,7 @@ export default class extends Controller {
     } catch (e) {
       console.error("timeline-search _restoreKeys error:", e)
     }
+    this._updateClearBtn()
   }
 
   _restoreFromStorage() {

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "suggestions"]
+  static targets = ["input", "suggestions", "modeBtn"]
 
   static STORAGE_KEY = "timeline_added_bands"
   static HTML_CACHE_PREFIX = "timeline_unit_html_v6_"
@@ -10,6 +10,7 @@ export default class extends Controller {
     this.debounceTimer = null
     this.addedKeys = new Set()
     this.selectedIndex = -1
+    this.mode = "band"
     this.handleClickOutside = this._onClickOutside.bind(this)
     document.addEventListener("click", this.handleClickOutside)
 
@@ -65,29 +66,48 @@ export default class extends Controller {
     }
   }
 
+  setMode(event) {
+    const btn = event.currentTarget
+    this.mode = btn.dataset.mode
+    this.inputTarget.value = ""
+    this.hideSuggestions()
+    this.inputTarget.placeholder = this.mode === "person" ? "人物を検索..." : "バンドを追加..."
+    this.modeBtnTargets.forEach(b => {
+      const active = b.dataset.mode === this.mode
+      b.classList.toggle("bg-indigo-600", active)
+      b.classList.toggle("text-white", active)
+      b.classList.toggle("font-medium", active)
+      b.classList.toggle("text-zinc-600", !active)
+      b.classList.toggle("dark:text-zinc-400", !active)
+      b.setAttribute("aria-pressed", active ? "true" : "false")
+    })
+  }
+
   async fetchSuggestions(q) {
-    const searchUrl = this.inputTarget.dataset.searchUrl
+    const searchUrl = this.mode === "person"
+      ? this.inputTarget.dataset.personSearchUrl
+      : this.inputTarget.dataset.searchUrl
     try {
       const res = await fetch(`${searchUrl}?q=${encodeURIComponent(q)}`, {
         headers: { "Accept": "application/json" }
       })
       if (!res.ok) return
-      const units = await res.json()
-      this.renderSuggestions(units)
+      const results = await res.json()
+      this.renderSuggestions(results)
     } catch (e) {
       console.error("timeline-search fetchSuggestions error:", e)
     }
   }
 
-  renderSuggestions(units) {
+  renderSuggestions(results) {
     this.selectedIndex = -1
-    if (!units.length) {
+    if (!results.length) {
       this.hideSuggestions()
       return
     }
 
-    this.suggestionsTarget.innerHTML = units.map(u => {
-      const already = this.addedKeys.has(u.key)
+    this.suggestionsTarget.innerHTML = results.map(u => {
+      const already = this.mode === "band" && this.addedKeys.has(u.key)
       const cls = already ? "opacity-50 cursor-default" : "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-700"
       const badge = already ? `<span class="text-xs text-zinc-400 whitespace-nowrap">追加済み</span>` : ""
       return `<li data-key="${this.esc(u.key)}" class="px-3 py-2 flex items-center justify-between gap-2 ${cls}">
@@ -96,14 +116,38 @@ export default class extends Controller {
     }).join("")
 
     this.suggestionsTarget.querySelectorAll("li[data-key]").forEach(li => {
-      if (!this.addedKeys.has(li.dataset.key)) {
+      if (this.mode === "person" || !this.addedKeys.has(li.dataset.key)) {
         li.addEventListener("click", () => {
           const name = li.querySelector("span").textContent.trim()
-          this.addUnit(li.dataset.key, name)
+          if (this.mode === "person") {
+            this.addPersonUnits(li.dataset.key, name)
+          } else {
+            this.addUnit(li.dataset.key, name)
+          }
         })
       }
     })
     this.suggestionsTarget.classList.remove("hidden")
+  }
+
+  async addPersonUnits(personKey, personName) {
+    this.hideSuggestions()
+    this.inputTarget.value = ""
+    try {
+      const baseUrl = this.inputTarget.dataset.personUnitsBaseUrl
+      const res = await fetch(`${baseUrl}/${encodeURIComponent(personKey)}/units`, {
+        headers: { "Accept": "application/json" }
+      })
+      if (!res.ok) throw new Error(`fetch failed: ${res.status}`)
+      const { unit_keys } = await res.json()
+      const newKeys = unit_keys.filter(k => !this.addedKeys.has(k))
+      if (!newKeys.length) return
+      await this._restoreKeys(newKeys)
+      this._saveToStorage()
+    } catch (e) {
+      console.error("timeline-search addPersonUnits error:", e)
+      alert(`「${personName}」の関連バンドの追加に失敗しました`)
+    }
   }
 
   get _cacheKeyPrefix() {

--- a/app/javascript/controllers/timeline_search_controller.js
+++ b/app/javascript/controllers/timeline_search_controller.js
@@ -315,7 +315,10 @@ export default class extends Controller {
       }
     }
 
-    if (!uncached.length) return
+    if (!uncached.length) {
+      this._updateClearBtn()
+      return
+    }
 
     // 未キャッシュ分を1リクエストでバッチ取得
     try {

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -120,6 +120,22 @@
   <!-- バンド追加検索 -->
   <div class="mb-3 relative" data-controller="timeline-search">
     <div class="flex gap-2">
+      <!-- モード切り替えタブ -->
+      <div class="flex rounded border border-zinc-300 dark:border-zinc-600 overflow-hidden text-sm flex-shrink-0"
+           role="group" aria-label="検索モードの切り替え">
+        <button type="button"
+                data-action="click->timeline-search#setMode"
+                data-mode="band"
+                data-timeline-search-target="modeBtn"
+                aria-pressed="true"
+                class="px-2.5 py-1.5 bg-indigo-600 text-white font-medium transition-colors">バンド</button>
+        <button type="button"
+                data-action="click->timeline-search#setMode"
+                data-mode="person"
+                data-timeline-search-target="modeBtn"
+                aria-pressed="false"
+                class="px-2.5 py-1.5 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors">人から</button>
+      </div>
       <div class="relative flex-1 max-w-xs">
         <input type="text"
                placeholder="バンドを追加..."
@@ -127,6 +143,8 @@
                data-unit-url="<%= timeline_unit_path(ym: @year_min) %>"
                data-units-url="<%= timeline_units_path(ym: @year_min) %>"
                data-search-url="<%= search_units_path %>"
+               data-person-search-url="<%= search_people_path %>"
+               data-person-units-base-url="<%= people_path %>"
                class="w-full px-3 py-1.5 text-sm border border-zinc-300 dark:border-zinc-600 rounded
                       bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100
                       placeholder-zinc-400 dark:placeholder-zinc-500

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -158,7 +158,14 @@
             role="listbox"></ul>
       </div>
     </div>
-    <p class="mt-1 text-xs text-zinc-400 dark:text-zinc-500">追加したバンドはブラウザに保存され、次回以降も表示されます</p>
+    <div class="mt-1 flex items-center gap-3">
+      <p class="text-xs text-zinc-400 dark:text-zinc-500">追加したバンドはブラウザに保存され、次回以降も表示されます</p>
+      <button type="button"
+              data-action="click->timeline-search#clearAll"
+              data-timeline-search-target="clearBtn"
+              class="hidden text-xs text-zinc-400 dark:text-zinc-500 hover:text-red-500 dark:hover:text-red-400 underline transition-colors flex-shrink-0"
+              aria-label="追加したバンドをすべて削除">全クリア</button>
+    </div>
   </div>
 
   <%#

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,14 @@ Rails.application.routes.draw do
   get '/index/:index_group', to: 'indices#index', as: :indices_group
   get '/index/show/:id', to: 'indices#show', as: :index_show
 
-  resources :people, param: :key, only: %i[index show], constraints: { key: %r{[^/]+} }
+  resources :people, param: :key, only: %i[index show], constraints: { key: %r{[^/]+} } do
+    collection do
+      get :search
+    end
+    member do
+      get :units
+    end
+  end
   resources :units, param: :key, only: %i[index show], constraints: { key: %r{[^/]+} } do
     collection do
       get :search


### PR DESCRIPTION
## Summary
- タイムライン検索エリアに「バンド / 人から」モード切り替えタブを追加
- 人物モードで人物を検索・選択すると、その人が関与する全バンドをタイムラインに一括追加
- `GET /people/search` エンドポイントを追加（name / name_kana / name_log / aliases を対象に優先順位付きオートコンプリート）
- `GET /people/:key/units` エンドポイントを追加（その人が関与した Unit の key 一覧を返す）
- 追加バンドを全件削除する「全クリア」ボタンを追加（追加バンドが1件以上のときのみ表示、実行前に確認ダイアログを表示）

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 「バンド」タブ：従来通りバンド名で検索・追加できること
- [ ] 「人から」タブ：人物名（旧名・aliases 含む）で検索できること
- [ ] 人物を選択すると関与バンドが一括追加されること（既に追加済みのバンドは重複しないこと）
- [ ] 「全クリア」ボタンが追加バンド1件以上のときのみ表示され、確認後に全削除されること
- [ ] ページリロード後も追加バンドが復元され、全クリアボタンが表示されること

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)