### PR TITLE
feat: Unit・Person 編集画面から wiki_page_import を保留・除外に設定、スキップ済みに NAME 検索を追加

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -32,6 +32,7 @@ module Admin
 
     def edit
       @person.links.build # Always add an empty link field for new entries
+      @wiki_page_imports = @person.wiki_page_imports.includes(:wikipage).order(updated_at: :desc)
       @update_logs = UpdateLog.for_person(@person)
                               .includes(:user)
                               .order(created_at: :desc)

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -40,6 +40,7 @@ module Admin
       @unit_person = @unit.unit_people.build(period: 1, order_in_period: (@unit_people.last&.order_in_period || 0) + 1)
       @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(snapshot_date: :desc)
       @unit.links.build # Build an empty link for the form
+      @wiki_page_imports = @unit.wiki_page_imports.includes(:wikipage).order(updated_at: :desc)
       @update_logs = UpdateLog.for_unit(@unit)
                               .includes(:user)
                               .order(created_at: :desc)

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -43,6 +43,18 @@ module Admin
       end
     end
 
+    def set_deferred
+      wpi = WikiPageImport.find(params[:id])
+      wpi.update!(status: 'deferred', updated_at: Time.current)
+      redirect_back_or_to admin_wiki_page_imports_path, notice: '保留にしました'
+    end
+
+    def set_ignored
+      wpi = WikiPageImport.find(params[:id])
+      wpi.update!(note: 'ignored', updated_at: Time.current)
+      redirect_back_or_to admin_wiki_page_imports_path, notice: '除外しました'
+    end
+
     def update_page_type
       wpi = WikiPageImport.find(params[:id])
       page_type = params[:page_type].presence

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -62,8 +62,11 @@ module Admin
         wpi.update!(page_type: nil, manually_set: false)
         redirect_back_or_to admin_wiki_page_imports_path, notice: '手動仕訳をキャンセルしました'
       elsif WikiPageImport::PAGE_TYPES.include?(page_type)
-        wpi.update!(page_type: page_type, manually_set: true)
-        redirect_back_or_to admin_wiki_page_imports_path, notice: "page_type を #{page_type} に設定しました"
+        attrs = { page_type: page_type, manually_set: true }
+        attrs[:status] = 'skipped' if wpi.status == 'deferred'
+        attrs[:note] = nil if wpi.note == 'ignored'
+        wpi.update!(attrs)
+        redirect_back_or_to admin_wiki_page_imports_path, notice: "page_type を #{WikiPageImport::PAGE_TYPE_LABELS[page_type]} に設定しました"
       else
         redirect_to admin_wiki_page_imports_path, alert: '無効な page_type です'
       end

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -9,6 +9,7 @@ module Admin
       @show_deferred     = params[:show_deferred] == '1'
       @show_ignored      = params[:show_ignored] == '1'
       @ms_page_type      = @show_manually_set ? (params[:ms_page_type].presence || 'unit') : nil
+      @q                 = params[:q].presence
 
       scope = if @show_manually_set
                 WikiPageImport.manually_set.where.not(status: 'imported').where(page_type: @ms_page_type).includes(:wikipage).order(updated_at: :desc)
@@ -17,7 +18,9 @@ module Admin
               elsif @show_ignored
                 WikiPageImport.skipped.where(manually_set: false, note: 'ignored').includes(:wikipage).order(updated_at: :desc)
               else
-                WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored').includes(:wikipage).order(updated_at: :desc)
+                base = WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored')
+                base = base.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
+                base.includes(:wikipage).order(updated_at: :desc)
               end
 
       @pagy, @wiki_page_imports = pagy(scope, limit: 50)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -37,6 +37,7 @@ class Person < ApplicationRecord
   include Discard::Model
   include WikiParser
   has_many :links, as: :linkable, dependent: :destroy
+  has_many :wiki_page_imports, as: :import_target
   has_many :unit_people
   has_many :units, through: :unit_people
   has_many :person_logs

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -33,6 +33,7 @@ class Unit < ApplicationRecord
   include Discard::Model
   has_many :links, as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: proc { |attrs| attrs['url'].blank? }
+  has_many :wiki_page_imports, as: :import_target
   has_many :unit_people
   has_many :people, through: :unit_people
   has_many :unit_logs, dependent: :destroy

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -13,6 +13,7 @@
       <div>
         <%= render "links_form", person: @person %>
         <%= render "admin/sections/list", sectionable: @person, sections: @person.sections.with_discarded.order(:sort_order) %>
+        <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports %>
       </div>
     </div>
   </div>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -13,7 +13,7 @@
       <div>
         <%= render "links_form", person: @person %>
         <%= render "admin/sections/list", sectionable: @person, sections: @person.sections.with_discarded.order(:sort_order) %>
-        <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports %>
+        <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports, import_target: @person %>
       </div>
     </div>
   </div>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -17,7 +17,7 @@
         <%= render "new_member_form", unit: @unit, unit_person: @unit_person %>
         <%= render "links_form", unit: @unit %>
         <%= render "admin/sections/list", sectionable: @unit, sections: @unit.sections.with_discarded.order(:sort_order) %>
-        <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports %>
+        <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports, import_target: @unit %>
       </div>
     </div>
   </div>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -17,6 +17,7 @@
         <%= render "new_member_form", unit: @unit, unit_person: @unit_person %>
         <%= render "links_form", unit: @unit %>
         <%= render "admin/sections/list", sectionable: @unit, sections: @unit.sections.with_discarded.order(:sort_order) %>
+        <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports %>
       </div>
     </div>
   </div>

