### PR TITLE
feat: 旧wikiページ全件を wiki_page_imports に登録する rake タスクを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,9 @@
 - `/release-pr` スキルはリリース専用。機能修正・バグ修正には使わない
 - `develop` および `main` への直接 push は禁止。必ずブランチを切って PR を作成すること
 
+## データ操作の禁止事項
+- `wikipages` テーブルは読み取り専用として扱う。明示的な指示がない限り、更新・削除・挿入を行ってはいけない
+
 ## コマンド実行
 - Rails コマンドは必ず `bundle exec` をつける（例: `bundle exec rails db:migrate`）
 - `db:rollback` は**危険**。実行前に必ず `db:migrate:status` でロールバック対象を確認し、ユーザーに確認を求めること。

--- a/lib/tasks/wiki_page_imports.rake
+++ b/lib/tasks/wiki_page_imports.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :wiki_page_imports do
+  desc 'Wikipage 全件を wiki_page_imports に pending で登録する（冪等）'
+  task seed: :environment do
+    puts 'Seeding wiki_page_imports...'
+    inserted = 0
+    skipped = 0
+
+    Wikipage.find_each do |wp|
+      if WikiPageImport.exists?(wikipage_id: wp.id)
+        skipped += 1
+        next
+      end
+
+      WikiPageImport.create!(wikipage_id: wp.id, status: 'pending')
+      inserted += 1
+    end
+
+    puts 'Done!'
+    puts "  Inserted: #{inserted}"
+    puts "  Skipped:  #{skipped} (already registered)"
+  end
+end


### PR DESCRIPTION
## Summary
- `bundle exec rails wiki_page_imports:seed` で `Wikipage` 全件を `wiki_page_imports` に `status: pending` で登録
- 既登録レコードはスキップするため冪等（2回実行しても重複しない）
- 実行結果（登録件数・スキップ件数）をログ出力

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `bundle exec rails wiki_page_imports:seed` が正常完了すること
- [ ] 2回実行時に Inserted: 0 / Skipped: 全件 になること

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)