### PR TITLE
feat: activity_period のラベル・日付表示レイアウト改善

### DIFF
--- a/app/components/basic_attributes_component.html.erb
+++ b/app/components/basic_attributes_component.html.erb
@@ -46,16 +46,12 @@
       <% end %>
 
       <% if @resource.activity_periods.present? %>
-        <div class="flex flex-col sm:flex-row sm:justify-between sm:items-baseline border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
+        <div class="flex flex-col border-b border-zinc-100 dark:border-zinc-800 pb-3 last:border-0">
           <dt class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">活動時期</dt>
-          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100 text-right">
+          <dd class="text-[0.9375rem] font-bold text-zinc-900 dark:text-zinc-100 grid gap-x-3 justify-end" style="grid-template-columns: auto auto">
             <% @resource.activity_periods.each do |period| %>
-              <div>
-                <%= period.from %> 〜 <%= period.to.presence || '現在' %>
-                <% if period.label.present? %>
-                  <span class="ml-1 text-xs font-normal text-zinc-400 dark:text-zinc-500">(<%= period.label %>)</span>
-                <% end %>
-              </div>
+              <span class="text-xs font-normal text-zinc-600 dark:text-zinc-300 text-right self-center"><%= period.label %></span>
+              <span class="whitespace-nowrap font-mono text-sm"><%= period.from %><span class="text-[0.6rem] text-zinc-400 dark:text-zinc-500">〜</span><%= period.to.presence || '現在' %></span>
             <% end %>
           </dd>
         </div>

--- a/app/components/unit_card_component.html.erb
+++ b/app/components/unit_card_component.html.erb
@@ -32,11 +32,11 @@
     <% if @unit.activity_periods.present? %>
       <div class="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
         <% @unit.activity_periods.each do |period| %>
-          <div>
-            <%= period.from %> 〜 <%= period.to.presence || '現在' %>
+          <div class="flex items-baseline gap-2">
             <% if period.label.present? %>
-              <span class="text-zinc-400 dark:text-zinc-500">(<%= period.label %>)</span>
+              <span class="text-zinc-400 dark:text-zinc-500 shrink-0"><%= period.label %></span>
             <% end %>
+            <span class="whitespace-nowrap"><%= period.from %> 〜 <%= period.to.presence || '現在' %></span>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## Summary
- ラベルと日付を2カラムグリッドで縦揃えに変更
- 「活動時期」行を縦積みレイアウトにしてラベル折り返しを防止
- 日付を等幅フォント・小サイズに変更してラベルが折り返さない幅に調整
- 「〜」を小さく薄く表示

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 活動時期のラベルが折り返さずに表示されること
- [ ] 複数の活動時期がある場合に日付が縦揃えになること
- [ ] ダークモードで表示が崩れないこと

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)