### PR TITLE
feat: release-pr スキルにリリース内容の issue 一覧を追加

### DIFF
--- a/.claude/skills/release-pr/SKILL.md
+++ b/.claude/skills/release-pr/SKILL.md
@@ -19,19 +19,36 @@ description: developブランチから release/0.yyyy.mmdd ブランチを切っ
    git pull origin develop
    ```
 
-3. リリースブランチを作成する
+3. main との差分コミットから issue 番号を収集する
+   - 以下のコマンドで issue 番号を抽出する（`issue #NNN` 形式とブランチ名 `feat/issue-NNN-` 形式に対応）:
+     ```
+     git log origin/main..develop --oneline | grep -oE 'issue[ -]#?[0-9]+|feat/issue-[0-9]+' | grep -oE '[0-9]+' | sort -u
+     ```
+   - issue が1件も見つからない場合は「変更内容なし（依存関係更新のみ等）」と記載する
+
+4. リリースブランチを作成する
    ```
    git checkout -b release/0.<date>
    ```
 
-4. リモートにpushする
+5. リモートにpushする
    ```
    git push origin release/0.<date>
    ```
 
-5. PRを作成する（ベースブランチは `main`）
+6. PRを作成する（ベースブランチは `main`）
+   収集した issue 一覧を PR の本文に含める。フォーマット:
    ```
-   gh pr create --base main --title "release/0.<date>" --body "## Release 0.<date>"
+   ## Release 0.<date>
+
+   ### 含まれる変更
+
+   - #123
+   - #456
    ```
 
-6. 作成したPRのURLをユーザーに表示する
+   ```
+   gh pr create --base main --title "release/0.<date>" --body "<上記フォーマットの本文>"
+   ```
+
+7. 作成したPRのURLをユーザーに表示する


### PR DESCRIPTION
## 概要

`/release-pr` スキルで作成する PR の説明に、リリースに含まれる issue 番号を自動で記載するよう改善する。

## 変更内容

- `main` との差分コミットから issue 番号を抽出するコマンドを手順に追加
- PR 本文のフォーマットを `#NNN` 形式の issue リストに更新