### PR TITLE
feat: wiki_page_imports 管理画面に除外済みタブ・手動仕訳済みに page_type サブタブを追加

### DIFF
--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -8,9 +8,10 @@ module Admin
       @show_manually_set = params[:manually_set] == '1'
       @show_deferred     = params[:show_deferred] == '1'
       @show_ignored      = params[:show_ignored] == '1'
+      @ms_page_type      = @show_manually_set ? (params[:ms_page_type].presence || 'unit') : nil
 
       scope = if @show_manually_set
-                WikiPageImport.manually_set.where.not(status: 'imported').includes(:wikipage).order(updated_at: :desc)
+                WikiPageImport.manually_set.where.not(status: 'imported').where(page_type: @ms_page_type).includes(:wikipage).order(updated_at: :desc)
               elsif @show_deferred
                 WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
               elsif @show_ignored

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -9,15 +9,15 @@ module Admin
       @show_deferred     = params[:show_deferred] == '1'
       @show_ignored      = params[:show_ignored] == '1'
 
-      if @show_manually_set
-        scope = WikiPageImport.manually_set.where.not(status: 'imported').includes(:wikipage).order(updated_at: :desc)
-      elsif @show_deferred
-        scope = WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
-      elsif @show_ignored
-        scope = WikiPageImport.skipped.where(manually_set: false, note: 'ignored').includes(:wikipage).order(updated_at: :desc)
-      else
-        scope = WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored').includes(:wikipage).order(updated_at: :desc)
-      end
+      scope = if @show_manually_set
+                WikiPageImport.manually_set.where.not(status: 'imported').includes(:wikipage).order(updated_at: :desc)
+              elsif @show_deferred
+                WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
+              elsif @show_ignored
+                WikiPageImport.skipped.where(manually_set: false, note: 'ignored').includes(:wikipage).order(updated_at: :desc)
+              else
+                WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored').includes(:wikipage).order(updated_at: :desc)
+              end
 
       @pagy, @wiki_page_imports = pagy(scope, limit: 50)
     end

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -27,7 +27,7 @@ module Admin
       ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
       if ids.any?
         WikiPageImport.where(id: ids).update_all(status: 'deferred', updated_at: Time.current)
-        redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を deferred にしました"
+        redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を保留にしました"
       else
         redirect_to admin_wiki_page_imports_path, alert: '項目が選択されていません'
       end
@@ -37,7 +37,7 @@ module Admin
       ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
       if ids.any?
         WikiPageImport.where(id: ids).update_all(note: 'ignored', updated_at: Time.current)
-        redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を ignored にしました"
+        redirect_to admin_wiki_page_imports_path, notice: "#{ids.size} 件を除外しました"
       else
         redirect_to admin_wiki_page_imports_path, alert: '項目が選択されていません'
       end

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -7,15 +7,16 @@ module Admin
     def index
       @show_manually_set = params[:manually_set] == '1'
       @show_deferred     = params[:show_deferred] == '1'
-      @include_ignored   = params[:include_ignored] == '1'
+      @show_ignored      = params[:show_ignored] == '1'
 
       if @show_manually_set
         scope = WikiPageImport.manually_set.where.not(status: 'imported').includes(:wikipage).order(updated_at: :desc)
       elsif @show_deferred
         scope = WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
+      elsif @show_ignored
+        scope = WikiPageImport.skipped.where(manually_set: false, note: 'ignored').includes(:wikipage).order(updated_at: :desc)
       else
-        scope = WikiPageImport.skipped.where(manually_set: false).includes(:wikipage).order(updated_at: :desc)
-        scope = scope.where.not(note: 'ignored') unless @include_ignored
+        scope = WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored').includes(:wikipage).order(updated_at: :desc)
       end
 
       @pagy, @wiki_page_imports = pagy(scope, limit: 50)

--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -28,6 +28,16 @@
 class WikiPageImport < ApplicationRecord
   STATUSES = %w[pending imported skipped deferred error].freeze
   PAGE_TYPES = %w[unit person live_house custom_page omnibus moved office_label other].freeze
+  PAGE_TYPE_LABELS = {
+    'unit'         => 'ユニット',
+    'person'       => '人物',
+    'live_house'   => 'ライブハウス',
+    'custom_page'  => 'カスタムページ',
+    'omnibus'      => 'オムニバス',
+    'moved'        => '移動',
+    'office_label' => '事務所/レーベル',
+    'other'        => 'その他'
+  }.freeze
 
   belongs_to :wikipage
   belongs_to :import_target, polymorphic: true, optional: true

