### PR TITLE
feat: moved ページのインポートとリダイレクト対応

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,11 @@ class ProfilesController < ApplicationController
     @resource = Unit.kept.includes(:links).find_by(key: params[:key]) ||
                 Person.kept.includes(:links).find_by!(key: params[:key])
 
+    if @resource.is_a?(Unit) && @resource.destination_key.present?
+      redirect_to profile_path(@resource.destination_key), status: :moved_permanently
+      return
+    end
+
     @links = @resource.links.where(active: true).order(:sort_order)
 
     @resource.is_a?(Person) ? load_person_data : load_unit_data

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -42,7 +42,7 @@ class Unit < ApplicationRecord
   has_many :tag_indices, through: :tag_index_items
   has_many :sections, as: :sectionable, dependent: :destroy
   has_many :unit_snapshots, dependent: :destroy
-  enum :unit_type, { band: 0, unit: 1, session: 2, solo: 3, limited: 4, other: 99 }
+  enum :unit_type, { band: 0, unit: 1, session: 2, solo: 3, limited: 4, moved: 5, other: 99 }
   enum :status, { pre: 0, active: 1, freeze: 2, disbanded: 3, unknown: 99 }
 
   validates :status, presence: true

--- a/db/migrate/20260328031736_add_destination_key_to_units.rb
+++ b/db/migrate/20260328031736_add_destination_key_to_units.rb
@@ -1,0 +1,5 @@
+class AddDestinationKeyToUnits < ActiveRecord::Migration[8.1]
+  def change
+    add_column :units, :destination_key, :string
+  end
+end

--- a/db/migrate/20260328031736_add_destination_key_to_units.rb
+++ b/db/migrate/20260328031736_add_destination_key_to_units.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDestinationKeyToUnits < ActiveRecord::Migration[8.1]
   def change
     add_column :units, :destination_key, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_143450) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_28_031736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -310,6 +310,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_143450) do
     t.jsonb "activity_period"
     t.jsonb "aliases", default: [], null: false
     t.datetime "created_at", null: false
+    t.string "destination_key"
     t.datetime "discarded_at"
     t.string "key"
     t.string "name"

--- a/lib/tasks/README.md
+++ b/lib/tasks/README.md
@@ -113,6 +113,42 @@ LIMIT=10 PATH=/opt/homebrew/opt/ruby/bin:$PATH bin/rails import:units_v2      # 
 - 日付がない（ラベルのみの）セクションはスキップされます
 
 
+### 2-3. import:moved - 移動ページのインポート
+
+`wiki_page_imports` の `status=skipped, page_type=moved` なページを対象に、`units` テーブルへ移動先情報を持つレコードを作成します。
+
+**使用方法**:
+```bash
+# 通常実行
+bundle exec rails import:moved
+
+# ドライランモード（DB への書き込みなしで結果を確認）
+DRYRUN=1 bundle exec rails import:moved
+```
+
+**処理内容**:
+
+wiki カラムの内容に応じて以下の3パターンで処理します。
+
+| 条件 | 処理 |
+|---|---|
+| `[[XXXX]]` または `[[表示名\|XXXX]]` が存在する | `units` または `people` を `old_key=XXXX` で検索し、移動先 Unit を作成 → `imported` に更新 |
+| `{{include ...}}` が存在する（wiki link なし） | 対象外のためスルー（ステータス変更なし） |
+| どちらでもない | `note='not moved'` で `skipped` のまま更新 |
+
+**作成される Unit レコード**:
+- `unit_type: moved`
+- `destination_key`: 移動先の Unit / Person の `key`
+- `key` / `old_key`: 移動元ページ名から生成
+
+**移動先が見つからない場合**:
+- `note='destination not found'` で更新（`status` は `skipped` のまま）
+
+**リダイレクト**:
+- `/{key}` にアクセスすると `destination_key` のページへ 301 リダイレクトされます
+
+---
+
 ### 3. import:reset - インポートデータの初期化
 
 インポートされたデータを全て削除し、データベースを初期状態（インポート前）に戻します。

