### PR TITLE
feat: Wiki Page Imports に name 検索・取込後除外機能を追加

### DIFF
--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -1,46 +1,22 @@
 # frozen_string_literal: true
 
 module Admin
-  class WikiPageImportsController < Admin::BaseController
+  class WikiPageImportsController < Admin::BaseController # rubocop:disable Metrics/ClassLength
     before_action :require_admin
 
     def index
-      @show_manually_set = params[:manually_set] == '1'
-      @show_deferred     = params[:show_deferred] == '1'
-      @show_ignored      = params[:show_ignored] == '1'
+      @show_manually_set     = params[:manually_set] == '1'
+      @show_deferred         = params[:show_deferred] == '1'
+      @show_ignored          = params[:show_ignored] == '1'
       @show_pending          = params[:show_pending] == '1'
       @show_error            = params[:show_error] == '1'
       @show_imported         = params[:show_imported] == '1'
       @show_imported_ignored = params[:show_imported_ignored] == '1'
       @show_post_excluded    = params[:show_post_excluded] == '1'
-      @ms_page_type      = @show_manually_set ? (params[:ms_page_type].presence || 'unit') : nil
-      @q                 = params[:q].presence
+      @ms_page_type          = @show_manually_set ? (params[:ms_page_type].presence || 'unit') : nil
+      @q                     = params[:q].presence
 
-      scope = if @show_manually_set
-                WikiPageImport.manually_set.where.not(status: 'imported').where(page_type: @ms_page_type).includes(:wikipage).order(updated_at: :desc)
-              elsif @show_deferred
-                WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
-              elsif @show_ignored
-                WikiPageImport.skipped.where(manually_set: false, note: 'ignored').includes(:wikipage).order(updated_at: :desc)
-              elsif @show_pending
-                WikiPageImport.pending.includes(:wikipage).order(updated_at: :desc)
-              elsif @show_error
-                WikiPageImport.error.includes(:wikipage).order(updated_at: :desc)
-              elsif @show_imported
-                scope = WikiPageImport.imported.where.not(note: 'ignored').order(updated_at: :desc)
-                scope = scope.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
-                scope.includes(:wikipage).preload(:import_target)
-              elsif @show_imported_ignored
-                WikiPageImport.imported.where(note: 'ignored').includes(:wikipage, :import_target).order(updated_at: :desc)
-              elsif @show_post_excluded
-                WikiPageImport.ignored.includes(:wikipage).order(updated_at: :desc)
-              else
-                base = WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored')
-                base = base.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
-                base.includes(:wikipage).order(updated_at: :desc)
-              end
-
-      @pagy, @wiki_page_imports = pagy(scope, limit: 50)
+      @pagy, @wiki_page_imports = pagy(index_scope, limit: 50)
     end
 
     def bulk_set_deferred
@@ -131,6 +107,42 @@ module Admin
       else
         redirect_to admin_wiki_page_imports_path, alert: 'page_type を選択してください'
       end
+    end
+
+    private
+
+    def index_scope
+      if @show_manually_set
+        WikiPageImport.manually_set.where.not(status: 'imported').where(page_type: @ms_page_type).includes(:wikipage).order(updated_at: :desc)
+      elsif @show_deferred
+        WikiPageImport.deferred.includes(:wikipage).order(updated_at: :desc)
+      elsif @show_ignored
+        WikiPageImport.skipped.where(manually_set: false, note: 'ignored').includes(:wikipage).order(updated_at: :desc)
+      elsif @show_pending
+        WikiPageImport.pending.includes(:wikipage).order(updated_at: :desc)
+      elsif @show_error
+        WikiPageImport.error.includes(:wikipage).order(updated_at: :desc)
+      elsif @show_imported
+        imported_scope
+      elsif @show_imported_ignored
+        WikiPageImport.imported.where(note: 'ignored').includes(:wikipage, :import_target).order(updated_at: :desc)
+      elsif @show_post_excluded
+        WikiPageImport.ignored.includes(:wikipage).order(updated_at: :desc)
+      else
+        skipped_scope
+      end
+    end
+
+    def imported_scope
+      scope = WikiPageImport.imported.where.not(note: 'ignored').order(updated_at: :desc)
+      scope = scope.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
+      scope.includes(:wikipage).preload(:import_target)
+    end
+
+    def skipped_scope
+      base = WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored')
+      base = base.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
+      base.includes(:wikipage).order(updated_at: :desc)
     end
   end
 end