--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -29,14 +29,14 @@ class WikiPageImport < ApplicationRecord
   STATUSES = %w[pending imported skipped deferred error].freeze
   PAGE_TYPES = %w[unit person live_house custom_page omnibus moved office_label other].freeze
   PAGE_TYPE_LABELS = {
-    'unit'         => 'ユニット',
-    'person'       => '人物',
-    'live_house'   => 'ライブハウス',
-    'custom_page'  => 'カスタムページ',
-    'omnibus'      => 'オムニバス',
-    'moved'        => '移動',
+    'unit' => 'ユニット',
+    'person' => '人物',
+    'live_house' => 'ライブハウス',
+    'custom_page' => 'カスタムページ',
+    'omnibus' => 'オムニバス',
+    'moved' => '移動',
     'office_label' => '事務所/レーベル',
-    'other'        => 'その他'
+    'other' => 'その他'
   }.freeze
 
   belongs_to :wikipage

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-      Wiki Page Imports（<%= @show_manually_set ? "手動仕訳済み - #{@ms_page_type}" : @show_deferred ? 'Deferred' : @show_ignored ? 'Ignored' : 'スキップ済み' %>）
+      Wiki Page Imports（<%= @show_manually_set ? "手動仕訳済み - #{WikiPageImport::PAGE_TYPE_LABELS[@ms_page_type]}" : @show_deferred ? '保留' : @show_ignored ? '除外済み' : 'スキップ済み' %>）
     </h1>
     <div class="flex items-center gap-2">
       <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