--- a/app/views/admin/wiki_page_imports/_import_target_panel.html.erb
+++ b/app/views/admin/wiki_page_imports/_import_target_panel.html.erb
@@ -1,0 +1,37 @@
+<% if wiki_page_imports.any? %>
+  <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-4 mb-4">
+    <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Wiki Page Imports</h3>
+    <div class="space-y-2">
+      <% wiki_page_imports.each do |wpi| %>
+        <div class="flex items-center justify-between gap-2 py-2 border-b border-gray-100 dark:border-gray-700 last:border-0">
+          <div class="flex items-center gap-2 min-w-0">
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium shrink-0
+              <%= wpi.status == 'imported'  ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' :
+                  wpi.status == 'skipped'   ? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' :
+                  wpi.status == 'deferred'  ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' :
+                  wpi.status == 'error'     ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
+                                              'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' %>">
+              <%= wpi.status %>
+            </span>
+            <% if wpi.note == 'ignored' %>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 shrink-0">除外済み</span>
+            <% end %>
+            <span class="text-sm text-gray-700 dark:text-gray-300 truncate"><%= wpi.wikipage&.title %></span>
+          </div>
+          <div class="flex items-center gap-1 shrink-0">
+            <% unless wpi.status == 'deferred' %>
+              <%= button_to '保留', set_deferred_admin_wiki_page_import_path(wpi), method: :patch,
+                    class: "px-2 py-1 text-xs bg-purple-500 text-white rounded hover:bg-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-400",
+                    onclick: "return confirm('この wiki page import を保留にします。よろしいですか？')" %>
+            <% end %>
+            <% unless wpi.note == 'ignored' %>
+              <%= button_to '除外', set_ignored_admin_wiki_page_import_path(wpi), method: :patch,
+                    class: "px-2 py-1 text-xs bg-yellow-500 text-white rounded hover:bg-yellow-600 focus:outline-none focus:ring-2 focus:ring-yellow-400",
+                    onclick: "return confirm('この wiki page import を除外します。よろしいですか？')" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/wiki_page_imports/_import_target_panel.html.erb
+++ b/app/views/admin/wiki_page_imports/_import_target_panel.html.erb
@@ -1,4 +1,5 @@
 <% if wiki_page_imports.any? %>
+  <% any_deferred_or_ignored = wiki_page_imports.any? { |wpi| wpi.status == 'deferred' || wpi.note == 'ignored' } %>
   <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-4 mb-4">
     <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Wiki Page Imports</h3>
     <div class="space-y-2">
@@ -33,5 +34,15 @@
         </div>
       <% end %>
     </div>
+
+    <% if any_deferred_or_ignored %>
+      <div class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+        <%= button_to "#{import_target.name} を論理削除する",
+              polymorphic_path([:admin, import_target]),
+              method: :delete,
+              class: "w-full px-3 py-2 text-sm bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400",
+              onclick: "return confirm('#{import_target.name} を論理削除します。よろしいですか？')" %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -42,6 +42,17 @@
 
   <%# スキップ済み一覧用フォーム（bulk_ignore / bulk_set_deferred 兼用） %>
   <% if !@show_manually_set && !@show_deferred && !@show_ignored %>
+    <%= form_with url: admin_wiki_page_imports_path, method: :get, class: "mb-4 flex items-center gap-2" do |sf| %>
+      <%= sf.text_field :q, value: @q, placeholder: "NAME 前方一致で検索…",
+            class: "text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 py-1.5 px-3 w-64",
+            aria: { label: "NAME 前方一致検索" } %>
+      <%= sf.submit "検索", class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700 cursor-pointer" %>
+      <% if @q %>
+        <%= link_to "クリア", admin_wiki_page_imports_path,
+              class: "px-3 py-1.5 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600" %>
+      <% end %>
+    <% end %>
+
     <%= form_with url: bulk_ignore_admin_wiki_page_imports_path, method: :patch, id: "skip-form" do |f| %>
       <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
         <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,8 @@ Rails.application.routes.draw do
     resources :wiki_page_imports, only: %i[index] do
       member do
         patch :update_page_type
+        patch :set_deferred
+        patch :set_ignored
       end
       collection do
         patch :bulk_ignore


### PR DESCRIPTION
## Summary

- Unit・Person の edit ページに **Wiki Page Imports パネル**を追加
  - 紐付く WikiPageImport の一覧・ステータスを表示
  - 「保留にする」「除外する」ボタン（確認ダイアログ付き）
  - 保留または除外済みの行がある場合、Unit/Person の**論理削除ボタン**を表示
- 保留・除外済みタブから page_type をセットすると**手動仕訳済みタブへ移動**
  - `status: 'deferred'` → `'skipped'` にリセット
  - `note: 'ignored'` → `nil` にクリア
- スキップ済みタブに **NAME 前方一致検索**を追加（`wikipages.name LIKE '...%'`）
- Unit・Person モデルに `has_many :wiki_page_imports, as: :import_target` を追加
- WikiPageImportsController に `set_deferred` / `set_ignored` アクションを追加

Closes #535

## Test plan

- [ ] Unit edit ページに Wiki Page Imports パネルが表示されること
- [ ] 「保留にする」「除外する」ボタンが確認ダイアログ付きで動作すること
- [ ] 保留または除外済みの行がある場合、論理削除ボタンが表示されること
- [ ] 保留・除外済みタブから page_type をセットすると手動仕訳済みタブに移動すること
- [ ] スキップ済みタブで NAME 前方一致検索が動作すること
- [ ] クリアリンクで検索条件がリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)