### PR TITLE
fix: units一覧でnameが空のページを検索対象外にする (issue #607)

### DIFF
--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -7,7 +7,7 @@ class UnitsController < ApplicationController
                                    .group(:tag_index_id)
                                    .count
 
-    scope = Unit.kept.order(updated_at: :desc)
+    scope = Unit.kept.where.not(name: [nil, '']).order(updated_at: :desc)
     if params[:q].present?
       scope = scope.where(
         'units.name ILIKE :q OR units.name_kana ILIKE :q OR units.name_log::text ILIKE :q OR units.aliases::text ILIKE :q',


### PR DESCRIPTION
## 概要

`/units` 一覧で name が空（nil または空文字）のページを検索・表示対象から除外する。

## 変更内容

- `UnitsController#index` のスコープに `where.not(name: [nil, ''])` を追加

## 背景

name が空の moved ページが 239 件存在しており、一覧に表示されても検索結果として役に立たないため除外する。

Closes #607