### PR TITLE
feat: wiki_page_imports の仕訳け機能と強制インポート対応 (#518)

### DIFF
--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -5,9 +5,16 @@ module Admin
     before_action :require_admin
 
     def index
-      @include_ignored = params[:include_ignored] == '1'
-      scope = WikiPageImport.skipped.includes(:wikipage).order(updated_at: :desc)
-      scope = scope.where.not(note: 'ignored') unless @include_ignored
+      @show_manually_set = params[:manually_set] == '1'
+      @include_ignored   = params[:include_ignored] == '1'
+
+      if @show_manually_set
+        scope = WikiPageImport.manually_set.where.not(status: 'imported').includes(:wikipage).order(updated_at: :desc)
+      else
+        scope = WikiPageImport.skipped.where(manually_set: false).includes(:wikipage).order(updated_at: :desc)
+        scope = scope.where.not(note: 'ignored') unless @include_ignored
+      end
+
       @pagy, @wiki_page_imports = pagy(scope, limit: 50)
     end
 
@@ -18,6 +25,36 @@ module Admin
         redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を ignored にしました"
       else
         redirect_to admin_wiki_page_imports_path, alert: '項目が選択されていません'
+      end
+    end
+
+    def update_page_type
+      wpi = WikiPageImport.find(params[:id])
+      page_type = params[:page_type].presence
+      if page_type.nil?
+        wpi.update!(page_type: nil, manually_set: false)
+        redirect_back_or_to admin_wiki_page_imports_path, notice: '手動仕訳をキャンセルしました'
+      elsif WikiPageImport::PAGE_TYPES.include?(page_type)
+        wpi.update!(page_type: page_type, manually_set: true)
+        redirect_back_or_to admin_wiki_page_imports_path, notice: "page_type を #{page_type} に設定しました"
+      else
+        redirect_to admin_wiki_page_imports_path, alert: '無効な page_type です'
+      end
+    end
+
+    def bulk_update_page_type
+      ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
+      page_type = params[:page_type].presence
+      if ids.empty?
+        redirect_to admin_wiki_page_imports_path, alert: '項目が選択されていません'
+      elsif page_type.nil?
+        WikiPageImport.where(id: ids).update_all(page_type: nil, manually_set: false, updated_at: Time.current)
+        redirect_back_or_to admin_wiki_page_imports_path, notice: "#{ids.size} 件の手動仕訳をキャンセルしました"
+      elsif WikiPageImport::PAGE_TYPES.include?(page_type)
+        WikiPageImport.where(id: ids).update_all(page_type: page_type, manually_set: true, updated_at: Time.current)
+        redirect_back_or_to admin_wiki_page_imports_path, notice: "#{ids.size} 件の page_type を #{page_type} に設定しました"
+      else
+        redirect_to admin_wiki_page_imports_path, alert: 'page_type を選択してください'
       end
     end
   end

--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -11,6 +11,7 @@
 #  import_target_type :string
 #  import_target_id   :bigint
 #  note               :text
+#  manually_set       :boolean          not null, default(false)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  wikipage_id        :bigint           not null
@@ -34,8 +35,9 @@ class WikiPageImport < ApplicationRecord
   validates :status, inclusion: { in: STATUSES }
   validates :page_type, inclusion: { in: PAGE_TYPES }, allow_nil: true
 
-  scope :pending,  -> { where(status: 'pending') }
-  scope :imported, -> { where(status: 'imported') }
-  scope :skipped,  -> { where(status: 'skipped') }
-  scope :error,    -> { where(status: 'error') }
+  scope :pending,       -> { where(status: 'pending') }
+  scope :imported,      -> { where(status: 'imported') }
+  scope :skipped,       -> { where(status: 'skipped') }
+  scope :error,         -> { where(status: 'error') }
+  scope :manually_set,  -> { where(manually_set: true) }
 end

--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -29,7 +29,14 @@ class WikipageImporterV2 < WikipageImporter
     return unless unit
 
     # 既存のスナップショットを削除し、再作成する
-    unit.unit_snapshots.destroy_all
+    # SnapshotPerson は Discard::Model を持つため default_scope { kept } が適用される。
+    # destroy_all の cascade では discarded レコードが除外され FK 制約違反になるため、
+    # with_discarded で全レコードを明示的に削除してから unit_snapshots を消す。
+    snapshot_ids = unit.unit_snapshots.pluck(:id)
+    if snapshot_ids.any?
+      SnapshotPerson.with_discarded.where(unit_snapshot_id: snapshot_ids).delete_all
+      unit.unit_snapshots.delete_all
+    end
 
     # 日付付きメンバーセクションを抽出
     dated_sections = extract_dated_member_sections

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,15 +1,31 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Wiki Page Imports（スキップ済み）</h1>
-    <div class="flex items-center gap-4">
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+      Wiki Page Imports（<%= @show_manually_set ? '手動仕訳済み' : 'スキップ済み' %>）
+    </h1>
+    <div class="flex items-center gap-2">
       <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
-      <% if @include_ignored %>
-        <%= link_to admin_wiki_page_imports_path, class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700" do %>
-          ignored を除外する
+
+      <% if @show_manually_set %>
+        <%= link_to admin_wiki_page_imports_path,
+              class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
+          スキップ済み一覧へ
         <% end %>
       <% else %>
-        <%= link_to admin_wiki_page_imports_path(include_ignored: 1), class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
-          ignored を含める
+        <%= link_to admin_wiki_page_imports_path(manually_set: 1),
+              class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
+          手動仕訳済みを表示
+        <% end %>
+        <% if @include_ignored %>
+          <%= link_to admin_wiki_page_imports_path,
+                class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700" do %>
+            ignored を除外する
+          <% end %>
+        <% else %>
+          <%= link_to admin_wiki_page_imports_path(include_ignored: 1),
+                class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
+            ignored を含める
+          <% end %>
         <% end %>
       <% end %>
     </div>
@@ -19,18 +35,31 @@
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
   </div>
 
+  <%# 個別 page_type 更新フォーム（行ごとに正しい action を持つ hidden form） %>
+  <% @wiki_page_imports.each do |wpi| %>
+    <%= form_with url: update_page_type_admin_wiki_page_import_path(wpi), method: :patch,
+                  id: "pt-form-#{wpi.id}", class: "hidden" do %>
+      <input type="hidden" name="page_type" id="pt-value-<%= wpi.id %>">
+    <% end %>
+  <% end %>
+
   <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch do |f| %>
     <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
       <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-700">
           <tr>
             <th class="px-4 py-3">
-              <input type="checkbox" id="check_all" class="rounded border-gray-300 dark:border-gray-600" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)">
+              <input type="checkbox" id="check_all" class="rounded border-gray-300 dark:border-gray-600" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
             </th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">page_type</th>
