### PR TITLE
feat: タグ索引ページのデザインを他の一覧ページに合わせて刷新 #551

### DIFF
--- a/app/views/indices/index.html.erb
+++ b/app/views/indices/index.html.erb
@@ -1,15 +1,35 @@
-<div class="container mx-auto px-4 py-8">
-  <h1 class="text-2xl font-bold mb-6"><%= @group_name %></h1>
-
-  <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
-    <% @indices.each do |index| %>
-      <%= link_to index_show_path(index.id), class: "block p-4 bg-white shadow rounded-lg hover:shadow-md transition-shadow text-center text-lg font-medium text-gray-800" do %>
-        <%= index.name %>
+<div class="flex justify-center min-h-screen p-0 md:p-8">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
+    <div class="mb-6">
+      <%= link_to indices_groups_path,
+            class: "inline-flex items-center gap-1 text-sm font-bold text-slate-400 dark:text-slate-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+        </svg>
+        グループ一覧に戻る
       <% end %>
+    </div>
+
+    <header class="mb-8">
+      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
+        <%= @group_name %>
+      </h1>
+      <p class="mt-1 text-sm text-slate-400 dark:text-slate-500 font-bold"><%= @indices.count %> indices</p>
+    </header>
+
+    <% if @indices.any? %>
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+        <% @indices.each do |index| %>
+          <%= link_to index_show_path(index.id),
+                class: "group block bg-slate-50 dark:bg-slate-900/50 p-4 rounded-2xl border border-slate-100 dark:border-slate-700 hover:border-indigo-400 dark:hover:border-indigo-500 hover:scale-[1.02] transition-all text-center font-black text-slate-700 dark:text-slate-200 group-hover:text-indigo-600 dark:group-hover:text-indigo-400" do %>
+            <%= index.name %>
+          <% end %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="py-20 text-center">
+        <p class="text-slate-400 dark:text-slate-500 font-bold">このグループにはインデックスがありません。</p>
+      </div>
     <% end %>
   </div>
-
-  <% if @indices.empty? %>
-    <p class="text-gray-500 mt-4">このグループにはインデックスがありません。</p>
-  <% end %>
 </div>

--- a/app/views/indices/show.html.erb
+++ b/app/views/indices/show.html.erb
@@ -1,78 +1,50 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="mb-6">
-    <%= link_to "← 索引一覧に戻る", indices_group_path(params[:index_group] || @index.index_group || 1), class: "text-indigo-600 hover:text-indigo-800" %>
-  </div>
-
-  <h1 class="text-3xl font-bold mb-8 flex items-center">
-    <span class="mr-2 px-3 py-1 bg-gray-200 rounded text-xl text-gray-700">索引</span>
-    <%= @index.name %>
-  </h1>
-
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-    
-    <%# Units Section %>
-    <div>
-      <h2 class="text-xl font-bold mb-4 pb-2 border-b border-gray-200">ユニット (<%= @units.count %>)</h2>
-      <% if @units.any? %>
-        <ul class="space-y-2">
-          <% @units.each do |unit| %>
-            <li>
-              <%= link_to profile_path(unit.key), class: "block p-2 -mx-2 hover:bg-gray-50 rounded transition text-gray-800" do %>
-                <span class="font-bold text-indigo-700 text-lg"><%= unit.name %></span>
-                <% if unit.name_kana.present? %>
-                  <span class="text-sm text-gray-500 ml-1">(<%= unit.name_kana %>)</span>
-                <% end %>
-                <% 
-                  aliases = unit.name_logs.reject { |l| l.name == unit.name }.map do |l|
-                    l.name_kana.present? ? "#{l.name}（#{l.name_kana}）" : l.name
-                  end.uniq
-                %>
-                <% if aliases.any? %>
-                  <span class="text-gray-400 mx-1">/</span>
-                  <span class="text-sm text-gray-600">
-                    <%= aliases.join('、') %>
-                  </span>
-                <% end %>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      <% else %>
-        <p class="text-gray-500 text-sm">該当するユニットはありません。</p>
+<div class="flex justify-center min-h-screen p-0 md:p-8">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
+    <div class="mb-6">
+      <%= link_to indices_group_path(params[:index_group] || @index.index_group || 1),
+            class: "inline-flex items-center gap-1 text-sm font-bold text-slate-400 dark:text-slate-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+        </svg>
+        索引一覧に戻る
       <% end %>
     </div>
