### PR TITLE
feat: import フローを改善し、リダイレクト・include・個人ページの誤分類を防ぐ（issue #562）

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,10 +6,10 @@ SKIP_LOG_CATEGORIES = [
   'オムニバス'
 ].freeze
 
-# コメント行・区切り行を除いた実質的な内容行を返す
+# コメント行・区切り行・リスト行を除いた実質的な内容行を返す
 def effective_lines(wikipage)
   wikipage.wiki.to_s.lines
-          .reject { |l| l.strip.empty? || l.start_with?('//') || l.strip == '----' }
+          .reject { |l| l.strip.empty? || l.start_with?('//') || l.start_with?('*') || l.strip == '----' }
 end
 
 # リダイレクト・移動ページかどうかを判定する

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,6 +6,33 @@ SKIP_LOG_CATEGORIES = [
   'オムニバス'
 ].freeze
 
+# コメント行・区切り行を除いた実質的な内容行を返す
+def effective_lines(wikipage)
+  wikipage.wiki.to_s.lines
+          .reject { |l| l.strip.empty? || l.start_with?('//') || l.strip == '----' }
+end
+
+# リダイレクト・移動ページかどうかを判定する
+# 「に移動しました」を含む行がある、または全有効行が「→ [[」で始まる場合に true
+def moved_page?(wikipage)
+  lines = effective_lines(wikipage)
+  return false if lines.empty?
+
+  moved_keyword = "\u306b\u79fb\u52d5\u3057\u307e\u3057\u305f" # に移動しました
+  return true if lines.any? { |l| l.include?(moved_keyword) }
+
+  # 全有効行が → [[ で始まる（ページ全体がリダイレクトのみ）
+  lines.all? { |l| l.match?(/^\u2192\s*\[\[/) }
+end
+
+# {{include ...}} のみで構成されるページかどうかを判定する
+def include_only?(wikipage)
+  lines = effective_lines(wikipage)
+  return false if lines.empty?
+
+  lines.all? { |l| l.match?(/\A\{\{include\s+/i) }
+end
+
 def extract_categories(wikipage)
   return [] if wikipage.wiki.blank?
 
@@ -160,6 +187,14 @@ namespace :import do # rubocop:disable Metrics/BlockLength
         if PersonImporter.ignored?(wp)
           skipped += 1
           update_wiki_page_import_as_skipped(wp, note: 'ignored')
+          next
+        elsif moved_page?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'moved', page_type: 'moved')
+          next
+        elsif include_only?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'include only', page_type: 'other')
           next
         elsif PersonImporter.valid_person?(wp)
           PersonImporter.import(wp)

--- a/lib/tasks/import_v2.rake
+++ b/lib/tasks/import_v2.rake
@@ -86,6 +86,18 @@ namespace :import do
           skipped += 1
           update_wiki_page_import_as_skipped(wp, note: 'ignored')
           next
+        elsif moved_page?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'moved', page_type: 'moved')
+          next
+        elsif include_only?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'include only', page_type: 'other')
+          next
+        elsif PersonImporter.valid_person?(wp)
+          skipped += 1
+          update_wiki_page_import_as_skipped(wp, note: 'person', page_type: 'person')
+          next
         elsif WikipageImporter.valid_unit?(wp)
           # ID指定時: インポート前に既存の関連レコードを削除
           if ENV['ID']
@@ -109,8 +121,8 @@ namespace :import do
           update_wiki_page_import_as_imported(wp, page_type: 'unit', target: unit)
         else
           skipped += 1
-          puts format_skip_log(wp) if wp.title.present? && !PersonImporter.valid_person?(wp)
-          update_wiki_page_import_as_skipped(wp, note: nil, page_type: 'moved') if wp.wiki.to_s.lines.first(3).any? { |line| line.include?('移動しました') }
+          puts format_skip_log(wp) if wp.title.present?
+          update_wiki_page_import_as_skipped(wp, note: 'not a unit or person')
         end
       end
     end


### PR DESCRIPTION
## 概要

全件再インポート時に、リダイレクトページ・include ページ・個人ページが Unit として誤登録されないよう、判定フローを改善。

closes #562

## 変更内容

### `import.rake` に共通ヘルパーを追加

- `effective_lines(wp)` — コメント行（`//`）・区切り行（`----`）・空行を除いた実質的な内容行を返す
- `moved_page?(wp)` — 以下のいずれかで true:
  - 「に移動しました」を含む行がある
  - 全有効行が `→ [[` で始まる（ページ全体がリダイレクトのみ）
- `include_only?(wp)` — 全有効行が `{{include ...}}` のみで構成される

### `import:units_v2` / `import:people` の判定フロー変更

**変更前:**
```
ignored? → valid_unit? → (valid_person?チェックしてログ出力) → skipped
```

**変更後:**
```
ignored? → moved_page? → include_only? → valid_person? → valid_unit? → skipped
```

- `valid_person?` を `valid_unit?` より先に評価 → 個人ページの Unit への混入を防止
- 旧来の移動ページ検出（最初の3行に `移動しました` を含むかのみ）を `moved_page?` に置き換え

## テスト

- RuboCop: offense なし
- 既存テスト: 78 runs, 0 failures