+            <% if @show_manually_set %>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
+            <% else %>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
+            <% end %>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
           </tr>
         </thead>
@@ -38,7 +67,7 @@
           <% @wiki_page_imports.each do |wpi| %>
             <tr>
               <td class="px-4 py-4">
-                <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600">
+                <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600" aria-label="<%= wpi.wikipage&.title %> を選択">
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
               <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
@@ -46,14 +75,43 @@
                 <% if wpi.wikipage %>
                   <%= link_to wpi.wikipage.vkdb_url, target: "_blank", rel: "noopener", class: "group flex items-center gap-1 hover:text-indigo-500 transition-colors" do %>
                     <span class="font-mono"><%= wpi.wikipage.name %></span>
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0" aria-hidden="true">
                       <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
                       <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
                     </svg>
                   <% end %>
                 <% end %>
               </td>
-              <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
+              <td class="px-6 py-4 text-sm whitespace-nowrap">
+                <div class="flex items-center gap-2">
+                  <select id="pt-select-<%= wpi.id %>"
+                          class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
+                          aria-label="<%= wpi.wikipage&.title %> の page_type">
+                    <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
+                    <option value="unit"   <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
+                    <option value="person" <%= 'selected' if wpi.page_type == 'person' %>>person</option>
+                    <option value="other"  <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                  </select>
+                  <button type="button"
+                          onclick="submitRowPageType(<%= wpi.id %>)"
+                          class="px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 shrink-0">
+                    Set
+                  </button>
+                </div>
+              </td>
+              <% if @show_manually_set %>
+                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
+                    <%= wpi.status == 'imported' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
+                        wpi.status == 'skipped'  ? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' :
+                        wpi.status == 'error'    ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
+                                                   'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' %>">
+                    <%= wpi.status %>
+                  </span>
+                </td>
+              <% else %>
+                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
+              <% end %>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
             </tr>
           <% end %>
