### PR TITLE
feat: import:backfill_alias_old_key タスクを追加

### DIFF
--- a/lib/tasks/import_moved.rake
+++ b/lib/tasks/import_moved.rake
@@ -113,6 +113,55 @@ namespace :import do
   end
 end
 
+namespace :import do
+  desc 'Backfill old_key into aliases registered by import:moved before old_key support was added'
+  task backfill_alias_old_key: :environment do
+    dryrun = ENV['DRYRUN'] == '1'
+
+    puts 'Starting alias old_key backfill...'
+    puts 'Mode: DRYRUN (DB への書き込みは行いません)' if dryrun
+
+    backfilled = 0
+    skipped    = 0
+
+    scope = WikiPageImport.where(status: 'imported', page_type: 'moved')
+                          .where.not(import_target_type: nil)
+                          .includes(:wikipage)
+    total = scope.count
+    puts "Target WikiPageImports: #{total}"
+
+    scope.find_each do |wpi|
+      wp          = wpi.wikipage
+      target      = wpi.import_target
+      next unless wp && target
+
+      title           = wp.title
+      encoded_old_key = URI.encode_www_form_component(wp.name.encode('EUC-JP'))
+
+      current_aliases = target[:aliases] || []
+      idx = current_aliases.index { |a| a['name'] == title && a['old_key'].blank? }
+
+      unless idx
+        puts "[SKIP] #{title} (WikiPageImport##{wpi.id}) → old_key 補完済み or alias なし"
+        skipped += 1
+        next
+      end
+
+      unless dryrun
+        current_aliases[idx] = current_aliases[idx].merge('old_key' => encoded_old_key)
+        target.update!(aliases: current_aliases)
+      end
+
+      puts "[BACKFILLED] #{title} (WikiPageImport##{wpi.id}) → #{target.key} の alias に old_key を補完"
+      backfilled += 1
+    end
+
+    puts dryrun ? 'Dryrun complete!' : 'Backfill complete!'
+    puts "  Backfilled: #{backfilled}"
+    puts "  Skipped:    #{skipped}"
+  end
+end
+
 def resolve_moved_key(base_key, current_id = nil)
   return base_key unless Unit.where(key: base_key).where.not(id: current_id).exists?
 


### PR DESCRIPTION
## Summary

#579 マージ前に `import:moved` で登録された aliases には `old_key` フィールドがなく、#580 の legacy redirect（aliases.old_key による `.html` URL 解決）が機能しない。本 PR はその既存レコードへの補完タスクを追加する。

- `WikiPageImport`（status=imported, page_type=moved）を走査
- `import_target` の aliases に `name` が一致し `old_key` が空のエントリを検出
- `wp.name` を EUC-JP エンコードした値（他の old_key と同形式）を補完して保存
- DRYRUN=1 で書き込みなしの事前確認が可能

DRYRUN 実行結果: 対象 263 件中 **38 件**が補完対象として検出。

Closes #583

## Test plan

- [ ] `DRYRUN=1 bundle exec rails import:backfill_alias_old_key` で `[BACKFILLED]` が 38 件出ることを確認
- [ ] DRYRUN なしで実行後、対象 aliases に `old_key` が補完されていることを確認
- [ ] 再実行時に重複補完されないことを確認（`[SKIP]` になること）
- [ ] 補完後、該当ページの `.html` URL で 301 リダイレクトが機能することを確認（#580 との連携）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)