### PR TITLE
feat: 本番DBの週次バックアップワークフローを追加

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,30 @@
+name: Database Backup
+
+on:
+  schedule:
+    - cron: '0 20 * * 0' # 毎週月曜 JST 05:00 (= UTC 日曜 20:00)
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y postgresql-client
+
+      - name: Run pg_dump
+        env:
+          DATABASE_URL: ${{ secrets.RENDER_DATABASE_URL }}
+        run: |
+          TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
+          FILENAME="vkdby_${TIMESTAMP}.dump"
+          pg_dump --format=custom --no-acl --no-owner "$DATABASE_URL" -f "$FILENAME"
+          echo "BACKUP_FILE=$FILENAME" >> "$GITHUB_ENV"
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ env.BACKUP_FILE }}
+          path: ${{ env.BACKUP_FILE }}
+          retention-days: 180


### PR DESCRIPTION
## Summary

- Render.com 本番 DB（Basic プラン）を GitHub Actions で週次バックアップする仕組みを追加
- 毎週月曜 JST 05:00（= UTC 日曜 20:00）に `pg_dump` を実行し、Artifact として 180 日間保存
- `workflow_dispatch` で手動実行も可能

## Test plan

- [ ] `workflow_dispatch` で手動実行し、Artifact にダンプファイルが保存されることを確認
- [ ] ダウンロードしたダンプを `pg_restore` でローカルに復元できることを確認

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)