@@ -61,12 +119,64 @@
       </table>
     </div>
 
-    <div class="flex justify-end">
-      <%= f.submit '選択した項目を ignored にする',
-            class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer",
-            onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
+    <div class="flex flex-wrap items-center justify-between gap-4">
+      <div class="flex items-center gap-2">
+        <label class="text-sm text-gray-600 dark:text-gray-400">一括設定:</label>
+        <select id="bulk-pt-select"
+                class="text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1.5 pr-8"
+                aria-label="一括設定する page_type">
+          <option value="">-- page_type --</option>
+          <option value="unit">unit</option>
+          <option value="person">person</option>
+          <option value="other">other</option>
+        </select>
+        <button type="button"
+                onclick="submitBulkPageType()"
+                class="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer">
+          選択した項目の page_type を設定
+        </button>
+      </div>
+
+      <% unless @show_manually_set %>
+        <%= f.submit '選択した項目を ignored にする',
+              class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400",
+              onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
+      <% end %>
     </div>
   <% end %>
+
+  <%# bulk_update_page_type 専用フォーム（JS で ids[] を注入して submit） %>
+  <%= form_with url: bulk_update_page_type_admin_wiki_page_imports_path, method: :patch,
+                id: "bulk-pt-form", class: "hidden" do %>
+    <input type="hidden" name="page_type" id="bulk-pt-page-type">
+  <% end %>
+
+  <script>
+    function submitRowPageType(id) {
+      document.getElementById('pt-value-' + id).value = document.getElementById('pt-select-' + id).value;
+      document.getElementById('pt-form-' + id).requestSubmit();
+    }
+
+    function submitBulkPageType() {
+      var checked = document.querySelectorAll('.row-check:checked');
+      if (checked.length === 0) {
+        alert('項目が選択されていません');
+        return;
+      }
+      var pageType = document.getElementById('bulk-pt-select').value;
+      var form = document.getElementById('bulk-pt-form');
+      form.querySelectorAll('input[name="ids[]"]').forEach(function(el) { el.remove(); });
+      checked.forEach(function(cb) {
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'ids[]';
+        input.value = cb.value;
+        form.appendChild(input);
+      });
+      document.getElementById('bulk-pt-page-type').value = pageType;
+      form.requestSubmit();
+    }
+  </script>
 
   <div class="mt-4 flex justify-center">
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,8 +87,12 @@ Rails.application.routes.draw do
     end
 
     resources :wiki_page_imports, only: %i[index] do
+      member do
+        patch :update_page_type
+      end
       collection do
         patch :bulk_ignore
+        patch :bulk_update_page_type
       end
     end
   end

--- a/db/migrate/20260324143450_add_manually_set_to_wiki_page_imports.rb
+++ b/db/migrate/20260324143450_add_manually_set_to_wiki_page_imports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddManuallySetToWikiPageImports < ActiveRecord::Migration[8.1]
   def change
     add_column :wiki_page_imports, :manually_set, :boolean, default: false, null: false

--- a/db/migrate/20260324143450_add_manually_set_to_wiki_page_imports.rb
+++ b/db/migrate/20260324143450_add_manually_set_to_wiki_page_imports.rb
@@ -1,0 +1,5 @@
+class AddManuallySetToWikiPageImports < ActiveRecord::Migration[8.1]
+  def change
+    add_column :wiki_page_imports, :manually_set, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_120912) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_24_143450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -357,6 +357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_120912) do
     t.bigint "import_target_id"
     t.string "import_target_type"
     t.datetime "last_imported_at"
+    t.boolean "manually_set", default: false, null: false
     t.text "note"
     t.string "page_type"
     t.string "status", default: "pending", null: false

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -89,47 +89,72 @@ namespace :import do
 
   desc 'Import people from Wikipages'
   task people: :environment do
+    manual_mode = ENV['MANUAL'] == '1'
     puts 'Starting person import from Wikipages...'
+    puts 'Mode: MANUAL (page_type=person の手動設定済みページのみ)' if manual_mode
     count = 0
     skipped = 0
 
