### PR TITLE
feat: インポートタスク実行時に wiki_page_imports のステータスを更新する

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -18,6 +18,21 @@ def extract_categories(wikipage)
   categories
 end
 
+def update_wiki_page_import_as_imported(wikipage, page_type:, target:)
+  wpi = WikiPageImport.find_or_create_by!(wikipage_id: wikipage.id)
+  wpi.update!(
+    status: 'imported',
+    page_type: page_type,
+    import_target: target,
+    last_imported_at: Time.current
+  )
+end
+
+def update_wiki_page_import_as_skipped(wikipage, note:)
+  wpi = WikiPageImport.find_or_create_by!(wikipage_id: wikipage.id)
+  wpi.update!(status: 'skipped', note: note) if wpi.status == 'pending'
+end
+
 def format_skip_log(wikipage)
   base_log = "[SKIPPED] #{wikipage.title} (ID: #{wikipage.id})"
 
@@ -95,13 +110,16 @@ namespace :import do
 
       if PersonImporter.ignored?(wp)
         skipped += 1
-        # Silent skip for ignored pages
+        update_wiki_page_import_as_skipped(wp, note: 'ignored')
         next
       elsif PersonImporter.valid_person?(wp)
         PersonImporter.import(wp)
         count += 1
+        person = Person.find_by(old_wiki_id: wp.id)
+        update_wiki_page_import_as_imported(wp, page_type: 'person', target: person)
       else
         skipped += 1
+        update_wiki_page_import_as_skipped(wp, note: 'not a unit or person')
         # ユニット候補の場合はログ出力しない
         puts format_skip_log(wp) if wp.title.present? && !WikipageImporter.valid_unit?(wp)
       end

--- a/lib/tasks/import_v2.rake
+++ b/lib/tasks/import_v2.rake
@@ -25,6 +25,7 @@ namespace :import do
 
       if WikipageImporter.ignored?(wp)
         skipped += 1
+        update_wiki_page_import_as_skipped(wp, note: 'ignored')
         next
       elsif WikipageImporter.valid_unit?(wp)
         # ID指定時: インポート前に既存の関連レコードを削除
@@ -46,6 +47,7 @@ namespace :import do
         # 作成されたスナップショット数をカウント
         unit = Unit.find_by(old_wiki_id: wp.id)
         snapshots_created += unit.unit_snapshots.count if unit
+        update_wiki_page_import_as_imported(wp, page_type: 'unit', target: unit)
       else
         skipped += 1
         puts format_skip_log(wp) if wp.title.present? && !PersonImporter.valid_person?(wp)


### PR DESCRIPTION
## Summary
- `import:units_v2` / `import:people` タスク実行時に対応する `wiki_page_imports` レコードを更新する
- インポート成功 → `status: imported`、`page_type`・`import_target`・`last_imported_at` を設定
- ignored → `status: skipped`、`note: 'ignored'`（`pending` のみ更新、`imported` は上書きしない）
- どちらでもないページ（`import:people` の else） → `status: skipped`、`note: 'not a unit or person'`
- `update_wiki_page_import_as_imported` / `update_wiki_page_import_as_skipped` ヘルパーを `import.rake` に追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `import:units_v2 ID=xxx` 実行後、対象の `wiki_page_imports` が `imported` になること
- [ ] `import:people ID=xxx` 実行後、対象の `wiki_page_imports` が `imported` になること
- [ ] ignored なページが `skipped / note: ignored` になること
- [ ] 既に `imported` なレコードが `skipped` で上書きされないこと

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)