### PR TITLE
feat: 管理画面の Unit/Person alias 編集フォームに old_key フィールドを追加

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -101,7 +101,7 @@ module Admin
         parts: [],
         links_attributes: %i[id text url active _destroy],
         name_logs_attributes: %i[name name_kana],
-        aliases_attributes: %i[name kana]
+        aliases_attributes: %i[name kana old_key]
       )
     end
   end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -115,7 +115,7 @@ module Admin
       params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key, :note,
                                    links_attributes: %i[id text url active sort_order _destroy],
                                    name_logs_attributes: %i[name name_kana],
-                                   aliases_attributes: %i[name kana],
+                                   aliases_attributes: %i[name kana old_key],
                                    activity_periods_attributes: %i[from to label])
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -145,7 +145,7 @@ class Person < ApplicationRecord
 
   def aliases_attributes=(attributes)
     self[:aliases] = attributes.values.reject { |a| a['name'].blank? }.map do |a|
-      { name: CGI.unescapeHTML(a['name'].to_s), kana: a['kana'].to_s }
+      { name: CGI.unescapeHTML(a['name'].to_s), kana: a['kana'].to_s, old_key: a['old_key'].to_s.presence }.compact
     end
   end
 

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -100,7 +100,7 @@ class Unit < ApplicationRecord
 
   def aliases_attributes=(attributes)
     self[:aliases] = attributes.values.reject { |a| a['name'].blank? }.map do |a|
-      { name: CGI.unescapeHTML(a['name'].to_s), kana: a['kana'].to_s }
+      { name: CGI.unescapeHTML(a['name'].to_s), kana: a['kana'].to_s, old_key: a['old_key'].to_s.presence }.compact
     end
   end
 

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -51,7 +51,7 @@
         <div class="space-y-4">
           <%
             aliases_for_form = person.aliases
-            aliases_for_form << ::OpenStruct.new(name: "", kana: "")
+            aliases_for_form << ::OpenStruct.new(name: "", kana: "", old_key: "")
           %>
           <%= form.fields_for :aliases, aliases_for_form do |alias_form| %>
             <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-end">
@@ -63,9 +63,13 @@
                 <%= alias_form.label :kana, "よみ", class: "block text-xs font-medium text-gray-700 dark:text-gray-300" %>
                 <%= alias_form.text_field :kana, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
               </div>
+              <div class="flex-1 w-full">
+                <%= alias_form.label :old_key, "旧キー (old_key)", class: "block text-xs font-medium text-gray-500 dark:text-gray-400" %>
+                <%= alias_form.text_field :old_key, class: "mt-1 block w-full rounded-md border-gray-200 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 sm:text-sm text-gray-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400" %>
+              </div>
             </div>
           <% end %>
-          <div class="text-xs text-gray-500">※名前を空にすると保存時に削除されます</div>
+          <div class="text-xs text-gray-500">※名前を空にすると保存時に削除されます。旧キーはインポート時に自動設定されます。</div>
         </div>
       </div>
 

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -82,7 +82,7 @@
     <div class="space-y-4">
       <%
         aliases_for_form = unit.aliases
-        aliases_for_form << OpenStruct.new(name: "", kana: "")
+        aliases_for_form << OpenStruct.new(name: "", kana: "", old_key: "")
       %>
       <%= form.fields_for :aliases, aliases_for_form do |alias_form| %>
         <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-end">
@@ -94,9 +94,13 @@
             <%= alias_form.label :kana, "よみ", class: "block text-xs font-medium text-gray-700 dark:text-gray-300" %>
             <%= alias_form.text_field :kana, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
           </div>
+          <div class="flex-1 w-full">
+            <%= alias_form.label :old_key, "旧キー (old_key)", class: "block text-xs font-medium text-gray-500 dark:text-gray-400" %>
+            <%= alias_form.text_field :old_key, class: "mt-1 block w-full rounded-md border-gray-200 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm text-gray-500 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400" %>
+          </div>
         </div>
       <% end %>
-      <div class="text-xs text-gray-500">※名前を空にすると保存時に削除されます</div>
+      <div class="text-xs text-gray-500">※名前を空にすると保存時に削除されます。旧キーはインポート時に自動設定されます。</div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- **モデル** (`unit.rb` / `person.rb`): `aliases_attributes=` で `old_key` を保持。空の場合はキー自体を保存しない（`.presence` + `.compact`）
- **コントローラー** (`admin/units_controller.rb` / `admin/people_controller.rb`): `aliases_attributes` の permit に `old_key` を追加
- **ビュー** (`admin/units/_form.html.erb` / `admin/people/_form.html.erb`): alias フォームに「旧キー (old_key)」入力欄を追加。薄いスタイルでインポート時に自動設定される値であることを示す

Closes #582

## Test plan

- [ ] Unit / Person 編集画面で aliases に old_key が表示されることを確認
- [ ] old_key を編集して保存すると反映されることを確認
- [ ] old_key を空にして保存すると aliases から old_key キーが消えることを確認（`name` は残る）
- [ ] 新規 alias 追加時に old_key を入力せずに保存しても正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)