-    query = Wikipage.all
-    if ENV['ID']
-      query = query.where(id: ENV['ID'])
-      puts "Targeting single ID: #{ENV['ID']}"
-    elsif ENV['START']
-      query = query.where('id >= ?', ENV['START'])
-      puts "Starting from ID: #{ENV['START']}"
+    if manual_mode
+      query = WikiPageImport.manually_set.where(page_type: 'person').includes(:wikipage)
+    else
+      query = Wikipage.all
+      if ENV['ID']
+        query = query.where(id: ENV['ID'])
+        puts "Targeting single ID: #{ENV['ID']}"
+      elsif ENV['START']
+        query = query.where('id >= ?', ENV['START'])
+        puts "Starting from ID: #{ENV['START']}"
+      end
     end
 
     limit = ENV['LIMIT']&.to_i
     puts "Limit: #{limit}" if limit
 
-    query.find_each.with_index do |wp, _index|
-      break if limit && count >= limit
+    if manual_mode
+      query.find_each do |wpi|
+        break if limit && count >= limit
 
-      if PersonImporter.ignored?(wp)
-        skipped += 1
-        update_wiki_page_import_as_skipped(wp, note: 'ignored')
-        next
-      elsif PersonImporter.valid_person?(wp)
+        wp = wpi.wikipage
+        unless wp
+          puts "[SKIP] WikiPageImport##{wpi.id}: wikipage not found"
+          next
+        end
+
         PersonImporter.import(wp)
         count += 1
+        puts "[IMPORTED] #{wp.title} (ID: #{wp.id})"
+
         person = Person.find_by(old_wiki_id: wp.id)
         update_wiki_page_import_as_imported(wp, page_type: 'person', target: person)
-      else
-        skipped += 1
-        # ユニット候補はunits_v2タスクで処理済みのためスキップ対象外
-        unless WikipageImporter.valid_unit?(wp)
-          update_wiki_page_import_as_skipped(wp, note: 'not a unit or person')
-          puts format_skip_log(wp) if wp.title.present?
+      end
+    else
+      query.find_each.with_index do |wp, _index|
+        break if limit && count >= limit
+
+        if PersonImporter.ignored?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'ignored')
+          next
+        elsif PersonImporter.valid_person?(wp)
+          PersonImporter.import(wp)
+          count += 1
+          person = Person.find_by(old_wiki_id: wp.id)
+          update_wiki_page_import_as_imported(wp, page_type: 'person', target: person)
+        else
+          skipped += 1
+          # ユニット候補はunits_v2タスクで処理済みのためスキップ対象外
+          unless WikipageImporter.valid_unit?(wp)
+            update_wiki_page_import_as_skipped(wp, note: 'not a unit or person')
+            puts format_skip_log(wp) if wp.title.present?
+          end
         end
       end
     end
 
     puts 'Import complete!'
     puts "  Imported: #{count} people"
-    puts "  Skipped:  #{skipped} pages"
+    puts "  Skipped:  #{skipped} pages" unless manual_mode
   end
 
   desc 'Reset all imported data'

--- a/lib/tasks/import_v2.rake
+++ b/lib/tasks/import_v2.rake
@@ -3,31 +3,39 @@
 namespace :import do
   desc 'Import units with snapshots from Wikipages (V2)'
   task units_v2: :environment do
+    manual_mode = ENV['MANUAL'] == '1'
     puts 'Starting unit import with snapshots from Wikipages (V2)...'
+    puts 'Mode: MANUAL (page_type=unit の手動設定済みページのみ)' if manual_mode
     count = 0
     skipped = 0
     snapshots_created = 0
 
-    query = Wikipage.all
-    if ENV['ID']
-      query = query.where(id: ENV['ID'])
-      puts "Targeting single ID: #{ENV['ID']}"
-    elsif ENV['START']
-      query = query.where('id >= ?', ENV['START'])
-      puts "Starting from ID: #{ENV['START']}"
+    if manual_mode
+      query = WikiPageImport.manually_set.where(page_type: 'unit').includes(:wikipage)
+    else
+      query = Wikipage.all
+      if ENV['ID']
+        query = query.where(id: ENV['ID'])
+        puts "Targeting single ID: #{ENV['ID']}"
+      elsif ENV['START']
+        query = query.where('id >= ?', ENV['START'])
+        puts "Starting from ID: #{ENV['START']}"
+      end
     end
 
     limit = ENV['LIMIT']&.to_i
     puts "Limit: #{limit}" if limit
 