--- a/lib/tasks/import_moved.rake
+++ b/lib/tasks/import_moved.rake
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+namespace :import do
+  desc 'Import moved pages from WikiPageImports (page_type=moved)'
+  task moved: :environment do
+    dryrun = ENV['DRYRUN'] == '1'
+
+    puts 'Starting moved page import...'
+    puts 'Mode: DRYRUN (DB への書き込みは行いません)' if dryrun
+    count = 0
+    skipped_no_dest = 0
+    skipped_not_moved = 0
+    skipped_include = 0
+
+    WIKI_LINK_RE = /\[\[(?:[^\|\]]+\|)?([^\]]+)\]\]/
+    INCLUDE_RE   = /\{\{include\s+/i
+
+    scope = WikiPageImport.where(status: 'skipped', page_type: 'moved').includes(:wikipage)
+    total = scope.count
+    puts "Target: #{total} records"
+
+    scope.find_each do |wpi|
+      wp = wpi.wikipage
+      unless wp
+        puts "[SKIP] WikiPageImport##{wpi.id}: wikipage not found"
+        next
+      end
+
+      wiki = wp.wiki.to_s
+
+      if (m = wiki.match(WIKI_LINK_RE))
+        destination_name = m[1].strip
+        destination = Unit.find_by(old_key: destination_name) ||
+                      Person.find_by(old_key: destination_name)
+
+        unless destination
+          # URL エンコード済みの old_key でも検索
+          encoded = URI.encode_www_form_component(destination_name.encode('EUC-JP'))
+          destination = Unit.find_by(old_key: encoded) || Person.find_by(old_key: encoded)
+        end
+
+        unless destination
+          wpi.update!(note: 'destination not found') unless dryrun
+          puts "[NOT FOUND] #{wp.title} (ID: #{wp.id}) → '#{destination_name}'"
+          skipped_no_dest += 1
+          next
+        end
+
+        # moved Unit を作成 or 更新
+        encoded_old_key = URI.encode_www_form_component(wp.name.encode('EUC-JP'))
+        source_for_key = if wp.name.match?(/^[[:ascii:]\s-]+$/)
+                           wp.name
+                         else
+                           encoded_old_key.gsub(/%/, '')
+                         end
+        unit_key = source_for_key.downcase.gsub(/[^a-z0-9-]+/, '-').gsub(/-+/, '-')
+
+        unit = Unit.find_by(old_wiki_id: wp.id) || Unit.new
+        unique_key = resolve_moved_key(unit_key, unit.id)
+
+        unless dryrun
+          unit.key             = unique_key
+          unit.name            = wp.title
+          unit.old_key         = encoded_old_key
+          unit.old_wiki_id     = wp.id
+          unit.unit_type       = :moved
+          unit.destination_key = destination.key
+          unit.status          = :active
+          unit.save!
+
+          wpi.update!(status: 'imported', import_target: unit)
+        end
+
+        puts "[IMPORTED] #{wp.title} (ID: #{wp.id}) → #{destination.key} (key: #{unique_key})"
+        count += 1
+
+      elsif wiki.match?(INCLUDE_RE)
+        puts "[SKIP/INCLUDE] #{wp.title} (ID: #{wp.id})"
+        skipped_include += 1
+
+      else
+        wpi.update!(status: 'skipped', note: 'not moved') unless dryrun
+        puts "[NOT MOVED] #{wp.title} (ID: #{wp.id})"
+        skipped_not_moved += 1
+      end
+    end
+
+    puts dryrun ? 'Dryrun complete!' : 'Import complete!'
+    puts "  Imported:              #{count}"
+    puts "  Destination not found: #{skipped_no_dest}"
+    puts "  Not moved:             #{skipped_not_moved}"
+    puts "  Include (skipped):     #{skipped_include}"
+  end
+end
+
+def resolve_moved_key(base_key, current_id = nil)
+  return base_key unless Unit.where(key: base_key).where.not(id: current_id).exists?
+
+  suffix = 2
+  loop do
+    candidate = "#{base_key}-#{suffix}"
+    return candidate unless Unit.where(key: candidate).where.not(id: current_id).exists?
+
+    suffix += 1
+  end
+end

--- a/lib/tasks/import_moved.rake
+++ b/lib/tasks/import_moved.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+MOVED_WIKI_LINK_RE = /\[\[(?:[^|\]]+\|)?([^\]]+)\]\]/
+MOVED_INCLUDE_RE   = /\{\{include\s+/i
+
 namespace :import do
   desc 'Import moved pages from WikiPageImports (page_type=moved)'
   task moved: :environment do
@@ -11,9 +14,6 @@ namespace :import do
     skipped_no_dest = 0
     skipped_not_moved = 0
     skipped_include = 0
-
-    WIKI_LINK_RE = /\[\[(?:[^\|\]]+\|)?([^\]]+)\]\]/
-    INCLUDE_RE   = /\{\{include\s+/i
 
     scope = WikiPageImport.where(status: 'skipped', page_type: 'moved').includes(:wikipage)
     total = scope.count
@@ -28,7 +28,7 @@ namespace :import do
 
       wiki = wp.wiki.to_s
 
-      if (m = wiki.match(WIKI_LINK_RE))
+      if (m = wiki.match(MOVED_WIKI_LINK_RE))
         destination_name = m[1].strip
         destination = Unit.find_by(old_key: destination_name) ||
                       Person.find_by(old_key: destination_name)
@@ -74,7 +74,7 @@ namespace :import do
         puts "[IMPORTED] #{wp.title} (ID: #{wp.id}) → #{destination.key} (key: #{unique_key})"
         count += 1
 
-      elsif wiki.match?(INCLUDE_RE)
+      elsif wiki.match?(MOVED_INCLUDE_RE)
         puts "[SKIP/INCLUDE] #{wp.title} (ID: #{wp.id})"
         skipped_include += 1
 


### PR DESCRIPTION
## Summary
- `units` テーブルに `destination_key` カラムを追加
- `Unit#unit_type` に `moved: 5` を追加
- `import:moved` rake タスクを新規作成（`DRYRUN=1` モード対応）
- `ProfilesController#show` で `destination_key` が設定された Unit への 301 リダイレクトを追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `DRYRUN=1 bundle exec rails import:moved` でログが出力されること
- [ ] `bundle exec rails import:moved` を実行し、moved Unit が作成されること
- [ ] 作成された moved Unit の `/{key}` にアクセスすると `/{destination_key}` へ 301 リダイレクトされること

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)