### PR TITLE
fix: convert_old_trends で「死去」を含む場合に passed_away を設定する

### DIFF
--- a/lib/tasks/convert_old_trends.rake
+++ b/lib/tasks/convert_old_trends.rake
@@ -146,6 +146,9 @@ namespace :convert do
                                 :other
                               end
     end
+
+    # trend_class によらず「死去」が含まれる場合は passed_away を優先
+    trend.person_phenomenon = :passed_away if old.content&.include?('死去')
   end
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 end


### PR DESCRIPTION
## Summary

- `apply_phenomenon` の末尾に、content に「死去」が含まれる場合 `person_phenomenon = :passed_away` を設定する処理を追加
- `trend_class` によらず優先して適用される

## Test plan

- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rake convert:old_trends` 実行後、「死去」を含む Trend の `person_phenomenon` が `passed_away` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)