### PR TITLE
feat: wiki_page_imports の page_type に live_house / custom_page / omnibus / moved を追加

### DIFF
--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -27,7 +27,7 @@
 
 class WikiPageImport < ApplicationRecord
   STATUSES = %w[pending imported skipped deferred error].freeze
-  PAGE_TYPES = %w[unit person other].freeze
+  PAGE_TYPES = %w[unit person live_house custom_page omnibus moved other].freeze
 
   belongs_to :wikipage
   belongs_to :import_target, polymorphic: true, optional: true

--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -27,7 +27,7 @@
 
 class WikiPageImport < ApplicationRecord
   STATUSES = %w[pending imported skipped deferred error].freeze
-  PAGE_TYPES = %w[unit person live_house custom_page omnibus moved other].freeze
+  PAGE_TYPES = %w[unit person live_house custom_page omnibus moved office_label other].freeze
 
   belongs_to :wikipage
   belongs_to :import_target, polymorphic: true, optional: true

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -74,7 +74,8 @@
                 <td class="px-4 py-4">
                   <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600" aria-label="<%= wpi.wikipage&.title %> を選択">
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 cursor-pointer select-none"
+                    onclick="this.closest('tr').querySelector('.row-check').click()"><%= wpi.wikipage_id %></td>
                 <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
                 <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   <% if wpi.wikipage %>
@@ -233,7 +234,8 @@
                 <td class="px-4 py-4">
                   <input type="checkbox" name="ids[]" value="<%= wpi.id %>" class="row-check rounded border-gray-300 dark:border-gray-600" aria-label="<%= wpi.wikipage&.title %> を選択">
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.wikipage_id %></td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 cursor-pointer select-none"
+                    onclick="this.closest('tr').querySelector('.row-check').click()"><%= wpi.wikipage_id %></td>
                 <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100"><%= wpi.wikipage&.title %></td>
                 <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                   <% if wpi.wikipage %>

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -93,9 +93,13 @@
                             class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
                             aria-label="<%= wpi.wikipage&.title %> の page_type">
                       <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
-                      <option value="unit"   <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
-                      <option value="person" <%= 'selected' if wpi.page_type == 'person' %>>person</option>
-                      <option value="other"  <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                      <option value="unit"        <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
+                      <option value="person"      <%= 'selected' if wpi.page_type == 'person' %>>person</option>
+                      <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
+                      <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
+                      <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
+                      <option value="moved"       <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
+                      <option value="other"       <%= 'selected' if wpi.page_type == 'other' %>>other</option>
                     </select>
                     <button type="button"
                             onclick="submitRowPageType(<%= wpi.id %>)"
@@ -121,6 +125,10 @@
             <option value="">-- page_type --</option>
             <option value="unit">unit</option>
             <option value="person">person</option>
+            <option value="live_house">live_house</option>
+            <option value="custom_page">custom_page</option>
+            <option value="omnibus">omnibus</option>
+            <option value="moved">moved</option>
             <option value="other">other</option>
           </select>
           <button type="button"
@@ -179,9 +187,12 @@
                           class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
                           aria-label="<%= wpi.wikipage&.title %> の page_type">
                     <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
-                    <option value="unit"   <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
-                    <option value="person" <%= 'selected' if wpi.page_type == 'person' %>>person</option>
-                    <option value="other"  <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                    <option value="unit"        <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
+                    <option value="person"      <%= 'selected' if wpi.page_type == 'person' %>>person</option>
+                    <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
+                    <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
+                    <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
+                    <option value="other"       <%= 'selected' if wpi.page_type == 'other' %>>other</option>
                   </select>
                   <button type="button"
                           onclick="submitRowPageType(<%= wpi.id %>)"
@@ -241,9 +252,13 @@
                             class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
                             aria-label="<%= wpi.wikipage&.title %> の page_type">
                       <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
-                      <option value="unit"   <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
-                      <option value="person" <%= 'selected' if wpi.page_type == 'person' %>>person</option>
-                      <option value="other"  <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                      <option value="unit"        <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
+                      <option value="person"      <%= 'selected' if wpi.page_type == 'person' %>>person</option>
+                      <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
+                      <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
+                      <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
+                      <option value="moved"       <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
+                      <option value="other"       <%= 'selected' if wpi.page_type == 'other' %>>other</option>
                     </select>
                     <button type="button"
                             onclick="submitRowPageType(<%= wpi.id %>)"
@@ -278,6 +293,10 @@
             <option value="">-- page_type --</option>
             <option value="unit">unit</option>
             <option value="person">person</option>
+            <option value="live_house">live_house</option>
+            <option value="custom_page">custom_page</option>
+            <option value="omnibus">omnibus</option>
+            <option value="moved">moved</option>
             <option value="other">other</option>
           </select>
           <button type="button"

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -99,8 +99,9 @@
                       <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
                       <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
                       <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
-                      <option value="moved"       <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
-                      <option value="other"       <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                      <option value="moved"        <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
+                      <option value="office_label" <%= 'selected' if wpi.page_type == 'office_label' %>>office_label</option>
+                      <option value="other"        <%= 'selected' if wpi.page_type == 'other' %>>other</option>
                     </select>
                     <button type="button"
                             onclick="submitRowPageType(<%= wpi.id %>)"
@@ -130,6 +131,7 @@
             <option value="custom_page">custom_page</option>
             <option value="omnibus">omnibus</option>
             <option value="moved">moved</option>
+            <option value="office_label">office_label</option>
             <option value="other">other</option>
           </select>
           <button type="button"
@@ -259,8 +261,9 @@
                       <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
                       <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
                       <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
-                      <option value="moved"       <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
-                      <option value="other"       <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                      <option value="moved"        <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
+                      <option value="office_label" <%= 'selected' if wpi.page_type == 'office_label' %>>office_label</option>
+                      <option value="other"        <%= 'selected' if wpi.page_type == 'other' %>>other</option>
                     </select>
                     <button type="button"
                             onclick="submitRowPageType(<%= wpi.id %>)"
@@ -299,6 +302,7 @@
             <option value="custom_page">custom_page</option>
             <option value="omnibus">omnibus</option>
             <option value="moved">moved</option>
+            <option value="office_label">office_label</option>
             <option value="other">other</option>
           </select>
           <button type="button"


### PR DESCRIPTION
## Summary
- `WikiPageImport::PAGE_TYPES` に `live_house`、`custom_page`、`omnibus`、`moved` を追加
- 管理画面の仕訳けセレクトボックス（行ごと・一括）にそれぞれのオプションを追加
- スキップ済み・手動仕訳済みタブで ID セルをクリックするとチェックボックスがトグルされるよう改善

## Test plan
- [ ] スキップ済みタブで各 page_type（live_house / custom_page / omnibus / moved / other）を選択して Set できる
- [ ] 一括設定セレクトから新しい page_type を選んで一括設定できる
- [ ] Deferred タブでも同様にセレクトに新しい選択肢が表示される
- [ ] ID セルをクリックするとチェックボックスがトグルされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)