### PR TITLE
feat: /people にカナ索引フィルターを追加 (#603)

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -2,12 +2,21 @@
 
 class PeopleController < ApplicationController
   def index
+    @tag_indices = TagIndex.where(index_group_id: 2).ordered
+    @tag_person_counts = TagIndexItem.where(tag_index_id: @tag_indices.select(:id), indexable_type: 'Person')
+                                     .group(:tag_index_id)
+                                     .count
+
     scope = Person.kept.where.not(key: [nil, '']).order(updated_at: :desc)
     if params[:q].present?
       scope = scope.where(
         'name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q',
         q: "%#{params[:q]}%"
       )
+    end
+    if params[:tag_id].present?
+      scope = scope.joins(:tag_indices).where(tag_indices: { id: params[:tag_id] })
+      scope = scope.reorder(name_kana: :asc)
     end
     @pagy, @people = pagy(scope, limit: 60)
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class PeopleController < ApplicationController
+  KANA_INDEX_GROUP_ID = 2
+
   def index
-    @tag_indices = TagIndex.where(index_group_id: 2).ordered
+    @tag_indices = TagIndex.where(index_group_id: KANA_INDEX_GROUP_ID).ordered
     @tag_person_counts = TagIndexItem.where(tag_index_id: @tag_indices.select(:id), indexable_type: 'Person')
                                      .group(:tag_index_id)
                                      .count

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -9,8 +9,21 @@
 
     <div class="mb-6">
       <%= form_with url: people_path, method: :get, local: true, class: "flex gap-2" do |f| %>
-        <%= f.text_field :q, value: params[:q], placeholder: "Search people...",
-            class: "w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-800 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-slate-400" %>
+        <div class="relative w-full"
+             data-controller="search-suggest"
+             data-search-suggest-url-value="<%= search_people_path %>"
+             data-search-suggest-profile-base-value="">
+          <%= f.text_field :q, value: params[:q], placeholder: "Search people...",
+              class: "w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-800 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-slate-400",
+              data: {
+                search_suggest_target: "input",
+                action: "input->search-suggest#onInput keydown->search-suggest#onKeydown"
+              } %>
+          <div data-search-suggest-target="suggestions"
+               style="position: fixed;"
+               class="hidden z-50 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg overflow-y-auto max-h-80">
+          </div>
+        </div>
         <%= f.button class: "bg-indigo-600 hover:bg-indigo-700 text-white p-3 rounded-xl transition-colors shadow-sm hover:shadow-md flex items-center justify-center min-w-[3rem]" do %>
            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
@@ -18,6 +31,20 @@
         <% end %>
       <% end %>
     </div>
+
+    <% if @tag_indices.present? %>
+      <div class="mb-8 flex flex-wrap gap-1 justify-center">
+        <%= link_to people_path(q: params[:q]), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{params[:tag_id].blank? ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
+          ALL
+        <% end %>
+        <% @tag_indices.each do |tag| %>
+          <%= link_to people_path(tag_id: tag.id, q: params[:q]), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{params[:tag_id].to_s == tag.id.to_s ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
+            <%= tag.name.delete_prefix('個人/') %>
+            <span class="ml-1 opacity-70 text-xs font-normal">(<%= @tag_person_counts[tag.id] || 0 %>)</span>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
 
     <% if @people.any? %>
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary

- `/people` エンドポイントに `/units` と同様のカナ索引フィルターを追加
- `index_group_id: 2`（個人カナ索引）の TagIndex を使用し、ア行〜ワ行で絞り込み可能
- 索引選択時は `name_kana: asc` 順に並び替え
- 検索フォームに search-suggest（入力補完）を追加

## Test plan

- [ ] `/people` にアクセスし、ア行〜ワ行のフィルターが表示されること
- [ ] 各行をクリックするとその行の人物のみ表示されること（件数も表示）
- [ ] ALL をクリックすると全件に戻ること
- [ ] キーワード検索とフィルターを組み合わせて使えること
- [ ] 検索フォームで入力補完が動作すること

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)