### PR TITLE
feat: wiki_page_imports の skipped 一覧管理画面を追加

### DIFF
--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -2,11 +2,23 @@
 
 module Admin
   class WikiPageImportsController < Admin::BaseController
+    before_action :require_admin
+
     def index
       @include_ignored = params[:include_ignored] == '1'
       scope = WikiPageImport.skipped.includes(:wikipage).order(updated_at: :desc)
       scope = scope.where.not(note: 'ignored') unless @include_ignored
       @pagy, @wiki_page_imports = pagy(scope, limit: 50)
+    end
+
+    def bulk_ignore
+      ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
+      if ids.any?
+        WikiPageImport.where(id: ids).update_all(note: 'ignored', updated_at: Time.current)
+        redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を ignored にしました"
+      else
+        redirect_to admin_wiki_page_imports_path, alert: '項目が選択されていません'
+      end
     end
   end
 end

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -3,10 +3,10 @@
 module Admin
   class WikiPageImportsController < Admin::BaseController
     def index
-      @pagy, @wiki_page_imports = pagy(
-        WikiPageImport.skipped.includes(:wikipage).order(updated_at: :desc),
-        limit: 50
-      )
+      @include_ignored = params[:include_ignored] == '1'
+      scope = WikiPageImport.skipped.includes(:wikipage).order(updated_at: :desc)
+      scope = scope.where.not(note: 'ignored') unless @include_ignored
+      @pagy, @wiki_page_imports = pagy(scope, limit: 50)
     end
   end
 end

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Admin
+  class WikiPageImportsController < Admin::BaseController
+    def index
+      @pagy, @wiki_page_imports = pagy(
+        WikiPageImport.skipped.includes(:wikipage).order(updated_at: :desc),
+        limit: 50
+      )
+    end
+  end
+end

--- a/app/models/wikipage.rb
+++ b/app/models/wikipage.rb
@@ -24,4 +24,8 @@
 #  index_wikipages_on_wiki_gin  (wiki) USING gin
 #
 class Wikipage < ApplicationRecord
+  def vkdb_url
+    encoded = URI.encode_www_form_component(name.encode('EUC-JP'))
+    "https://www.vkdb.jp/#{encoded}.html"
+  end
 end

--- a/app/models/wikipage.rb
+++ b/app/models/wikipage.rb
@@ -25,7 +25,7 @@
 #
 class Wikipage < ApplicationRecord
   def vkdb_url
-    encoded = URI.encode_www_form_component(name.encode('EUC-JP'))
+    encoded = URI.encode_www_form_component(name.gsub('/', '%2F').encode('EUC-JP'))
     "https://www.vkdb.jp/#{encoded}.html"
   end
 end

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,0 +1,49 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Wiki Page Imports（スキップ済み）</h1>
+    <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
+  </div>
+
+  <div class="mb-4 flex justify-center">
+    <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
+  </div>
+
+  <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
+    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-700">
+        <tr>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
+        </tr>
+      </thead>
+      <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+        <% @wiki_page_imports.each do |wpi| %>
+          <tr>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
+            <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
+            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+              <% if wpi.wikipage %>
+                <%= link_to wpi.wikipage.vkdb_url, target: "_blank", rel: "noopener", class: "group flex items-center gap-1 hover:text-indigo-500 transition-colors" do %>
+                  <span class="font-mono"><%= wpi.wikipage.name %></span>
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0">
+                    <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                    <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                  </svg>
+                <% end %>
+              <% end %>
+            </td>
+            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="mt-4 flex justify-center">
+    <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
+  </div>
+</div>

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,7 +1,18 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Wiki Page Imports（スキップ済み）</h1>
-    <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
+    <div class="flex items-center gap-4">
+      <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
+      <% if @include_ignored %>
+        <%= link_to admin_wiki_page_imports_path, class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700" do %>
+          ignored を除外する
+        <% end %>
+      <% else %>
+        <%= link_to admin_wiki_page_imports_path(include_ignored: 1), class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
+          ignored を含める
+        <% end %>
+      <% end %>
+    </div>
   </div>
 
   <div class="mb-4 flex justify-center">

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -19,40 +19,54 @@
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
   </div>
 