-    query.find_each.with_index do |wp, _index|
-      break if limit && count >= limit
+    if manual_mode
+      query.find_each do |wpi|
+        break if limit && count >= limit
 
-      if WikipageImporter.ignored?(wp)
-        skipped += 1
-        update_wiki_page_import_as_skipped(wp, note: 'ignored')
-        next
-      elsif WikipageImporter.valid_unit?(wp)
+        wp = wpi.wikipage
+        unless wp
+          puts "[SKIP] WikiPageImport##{wpi.id}: wikipage not found"
+          next
+        end
+
         # ID指定時: インポート前に既存の関連レコードを削除
         if ENV['ID']
           existing_unit = Unit.find_by(old_wiki_id: wp.id)
@@ -40,23 +48,53 @@ namespace :import do
           end
         end
 
-        # V2 importer を使用
         WikipageImporterV2.import(wp)
         count += 1
+        puts "[IMPORTED] #{wp.title} (ID: #{wp.id})"
 
-        # 作成されたスナップショット数をカウント
         unit = Unit.find_by(old_wiki_id: wp.id)
         snapshots_created += unit.unit_snapshots.count if unit
         update_wiki_page_import_as_imported(wp, page_type: 'unit', target: unit)
-      else
-        skipped += 1
-        puts format_skip_log(wp) if wp.title.present? && !PersonImporter.valid_person?(wp)
+      end
+    else
+      query.find_each.with_index do |wp, _index|
+        break if limit && count >= limit
+
+        if WikipageImporter.ignored?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'ignored')
+          next
+        elsif WikipageImporter.valid_unit?(wp)
+          # ID指定時: インポート前に既存の関連レコードを削除
+          if ENV['ID']
+            existing_unit = Unit.find_by(old_wiki_id: wp.id)
+            if existing_unit
+              sections_count = existing_unit.sections.count
+              links_count = existing_unit.links.count
+              existing_unit.sections.destroy_all
+              existing_unit.links.destroy_all
+              puts "  Pre-delete: #{sections_count} sections, #{links_count} links (#{existing_unit.name})"
+            end
+          end
+
+          # V2 importer を使用
+          WikipageImporterV2.import(wp)
+          count += 1
+
+          # 作成されたスナップショット数をカウント
+          unit = Unit.find_by(old_wiki_id: wp.id)
+          snapshots_created += unit.unit_snapshots.count if unit
+          update_wiki_page_import_as_imported(wp, page_type: 'unit', target: unit)
+        else
+          skipped += 1
+          puts format_skip_log(wp) if wp.title.present? && !PersonImporter.valid_person?(wp)
+        end
       end
     end
 
     puts 'Import complete!'
     puts "  Imported: #{count} units"
     puts "  Snapshots created: #{snapshots_created}"
-    puts "  Skipped:  #{skipped} pages"
+    puts "  Skipped:  #{skipped} pages" unless manual_mode
   end
 end


### PR DESCRIPTION
## Summary
- `manually_set` カラムを追加し、手動仕訳済みページを管理できるようにした
- 管理画面（スキップ済み一覧）で `page_type` を個別・一括設定できるよう対応
- `page_type` に空（`--`）を選ぶと手動仕訳をキャンセル（`manually_set: false` + `page_type: nil`）
- 手動仕訳済み一覧（`imported` 除外）を別表示するトグルを追加
- `import:units_v2 MANUAL=1` で `page_type: unit` の手動設定済みページを強制インポート
- `import:people MANUAL=1` で `page_type: person` の手動設定済みページを強制インポート
- 強制インポート後に `wiki_page_imports` のステータスを `imported` に更新
- `WikipageImporterV2` の snapshot 削除時に `SnapshotPerson` の `default_scope { kept }` による FK 制約エラーを修正

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] スキップ済み一覧でデフォルトは手動仕訳済みが除外されていること
- [ ] 「手動仕訳済みを表示」ボタンで手動仕訳済み一覧に切り替えられること
- [ ] 個別行の page_type セレクトで Set ボタンが動作すること
- [ ] 一括選択 + page_type 設定が動作すること
- [ ] `--` を選んで Set するとキャンセルされること
- [ ] `import:units_v2 MANUAL=1` / `import:people MANUAL=1` が期待通り動作すること

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)