### PR TITLE
feat: import:units_v2 の MODE 環境変数対応 (#533)

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -46,7 +46,7 @@ def format_skip_log(wikipage)
   end
 end
 
-namespace :import do
+namespace :import do # rubocop:disable Metrics/BlockLength
   desc 'Import units from Wikipages'
   task units: :environment do
     puts 'Starting unit import from Wikipages...'

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -89,7 +89,18 @@ namespace :import do
 
   desc 'Import people from Wikipages'
   task people: :environment do
-    manual_mode = ENV['MANUAL'] == '1'
+    mode = ENV['MODE']
+    manual_mode = mode == 'MANUAL'
+
+    unless manual_mode || mode == 'ALL' || ENV['ID'] || ENV['START']
+      puts 'Error: 実行条件を指定してください。'
+      puts '  MODE=ALL       全件対象'
+      puts '  MODE=MANUAL    手動仕訳済みページのみ'
+      puts '  ID=<id>        指定 ID のみ'
+      puts '  START=<id>     指定 ID 以降'
+      exit 1
+    end
+
     puts 'Starting person import from Wikipages...'
     puts 'Mode: MANUAL (page_type=person の手動設定済みページのみ)' if manual_mode
     count = 0
@@ -154,7 +165,7 @@ namespace :import do
 
     puts 'Import complete!'
     puts "  Imported: #{count} people"
-    puts "  Skipped:  #{skipped} pages" unless manual_mode
+    puts "  Skipped:  #{skipped} pages" unless manual_mode || ENV['ID']
   end
 
   desc 'Reset all imported data'

--- a/lib/tasks/import_v2.rake
+++ b/lib/tasks/import_v2.rake
@@ -3,7 +3,18 @@
 namespace :import do
   desc 'Import units with snapshots from Wikipages (V2)'
   task units_v2: :environment do
-    manual_mode = ENV['MANUAL'] == '1'
+    mode = ENV['MODE']
+    manual_mode = mode == 'MANUAL'
+
+    unless manual_mode || mode == 'ALL' || ENV['ID'] || ENV['START']
+      puts 'Error: 実行条件を指定してください。'
+      puts '  MODE=ALL       全件対象'
+      puts '  MODE=MANUAL    手動仕訳済みページのみ'
+      puts '  ID=<id>        指定 ID のみ'
+      puts '  START=<id>     指定 ID 以降'
+      exit 1
+    end
+
     puts 'Starting unit import with snapshots from Wikipages (V2)...'
     puts 'Mode: MANUAL (page_type=unit の手動設定済みページのみ)' if manual_mode
     count = 0
@@ -95,6 +106,6 @@ namespace :import do
     puts 'Import complete!'
     puts "  Imported: #{count} units"
     puts "  Snapshots created: #{snapshots_created}"
-    puts "  Skipped:  #{skipped} pages" unless manual_mode
+    puts "  Skipped:  #{skipped} pages" unless manual_mode || ENV['ID']
   end
 end


### PR DESCRIPTION
## Summary

- `MANUAL=1` を廃止し `MODE=MANUAL` に変更
- `MODE=ALL` を追加し、全件処理を明示的に指定できるようにした
- `MODE`・`ID`・`START` のいずれも未指定の場合は処理を行わず、使い方を表示して終了

## Test plan

- [ ] `MODE=ALL` で全件処理が実行されること
- [ ] `MODE=MANUAL` で手動仕訳済みページのみ処理されること
- [ ] `ID=<id>` で単体指定が動作すること
- [ ] `START=<id>` で範囲指定が動作すること
- [ ] 何も指定しない場合にエラーメッセージが表示され終了すること

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)