### PR TITLE
feat: units_v2 タスクで moved ページ自動検出・legacy_redirects エンコード対応

### DIFF
--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -3,9 +3,10 @@
 class LegacyRedirectsController < ApplicationController
   def show
     old_key = params[:old_key]
+    encoded_old_key = URI.encode_www_form_component(old_key)
 
     # Try to find Unit by old_key
-    if (unit = Unit.find_by(old_key: old_key))
+    if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key))
       new_url = profile_url(unit.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently
@@ -13,7 +14,7 @@ class LegacyRedirectsController < ApplicationController
     end
 
     # Fallback: Try to find Person by old_key
-    if (person = Person.find_by(old_key: old_key))
+    if (person = Person.find_by(old_key: old_key) || Person.find_by(old_key: encoded_old_key))
       new_url = profile_url(person.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently

--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -3,7 +3,7 @@
 class LegacyRedirectsController < ApplicationController
   def show
     old_key = params[:old_key]
-    encoded_old_key = URI.encode_www_form_component(old_key)
+    encoded_old_key = URI.encode_www_form_component(old_key.gsub('+', ' '))
 
     # Try to find Unit by old_key
     if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key))

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -28,9 +28,13 @@ def update_wiki_page_import_as_imported(wikipage, page_type:, target:)
   )
 end
 
-def update_wiki_page_import_as_skipped(wikipage, note:)
+def update_wiki_page_import_as_skipped(wikipage, note:, page_type: nil)
   wpi = WikiPageImport.find_or_create_by!(wikipage_id: wikipage.id)
-  wpi.update!(status: 'skipped', note: note) if wpi.status == 'pending'
+  return unless wpi.status == 'pending'
+
+  attrs = { status: 'skipped', note: note }
+  attrs[:page_type] = page_type if page_type
+  wpi.update!(attrs)
 end
 
 def format_skip_log(wikipage)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -30,7 +30,7 @@ end
 
 def update_wiki_page_import_as_skipped(wikipage, note:, page_type: nil)
   wpi = WikiPageImport.find_or_create_by!(wikipage_id: wikipage.id)
-  return unless wpi.status == 'pending'
+  return unless wpi.status == 'pending' || (page_type.present? && wpi.page_type.nil?)
 
   attrs = { status: 'skipped', note: note }
   attrs[:page_type] = page_type if page_type

--- a/lib/tasks/import_v2.rake
+++ b/lib/tasks/import_v2.rake
@@ -99,6 +99,7 @@ namespace :import do
         else
           skipped += 1
           puts format_skip_log(wp) if wp.title.present? && !PersonImporter.valid_person?(wp)
+          update_wiki_page_import_as_skipped(wp, note: nil, page_type: 'moved') if wp.wiki.to_s.lines.first(3).any? { |line| line.include?('移動しました') }
         end
       end
     end


### PR DESCRIPTION
## Summary
- `update_wiki_page_import_as_skipped` に `page_type:` オプションを追加
- `import:units_v2` タスクで wiki 先頭3行に「移動しました」が含まれる場合に `page_type: 'moved'` を自動設定
  - `page_type` 未設定のレコードは `status: 'pending'` 以外でも更新するよう条件を緩和
- `LegacyRedirectsController` で URL デコード済み old_key を再エンコードしてフォールバック検索
  - パス内の `+` はスペースに変換してから `URI.encode_www_form_component` を適用

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `import:units_v2` 実行後、「移動しました」を含む wiki ページの `page_type` が `moved` になっていること
- [ ] `/{old_key}.html` にアクセスしたとき、エンコード済み old_key を持つ Unit が正しくリダイレクトされること

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)