### PR TITLE
fix: Trend 関連の改善（passed_away対応・show表示改善・IDリセット）

### DIFF
--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -37,10 +37,11 @@ class TrendsController < ApplicationController
     person_ids = (@trend.people || []).map { |p| p['person_id'] }.compact
     @related_people = Person.where(id: person_ids).index_by(&:id) if person_ids.any?
 
-    return unless unit_ids.size == 1
+    first_unit_id = @trend.units.first&.dig('unit_id')
+    @unit = @related_units[first_unit_id]
+    return unless @unit
 
-    unit = @related_units.values.first
-    return unless unit
+    unit = @unit
 
     candidate_date = @trend.snapshot_date || @trend.date
     @snapshot = unit.unit_snapshots

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -53,8 +53,9 @@
               <%= twitter_embed(@trend.quote_url, @trend.quote) %>
             </div>
           <% else %>
-            <blockquote class="mt-8 border-l-4 border-indigo-500 pl-4 py-1 bg-slate-50 dark:bg-slate-800/50 rounded-r-lg">
-              <div class="text-lg italic text-slate-700 dark:text-slate-300">
+            <blockquote class="mt-8 relative pl-10 pr-4 py-4 bg-slate-50 dark:bg-slate-800/50 rounded-xl border border-slate-200 dark:border-slate-700">
+              <span class="absolute top-2 left-3 text-5xl leading-none text-indigo-300 dark:text-indigo-600 font-serif select-none" aria-hidden="true">&ldquo;</span>
+              <div class="text-base italic text-slate-700 dark:text-slate-300">
                 <%= simple_format(@trend.quote) %>
               </div>
               <% if @trend.quote_title.present? || @trend.quote_url.present? %>
@@ -82,7 +83,9 @@
           <% if @snapshot %>
             <section>
               <div class="flex items-center gap-2 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
-                <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Members</h2>
+                <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                  <% if @trend.units.size > 1 %><%= @unit.name %> <% end %>Members
+                </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>
                   <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= @snapshot.label %></span>
                 <% end %>

--- a/lib/tasks/convert_old_trends.rake
+++ b/lib/tasks/convert_old_trends.rake
@@ -5,6 +5,7 @@ namespace :convert do
   task old_trends: :environment do
     puts 'Start converting OldTrend to Trend...'
     Trend.delete_all
+    ActiveRecord::Base.connection.execute('ALTER SEQUENCE trends_id_seq RESTART WITH 1')
 
     count = 0
     skipped_count = 0


### PR DESCRIPTION
## Summary

- `convert:old_trends` で「死去」を含む場合に `person_phenomenon` を `passed_away` に設定
- `convert:old_trends` でデータクリア後にIDシーケンスを1からリセット
- Trend#show で複数ユニット紐づき時も1つ目のユニットでメンバー表示・関連トレンド・アイテムを取得
- 複数ユニット紐づき時はメンバーセクション名に対象バンド名を表示（例: 「バンド名 Members」）
- blockquote に引用符（`"`）装飾を追加し、カード風レイアウトに変更

## Test plan

- [ ] `convert:old_trends` 実行後、「死去」を含む OldTrend が `passed_away` で登録されること
- [ ] `convert:old_trends` 実行後にIDが1から振られること
- [ ] 複数ユニット紐づきの Trend#show でメンバーセクションが1つ目のユニットで表示されること
- [ ] 複数ユニット紐づき時にセクション名に「バンド名 Members」と表示されること
- [ ] 単一ユニットの場合はセクション名が「Members」のみであること
- [ ] quote がある Trend で blockquote の引用符装飾が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)