### PR TITLE
feat: wiki_page_imports に deferred ステータスを追加 (#521)

### DIFF
--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -6,16 +6,29 @@ module Admin
 
     def index
       @show_manually_set = params[:manually_set] == '1'
+      @show_deferred     = params[:show_deferred] == '1'
       @include_ignored   = params[:include_ignored] == '1'
 
       if @show_manually_set
         scope = WikiPageImport.manually_set.where.not(status: 'imported').includes(:wikipage).order(updated_at: :desc)
+      elsif @show_deferred
+        scope = WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
       else
         scope = WikiPageImport.skipped.where(manually_set: false).includes(:wikipage).order(updated_at: :desc)
         scope = scope.where.not(note: 'ignored') unless @include_ignored
       end
 
       @pagy, @wiki_page_imports = pagy(scope, limit: 50)
+    end
+
+    def bulk_set_deferred
+      ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
+      if ids.any?
+        WikiPageImport.where(id: ids).update_all(status: 'deferred', updated_at: Time.current)
+        redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を deferred にしました"
+      else
+        redirect_to admin_wiki_page_imports_path, alert: '項目が選択されていません'
+      end
     end
 
     def bulk_ignore

--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -26,7 +26,7 @@
 #
 
 class WikiPageImport < ApplicationRecord
-  STATUSES = %w[pending imported skipped error].freeze
+  STATUSES = %w[pending imported skipped deferred error].freeze
   PAGE_TYPES = %w[unit person other].freeze
 
   belongs_to :wikipage
@@ -38,6 +38,7 @@ class WikiPageImport < ApplicationRecord
   scope :pending,       -> { where(status: 'pending') }
   scope :imported,      -> { where(status: 'imported') }
   scope :skipped,       -> { where(status: 'skipped') }
+  scope :deferred,      -> { where(status: 'deferred') }
   scope :error,         -> { where(status: 'error') }
   scope :manually_set,  -> { where(manually_set: true) }
 end

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,21 +1,12 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-      Wiki Page Imports（<%= @show_manually_set ? '手動仕訳済み' : 'スキップ済み' %>）
+      Wiki Page Imports（<%= @show_manually_set ? '手動仕訳済み' : @show_deferred ? 'Deferred' : 'スキップ済み' %>）
     </h1>
     <div class="flex items-center gap-2">
       <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
 
-      <% if @show_manually_set %>
-        <%= link_to admin_wiki_page_imports_path,
-              class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
-          スキップ済み一覧へ
-        <% end %>
-      <% else %>
-        <%= link_to admin_wiki_page_imports_path(manually_set: 1),
-              class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
-          手動仕訳済みを表示
-        <% end %>
+      <% unless @show_manually_set || @show_deferred %>
         <% if @include_ignored %>
           <%= link_to admin_wiki_page_imports_path,
                 class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700" do %>
@@ -31,6 +22,22 @@
     </div>
   </div>
 
+  <%# タブナビゲーション %>
+  <div class="flex gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
+    <%= link_to admin_wiki_page_imports_path,
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{!@show_manually_set && !@show_deferred ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+      スキップ済み
+    <% end %>
+    <%= link_to admin_wiki_page_imports_path(show_deferred: 1),
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_deferred ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+      Deferred
+    <% end %>
+    <%= link_to admin_wiki_page_imports_path(manually_set: 1),
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_manually_set ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+      手動仕訳済み
+    <% end %>
+  </div>
+
   <div class="mb-4 flex justify-center">
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
   </div>
@@ -43,32 +50,116 @@
     <% end %>
   <% end %>
 
-  <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch do |f| %>
+  <%# スキップ済み一覧用フォーム（bulk_ignore / bulk_set_deferred 兼用） %>
+  <% if !@show_manually_set && !@show_deferred %>
+    <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch, id: "skip-form" do |f| %>
+      <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th class="px-4 py-3">
+                <input type="checkbox" id="check_all" class="rounded border-gray-300 dark:border-gray-600" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
+              </th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">page_type</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            <% @wiki_page_imports.each do |wpi| %>
+              <tr>
+                <td class="px-4 py-4">
+                  <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600" aria-label="<%= wpi.wikipage&.title %> を選択">
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
+                <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
+                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                  <% if wpi.wikipage %>
+                    <%= link_to wpi.wikipage.vkdb_url, target: "_blank", rel: "noopener", class: "group flex items-center gap-1 hover:text-indigo-500 transition-colors" do %>
+                      <span class="font-mono"><%= wpi.wikipage.name %></span>
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                        <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                      </svg>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td class="px-6 py-4 text-sm whitespace-nowrap">
+                  <div class="flex items-center gap-2">
+                    <select id="pt-select-<%= wpi.id %>"
+                            class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
+                            aria-label="<%= wpi.wikipage&.title %> の page_type">
+                      <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
+                      <option value="unit"   <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
+                      <option value="person" <%= 'selected' if wpi.page_type == 'person' %>>person</option>
+                      <option value="other"  <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                    </select>
+                    <button type="button"
+                            onclick="submitRowPageType(<%= wpi.id %>)"
+                            class="px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 shrink-0">
+                      Set
+                    </button>
+                  </div>
+                </td>
+                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-3 shadow-md">
+        <div class="flex items-center gap-2">
+          <label class="text-sm text-gray-600 dark:text-gray-400">一括設定:</label>
+          <select id="bulk-pt-select"
+                  class="text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1.5 pr-8"
+                  aria-label="一括設定する page_type">
+            <option value="">-- page_type --</option>
+            <option value="unit">unit</option>
+            <option value="person">person</option>
+            <option value="other">other</option>
+          </select>
+          <button type="button"
+                  onclick="submitBulkPageType()"
+                  class="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer">
+            選択した項目の page_type を設定
+          </button>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <%= f.submit '選択した項目を ignored にする',
+                class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400",
+                onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
+          <button type="button"
+                  onclick="submitBulkDeferred()"
+                  class="px-4 py-2 text-sm bg-purple-500 text-white rounded-md hover:bg-purple-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-purple-400">
+            選択した項目を deferred にする
+          </button>
+        </div>
+      </div>
+    <% end %>
+
+  <%# Deferred 一覧 %>
+  <% elsif @show_deferred %>
     <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
       <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-700">
           <tr>
-            <th class="px-4 py-3">
-              <input type="checkbox" id="check_all" class="rounded border-gray-300 dark:border-gray-600" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
-            </th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">page_type</th>
-            <% if @show_manually_set %>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
-            <% else %>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
-            <% end %>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
           </tr>
         </thead>
         <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
           <% @wiki_page_imports.each do |wpi| %>
             <tr>
-              <td class="px-4 py-4">
-                <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600" aria-label="<%= wpi.wikipage&.title %> を選択">
-              </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
               <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
               <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
@@ -99,19 +190,7 @@
                   </button>
                 </div>
               </td>
-              <% if @show_manually_set %>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
-                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
-                    <%= wpi.status == 'imported' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
-                        wpi.status == 'skipped'  ? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' :
-                        wpi.status == 'error'    ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
-                                                   'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' %>">
-                    <%= wpi.status %>
-                  </span>
-                </td>
-              <% else %>
-                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
-              <% end %>
+              <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
             </tr>
           <% end %>
@@ -119,36 +198,107 @@
       </table>
     </div>
 
-    <div class="flex flex-wrap items-center justify-between gap-4">
-      <div class="flex items-center gap-2">
-        <label class="text-sm text-gray-600 dark:text-gray-400">一括設定:</label>
-        <select id="bulk-pt-select"
-                class="text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1.5 pr-8"
-                aria-label="一括設定する page_type">
-          <option value="">-- page_type --</option>
-          <option value="unit">unit</option>
-          <option value="person">person</option>
-          <option value="other">other</option>
-        </select>
-        <button type="button"
-                onclick="submitBulkPageType()"
-                class="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer">
-          選択した項目の page_type を設定
-        </button>
+  <%# 手動仕訳済み一覧 %>
+  <% else %>
+    <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch do |f| %>
+      <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-700">
+            <tr>
+              <th class="px-4 py-3">
+                <input type="checkbox" id="check_all" class="rounded border-gray-300 dark:border-gray-600" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
+              </th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">ID</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Title</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Name</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">page_type</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+            <% @wiki_page_imports.each do |wpi| %>
+              <tr>
+                <td class="px-4 py-4">
+                  <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600" aria-label="<%= wpi.wikipage&.title %> を選択">
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
+                <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
+                <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                  <% if wpi.wikipage %>
+                    <%= link_to wpi.wikipage.vkdb_url, target: "_blank", rel: "noopener", class: "group flex items-center gap-1 hover:text-indigo-500 transition-colors" do %>
+                      <span class="font-mono"><%= wpi.wikipage.name %></span>
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 text-gray-400 group-hover:text-indigo-500 shrink-0" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                        <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                      </svg>
+                    <% end %>
+                  <% end %>
+                </td>
+                <td class="px-6 py-4 text-sm whitespace-nowrap">
+                  <div class="flex items-center gap-2">
+                    <select id="pt-select-<%= wpi.id %>"
+                            class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
+                            aria-label="<%= wpi.wikipage&.title %> の page_type">
+                      <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
+                      <option value="unit"   <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
+                      <option value="person" <%= 'selected' if wpi.page_type == 'person' %>>person</option>
+                      <option value="other"  <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                    </select>
+                    <button type="button"
+                            onclick="submitRowPageType(<%= wpi.id %>)"
+                            class="px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 shrink-0">
+                      Set
+                    </button>
+                  </div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                  <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
+                    <%= wpi.status == 'imported'  ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
+                        wpi.status == 'skipped'   ? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' :
+                        wpi.status == 'deferred'  ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' :
+                        wpi.status == 'error'     ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
+                                                    'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' %>">
+                    <%= wpi.status %>
+                  </span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
       </div>
 
-      <% unless @show_manually_set %>
-        <%= f.submit '選択した項目を ignored にする',
-              class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400",
-              onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
-      <% end %>
-    </div>
+      <div class="sticky bottom-0 z-10 flex flex-wrap items-center gap-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-3 shadow-md">
+        <div class="flex items-center gap-2">
+          <label class="text-sm text-gray-600 dark:text-gray-400">一括設定:</label>
+          <select id="bulk-pt-select"
+                  class="text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1.5 pr-8"
+                  aria-label="一括設定する page_type">
+            <option value="">-- page_type --</option>
+            <option value="unit">unit</option>
+            <option value="person">person</option>
+            <option value="other">other</option>
+          </select>
+          <button type="button"
+                  onclick="submitBulkPageType()"
+                  class="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer">
+            選択した項目の page_type を設定
+          </button>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
   <%# bulk_update_page_type 専用フォーム（JS で ids[] を注入して submit） %>
   <%= form_with url: bulk_update_page_type_admin_wiki_page_imports_path, method: :patch,
                 id: "bulk-pt-form", class: "hidden" do %>
     <input type="hidden" name="page_type" id="bulk-pt-page-type">
+  <% end %>
+
+  <%# bulk_set_deferred 専用フォーム %>
+  <%= form_with url: bulk_set_deferred_admin_wiki_page_imports_path, method: :patch,
+                id: "bulk-deferred-form", class: "hidden" do %>
   <% end %>
 
   <script>
@@ -174,6 +324,25 @@
         form.appendChild(input);
       });
       document.getElementById('bulk-pt-page-type').value = pageType;
