### PR TITLE
feat: オートコンプリートエンドポイントの悪用対策（優先度高）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ end
 
 gem 'redis', '>= 4.0.1'
 
+gem 'rack-attack'
 gem 'discard', '~> 1.4'
 gem 'romaji', '~> 0.3.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -82,8 +82,8 @@ end
 
 gem 'redis', '>= 4.0.1'
 
-gem 'rack-attack'
 gem 'discard', '~> 1.4'
+gem 'rack-attack'
 gem 'romaji', '~> 0.3.0'
 
 gem 'pagy', '~> 43.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.5)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -512,6 +514,7 @@ DEPENDENCIES
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.2)
   redcarpet
   redis (>= 4.0.1)
@@ -648,6 +651,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
+  rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -13,7 +13,7 @@ class PeopleController < ApplicationController
   end
 
   def search
-    q = params[:q].to_s.strip
+    q = params[:q].to_s.strip.first(100)
     if q.length < 2
       render json: []
       return

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -23,7 +23,7 @@ class UnitsController < ApplicationController
   end
 
   def search
-    q = params[:q].to_s.strip
+    q = params[:q].to_s.strip.first(100)
     if q.length < 2
       render json: []
       return

--- a/app/models/custom_page.rb
+++ b/app/models/custom_page.rb
@@ -32,6 +32,7 @@ class CustomPage < ApplicationRecord
   scope :published, -> { kept.where(active: true) }
 
   after_commit :expire_sidebar_cache
+  after_commit :expire_blocked_ips_cache, if: -> { key == Middleware::IpBlocker::CUSTOM_PAGE_KEY }
 
   def protected?
     PROTECTED_KEYS.include?(key)
@@ -41,5 +42,9 @@ class CustomPage < ApplicationRecord
 
   def expire_sidebar_cache
     Rails.cache.delete('sidebar/recently_updated')
+  end
+
+  def expire_blocked_ips_cache
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-Rack::Attack.throttle("search/ip", limit: 30, period: 60) do |req|
-  req.ip if req.path.start_with?("/people/search", "/units/search")
+Rack::Attack.throttle('search/ip', limit: 30, period: 60) do |req|
+  req.ip if req.path.start_with?('/people/search', '/units/search')
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# オートコンプリート・全文検索: IP ごとに 60 秒間 30 リクエストまで
 Rack::Attack.throttle('search/ip', limit: 30, period: 60) do |req|
-  req.ip if req.path.start_with?('/people/search', '/units/search')
+  req.ip if req.path.start_with?('/people/search', '/units/search', '/search')
+end
+
+# ログイン: IP ごとに 20 秒間 5 回まで（ブルートフォース対策）
+Rack::Attack.throttle('login/ip', limit: 5, period: 20) do |req|
+  req.ip if req.path == '/login' && req.post?
+end
+
+# ログイン: メールアドレスごとに 60 秒間 10 回まで（IP 偽装対策）
+Rack::Attack.throttle('login/email', limit: 10, period: 60) do |req|
+  req.params['email']&.downcase if req.path == '/login' && req.post?
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rack::Attack.throttle("search/ip", limit: 30, period: 60) do |req|
+  req.ip if req.path.start_with?("/people/search", "/units/search")
+end

--- a/lib/middleware/ip_blocker.rb
+++ b/lib/middleware/ip_blocker.rb
@@ -3,13 +3,11 @@
 module Middleware
   class IpBlocker
     CUSTOM_PAGE_KEY = 'blocking_ip_address'
-    CACHE_TTL = 5 * 60 # 5 minutes in seconds
+    CACHE_KEY = 'middleware/blocked_ips'
+    CACHE_TTL = 5.minutes
 
     def initialize(app)
       @app = app
-      @mutex = Mutex.new
-      @blocked_ips = nil
-      @cached_at = nil
     end
 
     def call(env)
@@ -28,13 +26,7 @@ module Middleware
     end
 
     def load_blocked_ips
-      @mutex.synchronize do
-        if @cached_at.nil? || (Time.now.to_i - @cached_at) > CACHE_TTL
-          @blocked_ips = fetch_blocked_ips
-          @cached_at = Time.now.to_i
-        end
-        @blocked_ips
-      end
+      Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL) { fetch_blocked_ips }
     end
 
     def fetch_blocked_ips