+
+    <header class="mb-8">
+      <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center gap-3">
+        <span class="px-2 py-0.5 bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 text-base rounded-lg font-black uppercase tracking-widest">INDEX</span>
+        <span><%= @index.name %></span>
+      </h1>
+      <div class="mt-2 flex gap-4 text-sm text-slate-400 dark:text-slate-500 font-bold">
+        <span><%= @units.count %> units</span>
+        <span><%= @people.count %> people</span>
+      </div>
+    </header>
+
+    <%# Units Section %>
+    <% if @units.any? %>
+      <section class="mb-10" aria-labelledby="units-heading">
+        <h2 id="units-heading" class="text-lg font-black text-slate-600 dark:text-slate-300 uppercase tracking-widest mb-4">Units</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          <%= render UnitCardComponent.with_collection(@units) %>
+        </div>
+      </section>
+    <% end %>
 
     <%# People Section %>
-    <div>
-      <h2 class="text-xl font-bold mb-4 pb-2 border-b border-gray-200">個人 (<%= @people.count %>)</h2>
-      <% if @people.any? %>
-        <ul class="space-y-2">
-          <% @people.each do |person| %>
-            <li>
-              <%= link_to profile_path(person.key), class: "block p-2 -mx-2 hover:bg-gray-50 rounded transition text-gray-800" do %>
-                <span class="font-bold text-indigo-700 text-lg"><%= person.name %></span>
-                <% if person.name_kana.present? %>
-                  <span class="text-sm text-gray-500 ml-1">(<%= person.name_kana %>)</span>
-                <% end %>
-                <% 
-                  aliases = person.name_logs.reject { |l| l.name == person.name }.map do |l|
-                    l.name_kana.present? ? "#{l.name}（#{l.name_kana}）" : l.name
-                  end.uniq
-                %>
-                <% if aliases.any? %>
-                  <span class="text-gray-400 mx-1">/</span>
-                  <span class="text-sm text-gray-600">
-                    <%= aliases.join('、') %>
-                  </span>
-                <% end %>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      <% else %>
-        <p class="text-gray-500 text-sm">該当する個人はありません。</p>
-      <% end %>
-    </div>
+    <% if @people.any? %>
+      <section aria-labelledby="people-heading">
+        <h2 id="people-heading" class="text-lg font-black text-slate-600 dark:text-slate-300 uppercase tracking-widest mb-4">People</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          <%= render PersonCardComponent.with_collection(@people) %>
+        </div>
+      </section>
+    <% end %>
 
+    <% if @units.empty? && @people.empty? %>
+      <div class="py-20 text-center">
+        <p class="text-slate-400 dark:text-slate-500 font-bold">このインデックスに該当するデータはありません。</p>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- `indices/show` (`/index/show/:id`): 旧 `container mx-auto` スタイルから shadow card ラッパーへ変更し、`UnitCardComponent` / `PersonCardComponent` でカード表示に統一
- `indices/index` (`/index/:index_group`): 同様に shadow card ラッパーへ変更し、グループ一覧への戻るリンクを追加
- ダークモード・アクセシビリティ（`aria-labelledby`、SVG `aria-hidden`）対応
- ヘッダーに units / people の件数を表示

## Test plan
- [ ] `/index` (groups 一覧) → `/index/:group_id` (タグ一覧) → `/index/show/:id` (タグ詳細) の遷移と戻るリンクが正常に動作する
- [ ] タグ詳細ページで units / people がカード表示される
- [ ] ダークモードで表示崩れがない

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)