### PR TITLE
fix: スナップショットメンバーの person_name 保存とパート先頭 ! 除去

### DIFF
--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -529,6 +529,7 @@ class WikipageImporterV2 < WikipageImporter
     sort_order = options[:sort_order]
 
     # パートをパース
+    part_str = part_str&.sub(/^!/, '')
     part_enum = parse_part(part_str)
     support = part_str&.include?('サポート') || part_str&.include?('sup') || false
     cleaned_part_alias = extract_name_from_wiki_link(part_str)&.gsub(/サポート|sup/i, '')&.strip
@@ -541,7 +542,7 @@ class WikipageImporterV2 < WikipageImporter
 
     snapshot.snapshot_people.create!(
       person: person,
-      person_name: person ? nil : name_str,
+      person_name: name_str,
       person_key: person&.key,
       old_person_key: old_member_key,
       part: part_enum,


### PR DESCRIPTION
## Summary
- スナップショットメンバーインポート時、person が見つかった場合も `person_name` に `name_str` を保存するよう修正（改名後の person に紐付いても、在籍時の名前が正しく表示されるようになる）
- パート文字列の先頭 `!` をインポート時に除去するよう修正

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 対象ユニットを再インポートし、改名前の名前（例: 龍）が正しく表示されること
- [ ] パートに `!` が付いているメンバーが正しいパートで取り込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)