### PR TITLE
fix: convert_old_trends の unit_name / person_name キーを name に統一

### DIFF
--- a/lib/tasks/convert_old_trends.rake
+++ b/lib/tasks/convert_old_trends.rake
@@ -68,9 +68,9 @@ namespace :convert do
       person = Person.find_by(old_wiki_id: old.wikipage_id)
 
       if unit
-        trend.units = [{ unit_id: unit.id, unit_name: unit.name }]
+        trend.units = [{ unit_id: unit.id, name: unit.name }]
       elsif person
-        trend.people = [{ person_id: person.id, person_name: person.name }]
+        trend.people = [{ person_id: person.id, name: person.name }]
       elsif old.target_name.present?
         trend.units = [{ name: old.target_name }]
       end


### PR DESCRIPTION
## Summary

- `convert_old_trends.rake` で units に `unit_name`、people に `person_name` キーで保存していたのを `name` に修正
- ビュー・コントローラーはすべて `name` キーを期待しているため、インポート時のキーを合わせる
- 既存データはインポートし直しで対応

## Test plan

- [x] `bundle exec rake convert:old_trends` 実行後、trends の units/people が `name` キーで保存されることを確認
- [ ] Trend 編集画面で Units/People が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)