### PR TITLE
fix: pg_dump をサーバーバージョン（PG18）に合わせる

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -10,8 +10,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y postgresql-client
+      - name: Install PostgreSQL 18 client
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y curl ca-certificates
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y postgresql-client-18
 
       - name: Run pg_dump
         env:

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
           FILENAME="vkdby_${TIMESTAMP}.dump"
-          pg_dump --format=custom --no-acl --no-owner "$DATABASE_URL" -f "$FILENAME"
+          /usr/lib/postgresql/18/bin/pg_dump --format=custom --no-acl --no-owner "$DATABASE_URL" -f "$FILENAME"
           echo "BACKUP_FILE=$FILENAME" >> "$GITHUB_ENV"
 
       - name: Upload backup artifact

--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ bundle exec annotaterb models
 bin/rails test
 ```
 
+## バックアップ
+
+### 自動バックアップ
+
+本番環境（Render.com）のデータベースバックアップは2段階で管理しています。
+
+| 種類 | 保持期間 | 仕組み |
+|------|----------|--------|
+| Render.com 自動バックアップ | 7日間 | Render Basic プランに付属 |
+| GitHub Actions バックアップ | 180日間 | 週次（毎週月曜 JST 05:00）で `pg_dump` を実行し Artifact として保存 |
+
+### 手動実行
+
+GitHub Actions の **Database Backup** ワークフローを `workflow_dispatch` で手動実行できます。
+
+```bash
+gh workflow run backup.yml --repo kuwavkdb/vkdby
+```
+
+### バックアップからの復元
+
+1. GitHub → Actions → Database Backup → 対象の実行 → Artifacts からダンプファイルをダウンロード
+2. ローカルに復元:
+
+```bash
+pg_restore --no-owner --no-acl -d <接続先DB> vkdby_YYYYMMDD_HHMMSS.dump
+```
+
 ## 注意事項
 - サーバー起動後は `http://127.0.0.1:3000` でアクセス可能です。
 - `bin/rails` 等を直接叩くとシステム Ruby が呼ばれてエラーになる可能性があるため、上記のように明示的にパスを通した実行を強く推奨します。


### PR DESCRIPTION
## Summary

- `pg_dump` のバージョン不一致（client: 16, server: 18）によるエラーを修正
- PGDG 公式リポジトリを追加して `postgresql-client-18` をインストールするよう変更

## 原因

Ubuntu の apt デフォルトリポジトリには PG16 しか含まれていないが、Render.com の DB サーバーは PG18 のため mismatch が発生していた。

## Test plan

- [ ] `workflow_dispatch` で手動実行し、バックアップが正常に完了することを確認

Refs #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)