### PR TITLE
fix: tag_id + q 同時指定時の ambiguous column エラーを修正 (issue #590)

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,7 +12,7 @@ class PeopleController < ApplicationController
     scope = Person.kept.where.not(key: [nil, '']).order(updated_at: :desc)
     if params[:q].present?
       scope = scope.where(
-        'name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q',
+        'people.name ILIKE :q OR people.name_kana ILIKE :q OR people.name_log::text ILIKE :q OR people.aliases::text ILIKE :q OR people.old_history ILIKE :q',
         q: "%#{params[:q]}%"
       )
     end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -10,7 +10,7 @@ class UnitsController < ApplicationController
     scope = Unit.kept.order(updated_at: :desc)
     if params[:q].present?
       scope = scope.where(
-        'name ILIKE :q OR name_kana ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',
+        'units.name ILIKE :q OR units.name_kana ILIKE :q OR units.name_log::text ILIKE :q OR units.aliases::text ILIKE :q',
         q: "%#{params[:q]}%"
       )
     end


### PR DESCRIPTION
## Summary

- `q`（キーワード検索）と `tag_id` を同時に指定すると `PG::AmbiguousColumn` エラーが発生するバグを修正
- `joins(:tag_indices)` により `tag_indices` テーブルが JOIN されると、`tag_indices.name` と `units.name` / `people.name` が衝突する
- `WHERE` 句のカラム参照をテーブル修飾子付き（`units.name`、`people.name` 等）に変更して解消
- `UnitsController` と `PeopleController` の両方で同じパターンのバグがあったため合わせて修正

## Test plan

- [x] `/units?q=アイコノ&tag_id=3139` にアクセスしてエラーなく結果が表示されること
- [x] `/people?q=...&tag_id=...` でも同様に動作すること
- [x] `q` のみ、`tag_id` のみ、両方なし のケースがそれぞれ正常動作すること

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)