### PR TITLE
fix: Pagy.options の非推奨警告を解消

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -3,4 +3,4 @@
 require 'pagy/toolbox/helpers/support/series'
 
 # Pagy initializer
-Pagy.options[:limit] = 60
+Pagy::OPTIONS[:limit] = 60


### PR DESCRIPTION
## Summary
- `Pagy.options` → `Pagy::OPTIONS` に変更（pagy v9以降の API に対応）

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] Rails 起動時に `[PAGY] 'Pagy.options' is deprecated` 警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)