### PR TITLE
feat: legacy redirect で aliases の old_key フィールドによる検索を追加

### DIFF
--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -7,8 +7,8 @@ class LegacyRedirectsController < ApplicationController
 
     # Try to find Unit by old_key
     if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key) ||
-               Unit.where("aliases @> ?", [{ old_key: old_key }].to_json).first ||
-               Unit.where("aliases @> ?", [{ old_key: encoded_old_key }].to_json).first)
+               Unit.where('aliases @> ?', [{ old_key: old_key }].to_json).first ||
+               Unit.where('aliases @> ?', [{ old_key: encoded_old_key }].to_json).first)
       new_url = profile_url(unit.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently
@@ -17,8 +17,8 @@ class LegacyRedirectsController < ApplicationController
 
     # Fallback: Try to find Person by old_key
     if (person = Person.find_by(old_key: old_key) || Person.find_by(old_key: encoded_old_key) ||
-                 Person.where("aliases @> ?", [{ old_key: old_key }].to_json).first ||
-                 Person.where("aliases @> ?", [{ old_key: encoded_old_key }].to_json).first)
+                 Person.where('aliases @> ?', [{ old_key: old_key }].to_json).first ||
+                 Person.where('aliases @> ?', [{ old_key: encoded_old_key }].to_json).first)
       new_url = profile_url(person.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently

--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -6,7 +6,9 @@ class LegacyRedirectsController < ApplicationController
     encoded_old_key = URI.encode_www_form_component(old_key.gsub('+', ' '))
 
     # Try to find Unit by old_key
-    if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key))
+    if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key) ||
+               Unit.where("aliases @> ?", [{ old_key: old_key }].to_json).first ||
+               Unit.where("aliases @> ?", [{ old_key: encoded_old_key }].to_json).first)
       new_url = profile_url(unit.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently
@@ -14,7 +16,9 @@ class LegacyRedirectsController < ApplicationController
     end
 
     # Fallback: Try to find Person by old_key
-    if (person = Person.find_by(old_key: old_key) || Person.find_by(old_key: encoded_old_key))
+    if (person = Person.find_by(old_key: old_key) || Person.find_by(old_key: encoded_old_key) ||
+                 Person.where("aliases @> ?", [{ old_key: old_key }].to_json).first ||
+                 Person.where("aliases @> ?", [{ old_key: encoded_old_key }].to_json).first)
       new_url = profile_url(person.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently


### PR DESCRIPTION
## Summary

`Unit` / `Person` の `old_key` 直接検索で見つからない場合に、`aliases` の `old_key` フィールドを jsonb containment 演算子（`@>`）で検索するフォールバックを追加。

これにより、`import:moved`（#579）で `{{include}}` 先の aliases に登録された移動元ページ名が、`.html` URL でアクセス可能になる。

- `aliases` カラムは `jsonb` + GIN インデックス済みのため `@>` 演算子がインデックスを活用
- `old_key` / `encoded_old_key` の両方で検索（既存の直接検索と同じ形式）

Closes #580

## Test plan

- [ ] `import:moved` 実行済みの環境で、移動元ページ名の `.html` URL にアクセスして 301 リダイレクトされることを確認
- [ ] `old_key` を持たない既存 aliases への影響がないことを確認（#583 の backfill 後に本格的に効果が出る）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)