### PR TITLE
fix: 旧フォーマットメンバーの逆順・二重登録・alias残留を修正

### DIFF
--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -8,6 +8,8 @@ class WikipageImporter < BaseWikipageImporter
     new(wikipage).import
   end
 
+  KNOWN_PART_KEYWORDS = %w[vocal guitar bass drums keyboard dj].freeze
+
   def self.valid_unit?(wikipage)
     return false if ignored?(wikipage)
     return false if wikipage.wiki.blank?
@@ -15,8 +17,12 @@ class WikipageImporter < BaseWikipageImporter
     # Check for member section or specific category that indicates a unit
     # Simple check: has {{member...}} tag or !Part... line
     has_member_plugin = wikipage.wiki.match?(/\{\{member2?\s+.*?\}\}/m)
-    # Support both formats: !Part… [[Name]] and ![[Name]]… Part
-    has_old_member_format = wikipage.wiki.match?(/^!([^…]+)…\s*\[\[/) || wikipage.wiki.match?(/^!\[\[.+?\]\]\s*…/)
+    # Support formats: !Part… [[Name]], ![[Name]]… Part, !Part… PlainName, !PlainName… Part
+    parts_pattern = "(#{KNOWN_PART_KEYWORDS.join('|')})"
+    has_old_member_format = wikipage.wiki.match?(/^!([^…]+)…\s*\[\[/) ||
+                            wikipage.wiki.match?(/^!\[\[.+?\]\]\s*…/) ||
+                            wikipage.wiki.match?(/^!#{parts_pattern}\s*…/i) ||
+                            wikipage.wiki.match?(/^![^…\[\n]+…\s*#{parts_pattern}\b/i)
 
     has_member_plugin || has_old_member_format
   end
@@ -181,7 +187,7 @@ class WikipageImporter < BaseWikipageImporter
     unit.name = unit_name
     unit.name_kana = unit_name_kana
     unit.name_log = name_log_entries if name_log_entries.present?
-    unit[:aliases] = unit_aliases if unit_aliases.any?
+    unit[:aliases] = unit_aliases
     unit.old_key = encoded_old_key
     unit.old_wiki_id = @wikipage.id
     unit.old_wiki_text = @original_content
@@ -381,9 +387,10 @@ class WikipageImporter < BaseWikipageImporter
     # 1. !Part… [[Name]]
     # 2. ![[Name]]… Part
     # 3. !Part… PlainName (no wiki link)
+    # 4. !PlainName… Part (reversed plain text — swapped in register_old_format_member)
     old_member_regex1 = /^!([^…\n]+)…\s*\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/
     old_member_regex2 = /^!\[\[([^|\]\n]+)(?:\|([^\]\n]+))?\]\]\s*…\s*([^…\n\r]+)/
-    old_member_regex3 = /^!([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
+    old_member_regex3 = /^!(?!\[\[)([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
 
     @wiki_content.scan(old_member_regex1) do |match|
       match_data = Regexp.last_match
@@ -434,6 +441,13 @@ class WikipageImporter < BaseWikipageImporter
   # rubocop:disable Metrics/ParameterLists
   def register_old_format_member(unit, part_str, name_str, old_member_key, member_status, order_in_period)
     # rubocop:enable Metrics/ParameterLists
+    # Detect reversed order: !Name… Part (e.g. !山田… Vocal)
+    cleaned_part = part_str.to_s.sub(/^!/, '').strip.downcase
+    cleaned_name = name_str.to_s.strip.downcase
+    if !KNOWN_PART_KEYWORDS.include?(cleaned_part) && KNOWN_PART_KEYWORDS.include?(cleaned_name)
+      part_str, name_str = name_str, part_str
+    end
+
     # "旧名→[[表示名|ページ名]]" 形式: 表示名を name_str、ページ名を old_member_key として取り出す
     if (m = name_str.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/))
       wiki_page_key = m[2].strip

--- a/app/services/wikipage_importer.rb
+++ b/app/services/wikipage_importer.rb
@@ -444,9 +444,7 @@ class WikipageImporter < BaseWikipageImporter
     # Detect reversed order: !Name… Part (e.g. !山田… Vocal)
     cleaned_part = part_str.to_s.sub(/^!/, '').strip.downcase
     cleaned_name = name_str.to_s.strip.downcase
-    if !KNOWN_PART_KEYWORDS.include?(cleaned_part) && KNOWN_PART_KEYWORDS.include?(cleaned_name)
-      part_str, name_str = name_str, part_str
-    end
+    part_str, name_str = name_str, part_str if !KNOWN_PART_KEYWORDS.include?(cleaned_part) && KNOWN_PART_KEYWORDS.include?(cleaned_name)
 
     # "旧名→[[表示名|ページ名]]" 形式: 表示名を name_str、ページ名を old_member_key として取り出す
     if (m = name_str.match(/\[\[([^|\]]+)\|([^\]]+)\]\]/))

--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -438,7 +438,7 @@ class WikipageImporterV2 < WikipageImporter
     URI.encode_www_form_component(key.encode('EUC-JP'))
   end
 
-  def collect_old_format_entries(entries, separator_index)
+  def collect_old_format_entries(entries, separator_index) # rubocop:disable Metrics/AbcSize
     old_member_regex1 = /^!([^…\n]+)…\s*\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/
     old_member_regex2 = /^!\[\[([^|\]\n]+)(?:\|([^\]\n]+))?\]\]\s*…\s*([^…\n]+)/
     old_member_regex3 = /^!(?!\[\[)([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
@@ -499,9 +499,7 @@ class WikipageImporterV2 < WikipageImporter
       # 逆順検出: !Name… Part (e.g. !山田… Vocal)
       cleaned_part = part_str.sub(/^!/, '').strip.downcase
       cleaned_name = name_str.strip.downcase
-      if !KNOWN_PART_KEYWORDS.include?(cleaned_part) && KNOWN_PART_KEYWORDS.include?(cleaned_name)
-        part_str, name_str = name_str, part_str
-      end
+      part_str, name_str = name_str, part_str if !KNOWN_PART_KEYWORDS.include?(cleaned_part) && KNOWN_PART_KEYWORDS.include?(cleaned_name)
 
       # "旧名→[[表示名|ページ名]]" 形式: 表示名を name_str、ページ名を old_member_key として取り出す
       wiki_page_key = nil

--- a/app/services/wikipage_importer_v2.rb
+++ b/app/services/wikipage_importer_v2.rb
@@ -440,8 +440,8 @@ class WikipageImporterV2 < WikipageImporter
 
   def collect_old_format_entries(entries, separator_index)
     old_member_regex1 = /^!([^…\n]+)…\s*\[\[([^|\]]+)(?:\|([^\]]+))?\]\]/
-    old_member_regex2 = /^!\[\[([^|\]\n]+)(?:\|([^\]\n]+))?\]\]…([^…\n]+)/
-    old_member_regex3 = /^!([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
+    old_member_regex2 = /^!\[\[([^|\]\n]+)(?:\|([^\]\n]+))?\]\]\s*…\s*([^…\n]+)/
+    old_member_regex3 = /^!(?!\[\[)([^…\n]+)…[^\S\n]*([^\[\s\n][^\n]*)/
 
     @wiki_content.scan(old_member_regex1) do |match|
       match_data = Regexp.last_match
@@ -495,6 +495,13 @@ class WikipageImporterV2 < WikipageImporter
       part_str = match[0].strip
       name_str = match[1].strip
       next if name_str.empty?
+
+      # 逆順検出: !Name… Part (e.g. !山田… Vocal)
+      cleaned_part = part_str.sub(/^!/, '').strip.downcase
+      cleaned_name = name_str.strip.downcase
+      if !KNOWN_PART_KEYWORDS.include?(cleaned_part) && KNOWN_PART_KEYWORDS.include?(cleaned_name)
+        part_str, name_str = name_str, part_str
+      end
 
       # "旧名→[[表示名|ページ名]]" 形式: 表示名を name_str、ページ名を old_member_key として取り出す
       wiki_page_key = nil

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -78,8 +78,10 @@ def format_skip_log(wikipage)
 end
 
 namespace :import do # rubocop:disable Metrics/BlockLength
-  desc 'Import units from Wikipages'
+  # DEPRECATED: Use import:units_v2 instead.
+  desc '[DEPRECATED] Import units from Wikipages. Use import:units_v2 instead.'
   task units: :environment do
+    warn '[DEPRECATED] import:units is deprecated. Use import:units_v2 instead.'
     puts 'Starting unit import from Wikipages...'
     count = 0
     skipped = 0


### PR DESCRIPTION
## Summary

- `!山田… Vocal` 形式（逆順プレーンテキスト）を正しくパースするため、パート・名前の自動スワップを追加（`WikipageImporter` / `WikipageImporterV2` 両対応）
- `old_member_regex3` に `(?!\[\[)` を追加し、`![[Name]]… Part` 形式との二重処理を防止
- `WikipageImporterV2#collect_old_format_entries` の `old_member_regex2` に `\s*` を追加し、`]] … Part`（スペースあり）のマッチ漏れを修正
- `valid_unit?` に逆順プレーンテキストおよび正順プレーンテキストの検出パターンを追加
- `unit[:aliases]` を常に上書きし、reimport 時の stale alias を除去

## Test plan

- [x] RuboCop パス
- [x] テストスイート 78 tests パス
- [x] DIR EN GREY (WikiID: 5384) で動作確認済み（メンバー正常登録・alias クリア・スナップショットメンバー正常登録）

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)