-  <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
-    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-      <thead class="bg-gray-50 dark:bg-gray-700">
-        <tr>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
-          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
-        </tr>
-      </thead>
-      <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-        <% @wiki_page_imports.each do |wpi| %>
+  <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch do |f| %>
+    <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
+      <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead class="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
-            <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
-            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
-              <% if wpi.wikipage %>
-                <%= link_to wpi.wikipage.vkdb_url, target: "_blank", rel: "noopener", class: "group flex items-center gap-1 hover:text-indigo-500 transition-colors" do %>
-                  <span class="font-mono"><%= wpi.wikipage.name %></span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0">
-                    <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
-                    <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
-                  </svg>
-                <% end %>
-              <% end %>
-            </td>
-            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
+            <th class="px-4 py-3">
+              <input type="checkbox" id="check_all" class="rounded border-gray-300 dark:border-gray-600" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)">
+            </th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+          <% @wiki_page_imports.each do |wpi| %>
+            <tr>
+              <td class="px-4 py-4">
+                <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600">
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
+              <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
+              <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                <% if wpi.wikipage %>
+                  <%= link_to wpi.wikipage.vkdb_url, target: "_blank", rel: "noopener", class: "group flex items-center gap-1 hover:text-indigo-500 transition-colors" do %>
+                    <span class="font-mono"><%= wpi.wikipage.name %></span>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0">
+                      <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                      <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                    </svg>
+                  <% end %>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="flex justify-end">
+      <%= f.submit '選択した項目を ignored にする',
+            class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer",
+            onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
+    </div>
+  <% end %>
 
   <div class="mt-4 flex justify-center">
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -162,6 +162,12 @@
                       </svg>
                       Pages
                     <% end %>
+                    <%= link_to admin_wiki_page_imports_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-indigo-600 dark:text-zinc-500 dark:group-hover:text-indigo-400">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                      </svg>
+                      Wiki Imports
+                    <% end %>
                   </div>
                   <div class="py-1">
                     <%= link_to admin_users_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
@@ -315,6 +321,9 @@
                       <% end %>
                       <%= link_to admin_custom_pages_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Pages
+                      <% end %>
+                      <%= link_to admin_wiki_page_imports_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
+                        Settings: Wiki Imports
                       <% end %>
                       <%= link_to admin_users_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,8 @@ Rails.application.routes.draw do
         post :restore
       end
     end
+
+    resources :wiki_page_imports, only: %i[index]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root 'custom_pages#index_page'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,7 +86,11 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :wiki_page_imports, only: %i[index]
+    resources :wiki_page_imports, only: %i[index] do
+      collection do
+        patch :bulk_ignore
+      end
+    end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root 'custom_pages#index_page'

--- a/db/migrate/20260324120912_add_index_status_to_wiki_page_imports.rb
+++ b/db/migrate/20260324120912_add_index_status_to_wiki_page_imports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexStatusToWikiPageImports < ActiveRecord::Migration[8.1]
+  def change
+    add_index :wiki_page_imports, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_112135) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_24_120912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -362,6 +362,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_112135) do
     t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
     t.bigint "wikipage_id", null: false
+    t.index ["status"], name: "index_wiki_page_imports_on_status"
     t.index ["wikipage_id"], name: "index_wiki_page_imports_on_wikipage_id", unique: true
   end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -119,9 +119,11 @@ namespace :import do
         update_wiki_page_import_as_imported(wp, page_type: 'person', target: person)
       else
         skipped += 1
-        update_wiki_page_import_as_skipped(wp, note: 'not a unit or person')
-        # ユニット候補の場合はログ出力しない
-        puts format_skip_log(wp) if wp.title.present? && !WikipageImporter.valid_unit?(wp)
+        # ユニット候補はunits_v2タスクで処理済みのためスキップ対象外
+        unless WikipageImporter.valid_unit?(wp)
+          update_wiki_page_import_as_skipped(wp, note: 'not a unit or person')
+          puts format_skip_log(wp) if wp.title.present?
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
- `status: skipped` の `wiki_page_imports` を一覧表示する管理画面を追加（`/admin/wiki_page_imports`）
- `status` カラムにインデックスを追加
- `name` カラムから旧サイト（vkdb.jp）へリンク（EUC-JP + `%252F` エンコード）
- デフォルトで `ignored` を除外し、ボタンで表示切替可能
- チェックボックスで複数選択し一括 ignored 化（テーブル下部のボタン、確認ダイアログあり）
- `require_admin` で admin ユーザーのみアクセス可
- `Wikipage#vkdb_url` メソッドを追加
- `import:people` で valid_unit なページを誤って `skipped` にしていたバグを修正

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `/admin/wiki_page_imports` で skipped 一覧が表示されること（ignored 除外）
- [ ] 「ignored を含める」ボタンで ignored も表示されること
- [ ] Name カラムのリンクが旧サイトに遷移すること
- [ ] チェックボックス選択 → テーブル下の「ignored にする」ボタンで確認ダイアログが出ること
- [ ] 実行後、対象レコードの note が `ignored` に更新されること
- [ ] admin 未満のユーザーはアクセス拒否されること

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)