### PR TITLE
feat: フリーワード検索で people の old_history を対象に追加 (issue #591)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -15,7 +15,7 @@ module Admin
               end
       if @q.present?
         scope = scope.where(
-          'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',
+          'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q',
           q: "%#{@q}%"
         )
       end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -5,7 +5,7 @@ class PeopleController < ApplicationController
     scope = Person.kept.where.not(key: [nil, '']).order(updated_at: :desc)
     if params[:q].present?
       scope = scope.where(
-        'name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',
+        'name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q',
         q: "%#{params[:q]}%"
       )
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,8 @@ class SearchController < ApplicationController
       @units = Unit.kept.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q', q: search_pattern)
                    .order(relevance_order, updated_at: :desc)
                    .limit(15)
-      @people = Person.kept.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q', q: search_pattern)
+      people_condition = 'name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q'
+      @people = Person.kept.where(people_condition, q: search_pattern)
                       .order(relevance_order, updated_at: :desc)
                       .limit(15)
     else

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,7 @@ class SearchController < ApplicationController
       @units = Unit.kept.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q', q: search_pattern)
                    .order(relevance_order, updated_at: :desc)
                    .limit(15)
-      @people = Person.kept.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q', q: search_pattern)
+      @people = Person.kept.where('name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q', q: search_pattern)
                       .order(relevance_order, updated_at: :desc)
                       .limit(15)
     else

--- a/db/migrate/20260419013851_add_index_old_history_to_people.rb
+++ b/db/migrate/20260419013851_add_index_old_history_to_people.rb
@@ -1,0 +1,5 @@
+class AddIndexOldHistoryToPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_index :people, :old_history, using: :gin, opclass: :gin_trgm_ops
+  end
+end

--- a/db/migrate/20260419013851_add_index_old_history_to_people.rb
+++ b/db/migrate/20260419013851_add_index_old_history_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIndexOldHistoryToPeople < ActiveRecord::Migration[8.1]
   def change
     add_index :people, :old_history, using: :gin, opclass: :gin_trgm_ops

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_145632) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_19_013851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -143,6 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_145632) do
     t.index ["key"], name: "index_people_on_key", unique: true
     t.index ["name"], name: "index_people_on_name", opclass: :gin_trgm_ops, using: :gin
     t.index ["name_kana"], name: "index_people_on_name_kana", opclass: :gin_trgm_ops, using: :gin
+    t.index ["old_history"], name: "index_people_on_old_history", opclass: :gin_trgm_ops, using: :gin
     t.index ["old_key"], name: "index_people_on_old_key", unique: true
   end
 


### PR DESCRIPTION
## Summary

- `old_history` カラム（活動履歴テキスト）をフリーワード検索の対象に追加
- DB 負荷対策として `old_history` に GIN trigram インデックスを追加
- 対象: 人物一覧ページ（`PeopleController#index`）、管理画面人物一覧（`Admin::PeopleController#index`）、グローバルナビ検索結果ページ（`SearchController#index`）
- オートコンプリート（`PeopleController#search` / `Admin::PeopleController#search`）は対象外

## Test plan

- [ ] 人物の `old_history` に含まれるユニット名で検索し、該当人物がヒットすること
- [ ] 人物一覧ページ（`/people?q=...`）での動作確認
- [ ] グローバルナビ検索（`/search?q=...`）での動作確認
- [ ] 管理画面人物一覧での動作確認
- [ ] オートコンプリートには影響しないこと

Closes #591