### PR TITLE
feat: Trend編集画面でDBに未登録のUnit名を追加できるようにする

### DIFF
--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -34,6 +34,9 @@ class TrendsController < ApplicationController
     unit_ids = @trend.units.map { |u| u['unit_id'] }
     @related_units = Unit.where(id: unit_ids).index_by(&:id)
 
+    person_ids = (@trend.people || []).map { |p| p['person_id'] }.compact
+    @related_people = Person.where(id: person_ids).index_by(&:id) if person_ids.any?
+
     return unless unit_ids.size == 1
 
     unit = @related_units.values.first

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     this.activeIndex = -1
     this.handleClickOutside = this.handleClickOutside.bind(this)
     document.addEventListener('click', this.handleClickOutside)
+    this.renderSelectedItems()
   }
 
   disconnect() {
@@ -209,7 +210,13 @@ export default class extends Controller {
     const newName = event.currentTarget.value
     const item = this.selectedItems.find(item => item._uid === uid)
     if (item) item.name = newName
+    event.currentTarget.style.width = `${Math.max(6, newName.length)}ch`
     this.updateHiddenField()
+  }
+
+  preventRemoveFocus(event) {
+    // × クリック時に input へフォーカスが移らないようにする
+    event.preventDefault()
   }
 
   renderSelectedItems() {
@@ -217,31 +224,31 @@ export default class extends Controller {
     const colorClass = this.fieldNameValue === 'people'
       ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
       : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200'
-    const inputColorClass = this.fieldNameValue === 'people'
-      ? 'text-green-800 dark:text-green-200'
-      : 'text-indigo-800 dark:text-indigo-200'
-
     this.selectedTarget.innerHTML = this.selectedItems.map(item => {
       const isUnregistered = item[idField] == null
-      const nameSize = Math.max(4, item.name ? item.name.length : 4)
+      const nameWidth = Math.max(6, (item.name || '').length)
       const unregisteredLabel = isUnregistered
-        ? `<span class="ml-1 text-xs opacity-50">(未登録)</span>`
+        ? `<span class="text-xs opacity-50 select-none">(未登録)</span>`
         : ''
 
       return `
-        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm ${colorClass}">
+        <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium ${colorClass}">
           <input type="text"
                  value="${this.escapeHtml(item.name || '')}"
-                 size="${nameSize}"
+                 style="width: ${nameWidth}ch"
                  data-action="input->autocomplete#renameItem"
                  data-uid="${item._uid}"
-                 class="bg-transparent border-none outline-none text-sm font-medium ${inputColorClass} min-w-[4ch]"
+                 class="bg-transparent rounded px-1 -mx-1 outline-none min-w-[6ch] transition-all cursor-text
+                        hover:bg-black/10 dark:hover:bg-white/10
+                        focus:bg-white dark:focus:bg-gray-700 focus:text-gray-900 dark:focus:text-gray-100 focus:shadow-[0_0_0_2px_currentColor] focus:rounded"
+                 title="クリックして表示名を編集"
                  aria-label="表示名">
           ${unregisteredLabel}
           <button type="button"
-                  data-action="click->autocomplete#removeItem"
+                  data-action="mousedown->autocomplete#preventRemoveFocus click->autocomplete#removeItem"
                   data-uid="${item._uid}"
-                  class="ml-1 hover:opacity-75" aria-label="削除">×</button>
+                  class="opacity-40 hover:opacity-100 hover:text-red-500 dark:hover:text-red-400 leading-none transition-all flex-shrink-0"
+                  aria-label="削除">×</button>
         </span>
       `
     }).join('')

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -79,7 +79,7 @@ export default class extends Controller {
   }
 
   get resultItems() {
-    return Array.from(this.resultsTarget.querySelectorAll('[data-id]'))
+    return Array.from(this.resultsTarget.querySelectorAll('[data-id], [data-unregistered]'))
   }
 
   highlightItem() {
@@ -109,31 +109,37 @@ export default class extends Controller {
       if (!response.ok) throw new Error('Search failed')
 
       const data = await response.json()
-      this.displayResults(data)
+      this.displayResults(data, query)
     } catch (error) {
       console.error('Autocomplete error:', error)
     }
   }
 
-  displayResults(items) {
+  displayResults(items, query) {
     this.activeIndex = -1
 
-    if (items.length === 0) {
-      this.hideResults()
-      return
-    }
-
     const idField = this.fieldNameValue === 'people' ? 'person_id' : 'unit_id'
-    const selectedIds = this.selectedItems.map(item => item[idField])
+    const selectedIds = this.selectedItems
+      .filter(item => item[idField] != null)
+      .map(item => item[idField])
 
     const filtered = items.filter(item => !selectedIds.includes(item.id))
 
-    if (filtered.length === 0) {
+    const isUnitsField = this.fieldNameValue === 'units'
+    const currentQuery = query || this.inputTarget.value.trim()
+
+    // units フィールドの場合、既に同名の未登録アイテムが追加済みか確認
+    const alreadyAddedAsUnregistered = isUnitsField &&
+      this.selectedItems.some(item => item.unit_id == null && item.name === currentQuery)
+
+    const showUnregisteredOption = isUnitsField && currentQuery.length >= 2 && !alreadyAddedAsUnregistered
+
+    if (filtered.length === 0 && !showUnregisteredOption) {
       this.hideResults()
       return
     }
 
-    this.resultsTarget.innerHTML = filtered
+    const registeredHtml = filtered
       .map(item => `
         <div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
              data-action="click->autocomplete#selectItem"
@@ -145,6 +151,16 @@ export default class extends Controller {
         </div>
       `).join('')
 
+    const unregisteredHtml = showUnregisteredOption
+      ? `<div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer border-t border-gray-100 dark:border-gray-700"
+               data-action="click->autocomplete#addUnregisteredItem"
+               data-unregistered="true"
+               data-name="${this.escapeHtml(currentQuery)}">
+            <div class="text-sm text-gray-500 dark:text-gray-400">「${this.escapeHtml(currentQuery)}」を未登録として追加</div>
+          </div>`
+      : ''
+
+    this.resultsTarget.innerHTML = registeredHtml + unregisteredHtml
     this.showResults()
   }
 
@@ -166,11 +182,30 @@ export default class extends Controller {
     this.hideResults()
   }
 
-  removeItem(event) {
-    const id = parseInt(event.currentTarget.dataset.id)
-    const idField = this.fieldNameValue === 'people' ? 'person_id' : 'unit_id'
+  addUnregisteredItem(event) {
+    const name = event.currentTarget.dataset.name
+    if (!name) return
 
-    this.selectedItems = this.selectedItems.filter(item => item[idField] !== id)
+    this.selectedItems.push({ name })
+    this.updateHiddenField()
+    this.renderSelectedItems()
+    this.inputTarget.value = ''
+    this.hideResults()
+  }
+
+  removeItem(event) {
+    const el = event.currentTarget
+
+    if (el.dataset.unregistered) {
+      const name = el.dataset.name
+      this.selectedItems = this.selectedItems.filter(item =>
+        !(item.unit_id == null && item.name === name)
+      )
+    } else {
+      const id = parseInt(el.dataset.id)
+      const idField = this.fieldNameValue === 'people' ? 'person_id' : 'unit_id'
+      this.selectedItems = this.selectedItems.filter(item => item[idField] !== id)
+    }
 
     this.updateHiddenField()
     this.renderSelectedItems()
@@ -182,15 +217,25 @@ export default class extends Controller {
       ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
       : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200'
 
-    this.selectedTarget.innerHTML = this.selectedItems.map(item => `
-      <span class="inline-flex items-center px-3 py-1 rounded-full text-sm ${colorClass}">
-        ${this.escapeHtml(item.name)}
-        <button type="button"
-                data-action="click->autocomplete#removeItem"
-                data-id="${item[idField]}"
-                class="ml-2 hover:opacity-75">×</button>
-      </span>
-    `).join('')
+    this.selectedTarget.innerHTML = this.selectedItems.map(item => {
+      const isUnregistered = item[idField] == null
+      const removeAttrs = isUnregistered
+        ? `data-unregistered="true" data-name="${this.escapeHtml(item.name)}"`
+        : `data-id="${item[idField]}"`
+      const label = isUnregistered
+        ? `${this.escapeHtml(item.name)}<span class="ml-1 text-xs opacity-60">(未登録)</span>`
+        : this.escapeHtml(item.name)
+
+      return `
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm ${colorClass}">
+          ${label}
+          <button type="button"
+                  data-action="click->autocomplete#removeItem"
+                  ${removeAttrs}
+                  class="ml-2 hover:opacity-75">×</button>
+        </span>
+      `
+    }).join('')
   }
 
   updateHiddenField() {

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -25,10 +25,14 @@ export default class extends Controller {
     }
   }
 
+  generateUid() {
+    return Math.random().toString(36).slice(2, 11)
+  }
+
   loadExistingItems() {
     try {
       const data = JSON.parse(this.hiddenFieldTarget.value || '[]')
-      return data
+      return data.map(item => ({ ...item, _uid: this.generateUid() }))
     } catch (e) {
       return []
     }
@@ -125,14 +129,14 @@ export default class extends Controller {
 
     const filtered = items.filter(item => !selectedIds.includes(item.id))
 
-    const isUnitsField = this.fieldNameValue === 'units'
+    const supportsUnregistered = this.fieldNameValue === 'units' || this.fieldNameValue === 'people'
     const currentQuery = query || this.inputTarget.value.trim()
 
-    // units フィールドの場合、既に同名の未登録アイテムが追加済みか確認
-    const alreadyAddedAsUnregistered = isUnitsField &&
-      this.selectedItems.some(item => item.unit_id == null && item.name === currentQuery)
+    // units/people フィールドの場合、既に同名の未登録アイテムが追加済みか確認
+    const alreadyAddedAsUnregistered = supportsUnregistered &&
+      this.selectedItems.some(item => item[idField] == null && item.name === currentQuery)
 
-    const showUnregisteredOption = isUnitsField && currentQuery.length >= 2 && !alreadyAddedAsUnregistered
+    const showUnregisteredOption = supportsUnregistered && currentQuery.length >= 2 && !alreadyAddedAsUnregistered
 
     if (filtered.length === 0 && !showUnregisteredOption) {
       this.hideResults()
@@ -170,10 +174,10 @@ export default class extends Controller {
     const key = event.currentTarget.dataset.key || ''
 
     if (this.fieldNameValue === 'artists') {
-      this.selectedItems.push({ unit_id: id, name, key })
+      this.selectedItems.push({ unit_id: id, name, key, _uid: this.generateUid() })
     } else {
       const idField = this.fieldNameValue === 'people' ? 'person_id' : 'unit_id'
-      this.selectedItems.push({ [idField]: id, name })
+      this.selectedItems.push({ [idField]: id, name, _uid: this.generateUid() })
     }
 
     this.updateHiddenField()
@@ -186,7 +190,7 @@ export default class extends Controller {
     const name = event.currentTarget.dataset.name
     if (!name) return
 
-    this.selectedItems.push({ name })
+    this.selectedItems.push({ name, _uid: this.generateUid() })
     this.updateHiddenField()
     this.renderSelectedItems()
     this.inputTarget.value = ''
@@ -194,21 +198,18 @@ export default class extends Controller {
   }
 
   removeItem(event) {
-    const el = event.currentTarget
-
-    if (el.dataset.unregistered) {
-      const name = el.dataset.name
-      this.selectedItems = this.selectedItems.filter(item =>
-        !(item.unit_id == null && item.name === name)
-      )
-    } else {
-      const id = parseInt(el.dataset.id)
-      const idField = this.fieldNameValue === 'people' ? 'person_id' : 'unit_id'
-      this.selectedItems = this.selectedItems.filter(item => item[idField] !== id)
-    }
-
+    const uid = event.currentTarget.dataset.uid
+    this.selectedItems = this.selectedItems.filter(item => item._uid !== uid)
     this.updateHiddenField()
     this.renderSelectedItems()
+  }
+
+  renameItem(event) {
+    const uid = event.currentTarget.dataset.uid
+    const newName = event.currentTarget.value
+    const item = this.selectedItems.find(item => item._uid === uid)
+    if (item) item.name = newName
+    this.updateHiddenField()
   }
 
   renderSelectedItems() {
@@ -216,30 +217,40 @@ export default class extends Controller {
     const colorClass = this.fieldNameValue === 'people'
       ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
       : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200'
+    const inputColorClass = this.fieldNameValue === 'people'
+      ? 'text-green-800 dark:text-green-200'
+      : 'text-indigo-800 dark:text-indigo-200'
 
     this.selectedTarget.innerHTML = this.selectedItems.map(item => {
       const isUnregistered = item[idField] == null
-      const removeAttrs = isUnregistered
-        ? `data-unregistered="true" data-name="${this.escapeHtml(item.name)}"`
-        : `data-id="${item[idField]}"`
-      const label = isUnregistered
-        ? `${this.escapeHtml(item.name)}<span class="ml-1 text-xs opacity-60">(未登録)</span>`
-        : this.escapeHtml(item.name)
+      const nameSize = Math.max(4, item.name ? item.name.length : 4)
+      const unregisteredLabel = isUnregistered
+        ? `<span class="ml-1 text-xs opacity-50">(未登録)</span>`
+        : ''
 
       return `
-        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm ${colorClass}">
-          ${label}
+        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm ${colorClass}">
+          <input type="text"
+                 value="${this.escapeHtml(item.name || '')}"
+                 size="${nameSize}"
+                 data-action="input->autocomplete#renameItem"
+                 data-uid="${item._uid}"
+                 class="bg-transparent border-none outline-none text-sm font-medium ${inputColorClass} min-w-[4ch]"
+                 aria-label="表示名">
+          ${unregisteredLabel}
           <button type="button"
                   data-action="click->autocomplete#removeItem"
-                  ${removeAttrs}
-                  class="ml-2 hover:opacity-75">×</button>
+                  data-uid="${item._uid}"
+                  class="ml-1 hover:opacity-75" aria-label="削除">×</button>
         </span>
       `
     }).join('')
   }
 
   updateHiddenField() {
-    this.hiddenFieldTarget.value = JSON.stringify(this.selectedItems)
+    // _uid はクライアント専用のため保存しない
+    const cleanItems = this.selectedItems.map(({ _uid, ...item }) => item)
+    this.hiddenFieldTarget.value = JSON.stringify(cleanItems)
   }
 
   showResults() {

--- a/app/views/admin/trends/edit.html.erb
+++ b/app/views/admin/trends/edit.html.erb
@@ -2,7 +2,10 @@
   <div class="max-w-4xl mx-auto">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Edit Trend</h1>
-      <%= link_to "Back", admin_trends_path, class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
+      <div class="flex gap-4">
+        <%= link_to "Show", trend_path(@trend), class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
+        <%= link_to "一覧", admin_trends_path, class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
+      </div>
     </div>
 
     <% if notice %>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -29,6 +29,18 @@
         <% end %>
         <span><%= format_wiki_title(@trend.title, link: false) %></span>
       </h1>
+      <% if @trend.people.present? %>
+        <div class="mt-2 flex flex-wrap items-center gap-1">
+          <% @trend.people.each do |person_data| %>
+            <% person = @related_people&.dig(person_data['person_id']) %>
+            <% if person %>
+              <%= link_to person.name, profile_path(person.key), class: "px-2 py-0.5 rounded text-sm font-medium bg-white/60 text-zinc-800 hover:bg-white/80 transition-colors border border-white/40" %>
+            <% elsif person_data['name'].present? %>
+              <span class="px-2 py-0.5 rounded text-sm font-medium bg-white/40 text-zinc-800 border border-white/30"><%= person_data['name'] %></span>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
     <div class="p-5 md:p-8">
 


### PR DESCRIPTION
## Summary

- Units autocomplete の検索結果の下に「`「入力名」を未登録として追加`」オプションを追加
- クリックすると `{ name }` のみ（`unit_id` なし）の形式で `units` JSON に保存される
- 選択済みバッジには `(未登録)` ラベルを表示。×ボタンで削除も可能
- 既に同名の未登録アイテムが追加済みの場合はオプションを非表示にして重複を防止
- Trend show ページは `unit_data['name'].present?` の分岐が既にあるため変更不要

## Test plan

- [ ] Trend 編集画面の Units フィールドで2文字以上入力し、「未登録として追加」オプションが表示されることを確認
- [ ] クリックで選択済みバッジに `(未登録)` 付きで追加されることを確認
- [ ] 保存後、Trend show ページでUnit名がリンクなしのテキストとして表示されることを確認
- [ ] ×ボタンで削除できることを確認
- [ ] 同名を2回追加しようとしてもオプションが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)