--- a/test/lib/middleware/ip_blocker_test.rb
+++ b/test/lib/middleware/ip_blocker_test.rb
@@ -14,7 +14,7 @@ class IpBlockerTest < ActiveSupport::TestCase
     page.update!(body: "192.168.1.100\n10.0.0.1\n")
 
     # キャッシュをクリア
-    @middleware.instance_variable_set(:@cached_at, nil)
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
 
     env = { 'REMOTE_ADDR' => '192.168.1.100', 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET' }
     status, _headers, _body = @middleware.call(env)
@@ -25,7 +25,7 @@ class IpBlockerTest < ActiveSupport::TestCase
     page = custom_pages(:blocking_ip_address)
     page.update!(body: "192.168.1.100\n")
 
-    @middleware.instance_variable_set(:@cached_at, nil)
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
 
     env = { 'REMOTE_ADDR' => '10.0.0.1', 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET' }
     status, _headers, _body = @middleware.call(env)
@@ -36,7 +36,7 @@ class IpBlockerTest < ActiveSupport::TestCase
     page = custom_pages(:blocking_ip_address)
     page.update!(body: "~~192.168.1.100~~\n10.0.0.1\n")
 
-    @middleware.instance_variable_set(:@cached_at, nil)
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
 
     env = { 'REMOTE_ADDR' => '192.168.1.100', 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET' }
     status, _headers, _body = @middleware.call(env)
@@ -47,7 +47,7 @@ class IpBlockerTest < ActiveSupport::TestCase
     page = custom_pages(:blocking_ip_address)
     page.update!(body: "~~192.168.1.100~~\n10.0.0.1\n")
 
-    @middleware.instance_variable_set(:@cached_at, nil)
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
 
     env = { 'REMOTE_ADDR' => '10.0.0.1', 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET' }
     status, _headers, _body = @middleware.call(env)
@@ -57,7 +57,7 @@ class IpBlockerTest < ActiveSupport::TestCase
   test 'カスタムページが存在しない場合は通過する' do
     CustomPage.where(key: 'blocking_ip_address').destroy_all
 
-    @middleware.instance_variable_set(:@cached_at, nil)
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
 
     env = { 'REMOTE_ADDR' => '192.168.1.100', 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET' }
     status, _headers, _body = @middleware.call(env)
@@ -71,7 +71,7 @@ class IpBlockerTest < ActiveSupport::TestCase
     end
     page.update!(body: "192.168.1.100\n", active: false)
 
-    @middleware.instance_variable_set(:@cached_at, nil)
+    Rails.cache.delete(Middleware::IpBlocker::CACHE_KEY)
 
     env = { 'REMOTE_ADDR' => '192.168.1.100', 'PATH_INFO' => '/', 'REQUEST_METHOD' => 'GET' }
     status, _headers, _body = @middleware.call(env)


### PR DESCRIPTION
## Summary

- `rack-attack` gem を追加し、以下のエンドポイントにレート制限を設定（超過時 429）
  - オートコンプリート・全文検索（`/people/search`, `/units/search`, `/search`）: IP ごとに 60 秒間 30 リクエストまで
  - ログイン（`POST /login`）: IP ごとに 20 秒間 5 回まで／メールアドレスごとに 60 秒間 10 回まで（IP 偽装対策）
- 検索クエリ `q` を最大 100 文字に切り詰め、極端に長い文字列が DB クエリに渡らないよう対策
- `IpBlocker` ミドルウェアのキャッシュをインメモリ Mutex から `Rails.cache` に移行し、`blocking_ip_address` ページ更新時にキャッシュを即時削除するよう対応

## Test plan

- [ ] `bin/rails test` が全件パスすること
- [ ] `/people/search?q=test` に 30 回超リクエストして 429 が返ることを確認
- [ ] `POST /login` に同一 IP から 20 秒以内に 6 回送信して 429 が返ることを確認
- [ ] `POST /login` に同一メールアドレスで 60 秒以内に 11 回送信して 429 が返ることを確認
- [ ] 101 文字以上の `q` を送っても正常にレスポンスが返ることを確認
- [ ] 管理画面で `blocking_ip_address` ページを保存後、ブロック対象 IP からのアクセスが即座に 403 になることを確認

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)