### PR TITLE
feat: unit/person/カスタムページ編集画面に論理削除ボタンを追加

### DIFF
--- a/app/views/admin/custom_pages/edit.html.erb
+++ b/app/views/admin/custom_pages/edit.html.erb
@@ -9,5 +9,17 @@
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
       <%= render "form", custom_page: @custom_page %>
     </div>
+
+    <% if current_user.super_operator_or_above? %>
+      <div class="mt-8 border border-red-300 rounded-lg p-4 dark:border-red-700">
+        <h2 class="text-lg font-semibold text-red-700 dark:text-red-400 mb-3">危険な操作</h2>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">このカスタムページを論理削除します。削除後も一覧画面から復元できます。</p>
+        <%= button_to "このカスタムページを削除する", admin_custom_page_path(@custom_page), method: :delete,
+            onclick: "return confirm('「#{@custom_page.title}」を削除しますか？\\nこの操作は取り消せますが、慎重に行ってください。')",
+            form: { class: "inline-block" },
+            class: "inline-flex items-center px-4 py-2 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2",
+            aria: { label: "このカスタムページを削除する" } %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -19,4 +19,16 @@
   </div>
 
   <%= render "admin/shared/update_logs", update_logs: @update_logs %>
+
+  <% if current_user.super_operator_or_above? %>
+    <div class="mt-8 border border-red-300 rounded-lg p-4 dark:border-red-700">
+      <h2 class="text-lg font-semibold text-red-700 dark:text-red-400 mb-3">危険な操作</h2>
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">この人物を論理削除します。削除後も一覧画面から復元できます。</p>
+      <%= button_to "この人物を削除する", admin_person_path(@person), method: :delete,
+          onclick: "return confirm('「#{@person.name}」を削除しますか？\\nこの操作は取り消せますが、慎重に行ってください。')",
+          form: { class: "inline-block" },
+          class: "inline-flex items-center px-4 py-2 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2",
+          aria: { label: "この人物を削除する" } %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -31,4 +31,16 @@
   </div>
 
   <%= render "admin/shared/update_logs", update_logs: @update_logs %>
+
+  <% if current_user.super_operator_or_above? %>
+    <div class="mt-8 border border-red-300 rounded-lg p-4 dark:border-red-700">
+      <h2 class="text-lg font-semibold text-red-700 dark:text-red-400 mb-3">危険な操作</h2>
+      <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">このユニットを論理削除します。削除後も一覧画面から復元できます。</p>
+      <%= button_to "このユニットを削除する", admin_unit_path(@unit), method: :delete,
+          onclick: "return confirm('「#{@unit.name}」を削除しますか？\\nこの操作は取り消せますが、慎重に行ってください。')",
+          form: { class: "inline-block" },
+          class: "inline-flex items-center px-4 py-2 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2",
+          aria: { label: "このユニットを削除する" } %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
## Summary

- unit・person・カスタムページの編集画面に「危険な操作」セクションと論理削除ボタンを追加
- `super_operator` 以上のユーザーのみ表示
- 赤色ボタン＋`confirm()` ダイアログで誤操作を防止
- 削除後は一覧画面にリダイレクト（復元は一覧画面から行う）

## Test plan

- [ ] super_operator 以上のユーザーで unit 編集画面を開き、削除ボタンが赤く表示されることを確認
- [ ] 確認ダイアログが表示されることを確認
- [ ] 削除後に一覧画面へリダイレクトされることを確認
- [ ] person・カスタムページでも同様に動作することを確認
- [ ] super_operator 未満のユーザーにはボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)