--- a/app/controllers/admin/wiki_page_imports_controller.rb
+++ b/app/controllers/admin/wiki_page_imports_controller.rb
@@ -12,6 +12,7 @@ module Admin
       @show_error            = params[:show_error] == '1'
       @show_imported         = params[:show_imported] == '1'
       @show_imported_ignored = params[:show_imported_ignored] == '1'
+      @show_post_excluded    = params[:show_post_excluded] == '1'
       @ms_page_type      = @show_manually_set ? (params[:ms_page_type].presence || 'unit') : nil
       @q                 = params[:q].presence
 
@@ -26,9 +27,13 @@ module Admin
               elsif @show_error
                 WikiPageImport.error.includes(:wikipage).order(updated_at: :desc)
               elsif @show_imported
-                WikiPageImport.imported.where.not(note: 'ignored').includes(:wikipage, :import_target).order(updated_at: :desc)
+                scope = WikiPageImport.imported.where.not(note: 'ignored').order(updated_at: :desc)
+                scope = scope.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
+                scope.includes(:wikipage).preload(:import_target)
               elsif @show_imported_ignored
                 WikiPageImport.imported.where(note: 'ignored').includes(:wikipage, :import_target).order(updated_at: :desc)
+              elsif @show_post_excluded
+                WikiPageImport.ignored.includes(:wikipage).order(updated_at: :desc)
               else
                 base = WikiPageImport.skipped.where(manually_set: false).where.not(note: 'ignored')
                 base = base.joins(:wikipage).where('wikipages.name LIKE ?', "#{@q}%") if @q
@@ -63,6 +68,21 @@ module Admin
     def set_ignored
       WikiPageImport.find(params[:id]).update!(note: 'ignored', updated_at: Time.current)
       redirect_back_or_to admin_wiki_page_imports_path, notice: '除外しました'
+    end
+
+    def exclude
+      wpi = WikiPageImport.find(params[:id])
+      ActiveRecord::Base.transaction do
+        wpi.import_target&.destroy!
+        wpi.update!(
+          status: 'ignored',
+          import_target_type: nil,
+          import_target_id: nil,
+          last_imported_at: nil,
+          updated_at: Time.current
+        )
+      end
+      redirect_back_or_to admin_wiki_page_imports_path(show_imported_ignored: 1), notice: '除外しました（取込先を削除しました）'
     end
 
     def update_page_type

--- a/app/models/wiki_page_import.rb
+++ b/app/models/wiki_page_import.rb
@@ -26,7 +26,7 @@
 #
 
 class WikiPageImport < ApplicationRecord