@@ -20,11 +20,11 @@
     <% end %>
     <%= link_to admin_wiki_page_imports_path(show_deferred: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_deferred ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
-      Deferred
+      保留
     <% end %>
     <%= link_to admin_wiki_page_imports_path(show_ignored: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
-      Ignored
+      除外済み
     <% end %>
   </div>
 
@@ -84,14 +84,9 @@
                             class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
                             aria-label="<%= wpi.wikipage&.title %> の page_type">
                       <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
-                      <option value="unit"        <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
-                      <option value="person"      <%= 'selected' if wpi.page_type == 'person' %>>person</option>
-                      <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
-                      <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
-                      <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
-                      <option value="moved"        <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
-                      <option value="office_label" <%= 'selected' if wpi.page_type == 'office_label' %>>office_label</option>
-                      <option value="other"        <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                      <% WikiPageImport::PAGE_TYPES.each do |pt| %>
+                        <option value="<%= pt %>" <%= 'selected' if wpi.page_type == pt %>><%= WikiPageImport::PAGE_TYPE_LABELS[pt] %></option>
+                      <% end %>
                     </select>
                     <button type="button"
                             onclick="submitRowPageType(<%= wpi.id %>)"
@@ -115,14 +110,9 @@
                   class="text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1.5 pr-8"
                   aria-label="一括設定する page_type">
             <option value="">-- page_type --</option>
-            <option value="unit">unit</option>
-            <option value="person">person</option>
-            <option value="live_house">live_house</option>
-            <option value="custom_page">custom_page</option>
-            <option value="omnibus">omnibus</option>
-            <option value="moved">moved</option>
-            <option value="office_label">office_label</option>
-            <option value="other">other</option>
+            <% WikiPageImport::PAGE_TYPES.each do |pt| %>
+              <option value="<%= pt %>"><%= WikiPageImport::PAGE_TYPE_LABELS[pt] %></option>
+            <% end %>
           </select>
           <button type="button"
                   onclick="submitBulkPageType()"
@@ -135,11 +125,11 @@
           <button type="button"
                   onclick="submitBulkDeferred()"
                   class="px-4 py-2 text-sm bg-purple-500 text-white rounded-md hover:bg-purple-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-purple-400">
-            選択した項目を deferred にする
+            選択した項目を保留にする
           </button>
-          <%= f.submit '選択した項目を ignored にする',
+          <%= f.submit '選択した項目を除外する',
                 class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400",
-                onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
+                onclick: "return confirm('選択した項目を除外します。よろしいですか？')" %>
         </div>
       </div>
     <% end %>
@@ -180,12 +170,9 @@
                           class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
                           aria-label="<%= wpi.wikipage&.title %> の page_type">
                     <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
-                    <option value="unit"        <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
-                    <option value="person"      <%= 'selected' if wpi.page_type == 'person' %>>person</option>
-                    <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
-                    <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
-                    <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
-                    <option value="other"       <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                    <% WikiPageImport::PAGE_TYPES.each do |pt| %>
+                      <option value="<%= pt %>" <%= 'selected' if wpi.page_type == pt %>><%= WikiPageImport::PAGE_TYPE_LABELS[pt] %></option>
+                    <% end %>
                   </select>
                   <button type="button"
                           onclick="submitRowPageType(<%= wpi.id %>)"
@@ -209,7 +196,7 @@
       <% WikiPageImport::PAGE_TYPES.each do |pt| %>
         <%= link_to admin_wiki_page_imports_path(manually_set: 1, ms_page_type: pt),
               class: "px-3 py-1.5 text-xs font-medium rounded-md border #{@ms_page_type == pt ? 'bg-indigo-600 border-indigo-600 text-white' : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}" do %>
-          <%= pt %>
+          <%= WikiPageImport::PAGE_TYPE_LABELS[pt] %>
         <% end %>
       <% end %>
     </div>
@@ -256,14 +243,9 @@
                             class="text-xs rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1 pr-6"
                             aria-label="<%= wpi.wikipage&.title %> の page_type">
                       <option value="" <%= 'selected' if wpi.page_type.nil? %>>--</option>
-                      <option value="unit"        <%= 'selected' if wpi.page_type == 'unit' %>>unit</option>
-                      <option value="person"      <%= 'selected' if wpi.page_type == 'person' %>>person</option>
-                      <option value="live_house"  <%= 'selected' if wpi.page_type == 'live_house' %>>live_house</option>
-                      <option value="custom_page" <%= 'selected' if wpi.page_type == 'custom_page' %>>custom_page</option>
-                      <option value="omnibus"     <%= 'selected' if wpi.page_type == 'omnibus' %>>omnibus</option>
-                      <option value="moved"        <%= 'selected' if wpi.page_type == 'moved' %>>moved</option>
-                      <option value="office_label" <%= 'selected' if wpi.page_type == 'office_label' %>>office_label</option>
-                      <option value="other"        <%= 'selected' if wpi.page_type == 'other' %>>other</option>
+                      <% WikiPageImport::PAGE_TYPES.each do |pt| %>
+                        <option value="<%= pt %>" <%= 'selected' if wpi.page_type == pt %>><%= WikiPageImport::PAGE_TYPE_LABELS[pt] %></option>
+                      <% end %>
                     </select>
                     <button type="button"
                             onclick="submitRowPageType(<%= wpi.id %>)"
@@ -296,14 +278,9 @@
                   class="text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-1.5 pr-8"
                   aria-label="一括設定する page_type">
             <option value="">-- page_type --</option>
-            <option value="unit">unit</option>
-            <option value="person">person</option>
-            <option value="live_house">live_house</option>
-            <option value="custom_page">custom_page</option>
-            <option value="omnibus">omnibus</option>
-            <option value="moved">moved</option>
-            <option value="office_label">office_label</option>
-            <option value="other">other</option>
+            <% WikiPageImport::PAGE_TYPES.each do |pt| %>
+              <option value="<%= pt %>"><%= WikiPageImport::PAGE_TYPE_LABELS[pt] %></option>
+            <% end %>
           </select>
           <button type="button"
                   onclick="submitBulkPageType()"
@@ -358,7 +335,7 @@
         alert('項目が選択されていません');
         return;
       }
-      if (!confirm('選択した項目を deferred にします。よろしいですか？')) return;
+      if (!confirm('選択した項目を保留にします。よろしいですか？')) return;
       var form = document.getElementById('bulk-deferred-form');
       form.querySelectorAll('input[name="ids[]"]').forEach(function(el) { el.remove(); });
       checked.forEach(function(cb) {

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -14,6 +14,10 @@
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{!@show_manually_set && !@show_deferred && !@show_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       スキップ済み
     <% end %>
+    <%= link_to admin_wiki_page_imports_path(manually_set: 1),
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_manually_set ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+      手動仕訳済み
+    <% end %>
     <%= link_to admin_wiki_page_imports_path(show_deferred: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_deferred ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       Deferred
@@ -21,10 +25,6 @@
     <%= link_to admin_wiki_page_imports_path(show_ignored: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       Ignored
-    <% end %>
-    <%= link_to admin_wiki_page_imports_path(manually_set: 1),
-          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_manually_set ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
-      手動仕訳済み
     <% end %>
   </div>
 
@@ -132,14 +132,14 @@
         </div>
 
         <div class="flex items-center gap-2">
-          <%= f.submit '選択した項目を ignored にする',
-                class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400",
-                onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
           <button type="button"
                   onclick="submitBulkDeferred()"
                   class="px-4 py-2 text-sm bg-purple-500 text-white rounded-md hover:bg-purple-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-purple-400">
             選択した項目を deferred にする
           </button>
+          <%= f.submit '選択した項目を ignored にする',
+                class: "px-4 py-2 text-sm bg-yellow-500 text-white rounded-md hover:bg-yellow-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400",
+                onclick: "return confirm('選択した項目を ignored にします。よろしいですか？')" %>
         </div>
       </div>
     <% end %>

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-      Wiki Page Imports（<%= @show_manually_set ? '手動仕訳済み' : @show_deferred ? 'Deferred' : @show_ignored ? 'Ignored' : 'スキップ済み' %>）
+      Wiki Page Imports（<%= @show_manually_set ? "手動仕訳済み - #{@ms_page_type}" : @show_deferred ? 'Deferred' : @show_ignored ? 'Ignored' : 'スキップ済み' %>）
     </h1>
     <div class="flex items-center gap-2">
       <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
@@ -204,6 +204,16 @@
 
   <%# 手動仕訳済み一覧 %>
   <% else %>
+    <%# page_type サブタブ %>
+    <div class="flex flex-wrap gap-1 mb-4">
+      <% WikiPageImport::PAGE_TYPES.each do |pt| %>
+        <%= link_to admin_wiki_page_imports_path(manually_set: 1, ms_page_type: pt),
+              class: "px-3 py-1.5 text-xs font-medium rounded-md border #{@ms_page_type == pt ? 'bg-indigo-600 border-indigo-600 text-white' : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}" do %>
+          <%= pt %>
+        <% end %>
+      <% end %>
+    </div>
+
     <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch do |f| %>
       <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
         <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,36 +1,26 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-      Wiki Page Imports（<%= @show_manually_set ? '手動仕訳済み' : @show_deferred ? 'Deferred' : 'スキップ済み' %>）
+      Wiki Page Imports（<%= @show_manually_set ? '手動仕訳済み' : @show_deferred ? 'Deferred' : @show_ignored ? 'Ignored' : 'スキップ済み' %>）
     </h1>
     <div class="flex items-center gap-2">
       <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>
-
-      <% unless @show_manually_set || @show_deferred %>
-        <% if @include_ignored %>
-          <%= link_to admin_wiki_page_imports_path,
-                class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700" do %>
-            ignored を除外する
-          <% end %>
-        <% else %>
-          <%= link_to admin_wiki_page_imports_path(include_ignored: 1),
-                class: "px-3 py-1.5 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600" do %>
-            ignored を含める
-          <% end %>
-        <% end %>
-      <% end %>
     </div>
   </div>
 
   <%# タブナビゲーション %>
   <div class="flex gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
     <%= link_to admin_wiki_page_imports_path,
-          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{!@show_manually_set && !@show_deferred ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{!@show_manually_set && !@show_deferred && !@show_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       スキップ済み
     <% end %>
     <%= link_to admin_wiki_page_imports_path(show_deferred: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_deferred ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       Deferred
+    <% end %>
+    <%= link_to admin_wiki_page_imports_path(show_ignored: 1),
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+      Ignored
     <% end %>
     <%= link_to admin_wiki_page_imports_path(manually_set: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_manually_set ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
@@ -51,7 +41,7 @@
   <% end %>
 
   <%# スキップ済み一覧用フォーム（bulk_ignore / bulk_set_deferred 兼用） %>
-  <% if !@show_manually_set && !@show_deferred %>
+  <% if !@show_manually_set && !@show_deferred && !@show_ignored %>
     <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch, id: "skip-form" do |f| %>
       <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
         <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
@@ -154,8 +144,8 @@
       </div>
     <% end %>
 
-  <%# Deferred 一覧 %>
-  <% elsif @show_deferred %>
+  <%# Deferred / Ignored 一覧（読み取り専用） %>
+  <% elsif @show_deferred || @show_ignored %>
     <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
       <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-700">


### PR DESCRIPTION
## Summary

- スキップ済みタブの「ignored を含める」ボタンを廃止し、**除外済み専用タブ**を追加
- スキップ済みタブはデフォルトで除外済みアイテムを非表示に変更
- 除外済みタブは `note: 'ignored'` の一覧を読み取り専用で表示
- **手動仕訳済みタブに page_type サブタブを追加**（デフォルト: ユニット）
- タブ順を統一: スキップ済み → 手動仕訳済み → 保留 → 除外済み
- 操作ボタン順を統一: page_type設定 → 保留にする → 除外する
- `WikiPageImport::PAGE_TYPE_LABELS` 定数を追加し、タブ・select・タイトルを日本語化

Closes #526

## Test plan

- [ ] スキップ済みタブに除外済みアイテムが表示されないこと
- [ ] 除外済みタブが表示され一覧が確認できること
- [ ] 手動仕訳済みタブで page_type サブタブが表示され、デフォルトでユニットが選択されること
- [ ] 各サブタブで対応する page_type のみ表示されること
- [ ] page_type の select・タイトルが日本語で表示されること
- [ ] 他のタブの動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)