### PR TITLE
chore: ダンプファイルのパスを vkdb_dump/ 配下の最新ファイルに更新

### DIFF
--- a/lib/tasks/import_old_trends.rake
+++ b/lib/tasks/import_old_trends.rake
@@ -5,7 +5,7 @@ namespace :import do
   task old_trends: :environment do
     require 'date'
 
-    file_path = Rails.root.join('trends_all_20260320.sql')
+    file_path = Rails.root.join('vkdb_dump/trends_all_20260411.sql')
     unless File.exist?(file_path)
       puts "File not found: #{file_path}"
       exit

--- a/script/import_release_schedule_from_mysql.sh
+++ b/script/import_release_schedule_from_mysql.sh
@@ -5,7 +5,7 @@ set -e
 # PostgreSQL 17のパスを設定
 PSQL="/opt/homebrew/opt/postgresql@17/bin/psql"
 DB_NAME="vkdby_development"
-SRC_SQL="release_schedule_all_20260201.sql"
+SRC_SQL="./vkdb_dump/release_schedule_all_20260411.sql"
 TMP_SQL="/tmp/release_schedule_inserts.sql"
 
 echo "=== MySQLダンプからPostgreSQLへのデータ移行 (release_schedule) ==="


### PR DESCRIPTION
## Summary
- `import:old_trends` タスクのダンプファイルパスを `vkdb_dump/trends_all_20260411.sql` に更新
- `import_release_schedule_from_mysql.sh` のダンプファイルパスを `./vkdb_dump/release_schedule_all_20260411.sql` に更新

## Test plan
- [x] `bin/rails import:old_trends` が正常に実行されること
- [x] `script/import_release_schedule_from_mysql.sh` が正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)