+      form.requestSubmit();
+    }
+
+    function submitBulkDeferred() {
+      var checked = document.querySelectorAll('.row-check:checked');
+      if (checked.length === 0) {
+        alert('項目が選択されていません');
+        return;
+      }
+      if (!confirm('選択した項目を deferred にします。よろしいですか？')) return;
+      var form = document.getElementById('bulk-deferred-form');
+      form.querySelectorAll('input[name="ids[]"]').forEach(function(el) { el.remove(); });
+      checked.forEach(function(cb) {
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'ids[]';
+        input.value = cb.value;
+        form.appendChild(input);
+      });
       form.requestSubmit();
     }
   </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
       collection do
         patch :bulk_ignore
         patch :bulk_update_page_type
+        patch :bulk_set_deferred
       end
     end
   end


### PR DESCRIPTION
## Summary
- スキップ済み一覧から「後で検討」として保留できる `deferred` ステータスを追加
- `pending`（初期未処理）と意味的に区別し、専用タブ（Deferred）と一括設定ボタンを提供
- スキップ済み・手動仕訳済み両タブの仕訳ボタンエリアを `sticky bottom-0` で常時表示に変更

## Test plan
- [ ] スキップ済み一覧で複数選択 → 「deferred にする」ボタンが動作する
- [ ] Deferred タブに移動した件数が表示される
- [ ] スキップ済み一覧に deferred ステータスの項目が混入しない
- [ ] 3タブ（スキップ済み / Deferred / 手動仕訳済み）が正しく切り替わる
- [ ] スクロール時にボタンエリアが画面下部に固定表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)