-  STATUSES = %w[pending imported skipped deferred error].freeze
+  STATUSES = %w[pending imported skipped deferred error ignored].freeze
   PAGE_TYPES = %w[unit person live_house custom_page omnibus moved office_label other].freeze
   PAGE_TYPE_LABELS = {
     'unit' => 'ユニット',
@@ -50,5 +50,6 @@ class WikiPageImport < ApplicationRecord
   scope :skipped,       -> { where(status: 'skipped') }
   scope :deferred,      -> { where(status: 'deferred') }
   scope :error,         -> { where(status: 'error') }
+  scope :ignored,       -> { where(status: 'ignored') }
   scope :manually_set,  -> { where(manually_set: true) }
 end

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -8,6 +8,7 @@
                              elsif @show_error            then 'エラー'
                              elsif @show_imported         then '取込済み'
                              elsif @show_imported_ignored then '取込済み（除外）'
+                             elsif @show_post_excluded   then '取込後除外'
                              else 'スキップ済み'
                              end %>）
     </h1>
@@ -19,7 +20,7 @@
   <%# タブナビゲーション %>
   <div class="flex gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
     <%= link_to admin_wiki_page_imports_path,
-          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{!@show_manually_set && !@show_deferred && !@show_ignored && !@show_pending && !@show_error && !@show_imported && !@show_imported_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{!@show_manually_set && !@show_deferred && !@show_ignored && !@show_pending && !@show_error && !@show_imported && !@show_imported_ignored && !@show_post_excluded ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       スキップ済み
     <% end %>
     <%= link_to admin_wiki_page_imports_path(manually_set: 1),
@@ -49,6 +50,10 @@
     <%= link_to admin_wiki_page_imports_path(show_imported_ignored: 1),
           class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_imported_ignored ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
       取込済み（除外）
+    <% end %>
+    <%= link_to admin_wiki_page_imports_path(show_post_excluded: 1),
+          class: "px-4 py-2 text-sm font-medium rounded-t-md border border-b-0 #{@show_post_excluded ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100' : 'bg-gray-50 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}" do %>
+      取込後除外
     <% end %>
   </div>
 
@@ -170,8 +175,23 @@
     <% end %>
 
   <%# Deferred / Ignored / Pending / Error / Imported 一覧 %>
-  <% elsif @show_deferred || @show_ignored || @show_pending || @show_error || @show_imported || @show_imported_ignored %>
+  <% elsif @show_deferred || @show_ignored || @show_pending || @show_error || @show_imported || @show_imported_ignored || @show_post_excluded %>
     <% show_checkboxes = @show_imported || @show_pending %>
+
+    <% if @show_imported %>
+      <%= form_with url: admin_wiki_page_imports_path, method: :get, class: "mb-4 flex items-center gap-2" do |sf| %>
+        <%= sf.hidden_field :show_imported, value: 1 %>
+        <%= sf.text_field :q, value: @q, placeholder: "NAME 前方一致で検索…",
+              class: "text-sm rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 py-1.5 px-3 w-64",
+              aria: { label: "NAME 前方一致検索" } %>
+        <%= sf.submit "検索", class: "px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700 cursor-pointer" %>
+        <% if @q %>
+          <%= link_to "クリア", admin_wiki_page_imports_path(show_imported: 1),
+                class: "px-3 py-1.5 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600" %>
+        <% end %>
+      <% end %>
+    <% end %>
+
     <div class="overflow-x-auto bg-white dark:bg-gray-800 shadow rounded-lg mb-4">
       <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-700">
@@ -187,6 +207,9 @@
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">page_type</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Note</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">更新日時</th>
+            <% if @show_imported_ignored %>
+              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">操作</th>
+            <% end %>
           </tr>
         </thead>
         <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
@@ -238,6 +261,15 @@
               </td>
               <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400"><%= wpi.note %></td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= wpi.updated_at.strftime('%Y/%m/%d %H:%M') %></td>
+              <% if @show_imported_ignored %>
+                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                  <%= button_to '除外',
+                        exclude_admin_wiki_page_import_path(wpi),
+                        method: :patch,
+                        class: "px-3 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400 cursor-pointer",
+                        onclick: "return confirm('取込先（Unit/Person）を削除し、除外済みにします。この操作は取り消せません。よろしいですか？')" %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         patch :update_page_type
         patch :set_deferred
         patch :set_ignored
+        patch :exclude
       end
       collection do
         patch :bulk_ignore


### PR DESCRIPTION
## Summary

- 取込済みタブに NAME 前方一致検索フォームを追加
- `WikiPageImport::STATUSES` に `ignored` を追加し `scope :ignored` を追加
- 取込済み（除外）タブの各行に「除外」ボタンを追加（`exclude` アクション：import_target を削除して `status: ignored` に更新）
- 「取込後除外」タブを新設（`show_post_excluded`）

## Test plan

- [ ] 取込済みタブで NAME 検索ができる
- [ ] 取込済み（除外）タブの各行に「除外」ボタンが表示される
- [ ] 「除外」ボタン実行で Unit/Person が削除され `status: ignored` になる
- [ ] 「取込後除外」タブに除外済みレコードが表示される
- [ ] 他のタブの表示・操作に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)