### PR TITLE
chore: person_logs テーブル廃止の後処理（seeds.rb コメント削除）

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,7 +53,6 @@ if unit
   unit.unit_logs.find_or_create_by!(log_date: '2020/01/01', phenomenon: :announcement, text: '結成発表（公式Xにて）')
   unit.unit_logs.find_or_create_by!(log_date: '2020/02/01', phenomenon: :first_live, text: '渋谷公会堂にて初ライブを開催')
 
-  # Existing PersonLogs for this unit's people will be integrated automatically
 end
 
 puts 'Done seeding links and logs.'


### PR DESCRIPTION
closes #439

## Summary
- `person_logs` テーブルは `20260410145632_drop_person_logs.rb` によりすでに廃止済み
- `db/seeds.rb` に残っていた廃止済み PersonLog に関するコメントを削除

## Test plan
- [ ] RuboCop / テストはすべて通過済み（pre-push フックで確認）