### PR TITLE
feat: index_groups に units/people フィルター表示順を設定できるようにする (issue #606)

### DIFF
--- a/app/controllers/admin/index_groups_controller.rb
+++ b/app/controllers/admin/index_groups_controller.rb
@@ -80,7 +80,7 @@ module Admin
     end
 
     def index_group_params
-      params.require(:index_group).permit(:name, :sort_order, :active)
+      params.require(:index_group).permit(:name, :sort_order, :active, :units_filter_order, :people_filter_order)
     end
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class PeopleController < ApplicationController
-  KANA_INDEX_GROUP_ID = 2
-
   def index
-    @tag_indices = TagIndex.where(index_group_id: KANA_INDEX_GROUP_ID).ordered
-    @tag_person_counts = TagIndexItem.where(tag_index_id: @tag_indices.select(:id), indexable_type: 'Person')
+    @filter_groups = IndexGroup.for_people.includes(tag_indices: :items)
+    all_tag_index_ids = @filter_groups.flat_map { |g| g.tag_indices.map(&:id) }
+    @tag_person_counts = TagIndexItem.where(tag_index_id: all_tag_index_ids, indexable_type: 'Person')
                                      .group(:tag_index_id)
                                      .count
 
@@ -16,8 +15,11 @@ class PeopleController < ApplicationController
         q: "%#{params[:q]}%"
       )
     end
-    if params[:tag_id].present?
-      scope = scope.joins(:tag_indices).where(tag_indices: { id: params[:tag_id] })
+    @selected_tag_ids = params[:tag_ids]&.to_unsafe_h&.transform_values(&:presence)&.compact || {}
+    if @selected_tag_ids.any?
+      @selected_tag_ids.each_value do |tag_id|
+        scope = scope.where(id: Person.joins(:tag_indices).where(tag_indices: { id: tag_id }).select(:id))
+      end
       scope = scope.reorder(name_kana: :asc)
     end
     @pagy, @people = pagy(scope, limit: 60)

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -2,8 +2,9 @@
 
 class UnitsController < ApplicationController
   def index
-    @tag_indices = TagIndex.where(index_group_id: 1).ordered
-    @tag_unit_counts = TagIndexItem.where(tag_index_id: @tag_indices.select(:id), indexable_type: 'Unit')
+    @filter_groups = IndexGroup.for_units.includes(tag_indices: :items)
+    all_tag_index_ids = @filter_groups.flat_map { |g| g.tag_indices.map(&:id) }
+    @tag_unit_counts = TagIndexItem.where(tag_index_id: all_tag_index_ids, indexable_type: 'Unit')
                                    .group(:tag_index_id)
                                    .count
 
@@ -14,8 +15,11 @@ class UnitsController < ApplicationController
         q: "%#{params[:q]}%"
       )
     end
-    if params[:tag_id].present?
-      scope = scope.joins(:tag_indices).where(tag_indices: { id: params[:tag_id] })
+    @selected_tag_ids = params[:tag_ids]&.to_unsafe_h&.transform_values(&:presence)&.compact || {}
+    if @selected_tag_ids.any?
+      @selected_tag_ids.each_value do |tag_id|
+        scope = scope.where(id: Unit.joins(:tag_indices).where(tag_indices: { id: tag_id }).select(:id))
+      end
       scope = scope.reorder(name_kana: :asc)
     end
 

--- a/app/models/index_group.rb
+++ b/app/models/index_group.rb
@@ -4,18 +4,22 @@
 #
 # Table name: index_groups
 #
-#  id         :bigint           not null, primary key
-#  active     :boolean          default(TRUE), not null
-#  name       :string           not null
-#  sort_order :integer          default(0), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                  :bigint           not null, primary key
+#  active              :boolean          default(TRUE), not null
+#  name                :string           not null
+#  people_filter_order :integer
+#  sort_order          :integer          default(0), not null
+#  units_filter_order  :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #
 class IndexGroup < ApplicationRecord
   has_many :tag_indices, dependent: :nullify
 
   scope :ordered, -> { order(sort_order: :asc) }
   scope :active, -> { where(active: true) }
+  scope :for_units, -> { active.where.not(units_filter_order: nil).order(units_filter_order: :asc) }
+  scope :for_people, -> { active.where.not(people_filter_order: nil).order(people_filter_order: :asc) }
 
   validates :name, presence: true
 end

--- a/app/views/admin/index_groups/_form.html.erb
+++ b/app/views/admin/index_groups/_form.html.erb
@@ -32,9 +32,19 @@
         <%= f.number_field :sort_order, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
       </div>
 
-      <div class="mb-6 flex items-center">
+      <div class="mb-4 flex items-center">
         <%= f.check_box :active, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
         <%= f.label :active, class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+
+      <div class="mb-4">
+        <%= f.label :units_filter_order, "Units 一覧フィルターの表示順（空白=非表示）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :units_filter_order, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
+      </div>
+
+      <div class="mb-6">
+        <%= f.label :people_filter_order, "People 一覧フィルターの表示順（空白=非表示）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.number_field :people_filter_order, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
       </div>
 
       <div class="flex items-center justify-between">

--- a/app/views/admin/index_groups/index.html.erb
+++ b/app/views/admin/index_groups/index.html.erb
@@ -11,6 +11,8 @@
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Order</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Active</th>
+          <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Units Filter</th>
+          <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">People Filter</th>
           <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
         </tr>
       </thead>
@@ -26,6 +28,12 @@
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">Inactive</span>
               <% end %>
             </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500">
+              <%= group.units_filter_order.present? ? group.units_filter_order : "-" %>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500">
+              <%= group.people_filter_order.present? ? group.people_filter_order : "-" %>
+            </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
               <%= link_to "Edit", edit_admin_index_group_path(group), class: "text-indigo-600 hover:text-indigo-900" %>
             </td>
@@ -36,6 +44,8 @@
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">-</td>
           <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900"><%= link_to "未分類 (Unassigned)", admin_index_group_path(0), class: "text-indigo-600 hover:text-indigo-900" %></td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">-</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500">-</td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500">-</td>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"></td>
         </tr>
       </tbody>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -32,16 +32,32 @@
       <% end %>
     </div>
 
-    <% if @tag_indices.present? %>
-      <div class="mb-8 flex flex-wrap gap-1 justify-center">
-        <%= link_to people_path(q: params[:q]), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{params[:tag_id].blank? ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
-          ALL
-        <% end %>
-        <% @tag_indices.each do |tag| %>
-          <%= link_to people_path(tag_id: tag.id, q: params[:q]), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{params[:tag_id].to_s == tag.id.to_s ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
-            <%= tag.name.delete_prefix('個人/') %>
-            <span class="ml-1 opacity-70 text-xs font-normal">(<%= @tag_person_counts[tag.id] || 0 %>)</span>
-          <% end %>
+    <% if @filter_groups.present? %>
+      <div class="mb-8 space-y-2">
+        <% @filter_groups.each do |group| %>
+          <div class="flex flex-wrap gap-1">
+            <%
+              current_tag_ids = @selected_tag_ids
+              group_selected = current_tag_ids[group.id.to_s].present?
+              clear_params = current_tag_ids.except(group.id.to_s)
+            %>
+            <% unless [1, 2].include?(group.id) %>
+              <span class="py-1 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide self-center"><%= group.name %> :</span>
+            <% end %>
+            <%= link_to people_path(q: params[:q], tag_ids: clear_params), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{group_selected ? 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600' : 'bg-indigo-600 text-white shadow-md'}" do %>
+              ALL
+            <% end %>
+            <% group.tag_indices.active.ordered.each do |tag| %>
+              <%
+                new_tag_ids = current_tag_ids.merge(group.id.to_s => tag.id.to_s)
+                is_selected = current_tag_ids[group.id.to_s].to_s == tag.id.to_s
+              %>
+              <%= link_to people_path(q: params[:q], tag_ids: new_tag_ids), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{is_selected ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
+                <%= tag.name.sub(/\A[^\/]*\//, '') %>
+                <span class="ml-1 opacity-70 text-xs font-normal">(<%= @tag_person_counts[tag.id] || 0 %>)</span>
+              <% end %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -32,16 +32,32 @@
       <% end %>
     </div>
 
-    <% if @tag_indices.present? %>
-      <div class="mb-8 flex flex-wrap gap-1 justify-center">
-        <%= link_to units_path(q: params[:q]), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{params[:tag_id].blank? ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
-          ALL
-        <% end %>
-        <% @tag_indices.each do |tag| %>
-          <%= link_to units_path(tag_id: tag.id, q: params[:q]), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{params[:tag_id].to_s == tag.id.to_s ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
-            <%= tag.name %>
-            <span class="ml-1 opacity-70 text-xs font-normal">(<%= @tag_unit_counts[tag.id] || 0 %>)</span>
-          <% end %>
+    <% if @filter_groups.present? %>
+      <div class="mb-8 space-y-2">
+        <% @filter_groups.each do |group| %>
+          <div class="flex flex-wrap gap-1">
+            <%
+              current_tag_ids = @selected_tag_ids
+              group_selected = current_tag_ids[group.id.to_s].present?
+              clear_params = current_tag_ids.except(group.id.to_s)
+            %>
+            <% unless [1, 2].include?(group.id) %>
+              <span class="py-1 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide self-center"><%= group.name %> :</span>
+            <% end %>
+            <%= link_to units_path(q: params[:q], tag_ids: clear_params), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{group_selected ? 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600' : 'bg-indigo-600 text-white shadow-md'}" do %>
+              ALL
+            <% end %>
+            <% group.tag_indices.active.ordered.each do |tag| %>
+              <%
+                new_tag_ids = current_tag_ids.merge(group.id.to_s => tag.id.to_s)
+                is_selected = current_tag_ids[group.id.to_s].to_s == tag.id.to_s
+              %>
+              <%= link_to units_path(q: params[:q], tag_ids: new_tag_ids), class: "px-2 py-1 rounded-lg text-sm font-bold transition-all #{is_selected ? 'bg-indigo-600 text-white shadow-md' : 'bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-600'}" do %>
+                <%= tag.name.sub(/\A[^\/]*\//, '') %>
+                <span class="ml-1 opacity-70 text-xs font-normal">(<%= @tag_unit_counts[tag.id] || 0 %>)</span>
+              <% end %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/db/migrate/20260420105114_add_usage_to_index_groups.rb
+++ b/db/migrate/20260420105114_add_usage_to_index_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUsageToIndexGroups < ActiveRecord::Migration[8.1]
   def change
     add_column :index_groups, :units_filter_order, :integer, default: nil
@@ -7,8 +9,8 @@ class AddUsageToIndexGroups < ActiveRecord::Migration[8.1]
     # id:1 (カナ索引) -> Units用 表示順1, id:2 (個人カナ索引) -> People用 表示順1
     reversible do |dir|
       dir.up do
-        execute "UPDATE index_groups SET units_filter_order = 1 WHERE id = 1"
-        execute "UPDATE index_groups SET people_filter_order = 1 WHERE id = 2"
+        execute 'UPDATE index_groups SET units_filter_order = 1 WHERE id = 1'
+        execute 'UPDATE index_groups SET people_filter_order = 1 WHERE id = 2'
       end
     end
   end

--- a/db/migrate/20260420105114_add_usage_to_index_groups.rb
+++ b/db/migrate/20260420105114_add_usage_to_index_groups.rb
@@ -1,0 +1,15 @@
+class AddUsageToIndexGroups < ActiveRecord::Migration[8.1]
+  def change
+    add_column :index_groups, :units_filter_order, :integer, default: nil
+    add_column :index_groups, :people_filter_order, :integer, default: nil
+
+    # 既存データの初期値を現状の運用に合わせて設定
+    # id:1 (カナ索引) -> Units用 表示順1, id:2 (個人カナ索引) -> People用 表示順1
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE index_groups SET units_filter_order = 1 WHERE id = 1"
+        execute "UPDATE index_groups SET people_filter_order = 1 WHERE id = 2"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_19_013851) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_105114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -67,7 +67,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_19_013851) do
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
     t.string "name", null: false
+    t.integer "people_filter_order"
     t.integer "sort_order", default: 0, null: false
+    t.integer "units_filter_order"
     t.datetime "updated_at", null: false
   end
 


### PR DESCRIPTION
## 概要

`/admin/index_groups` で各 IndexGroup を Units / People 一覧のフィルターとして使うかどうか、また表示順を管理できるようにする。

closes #606

## 変更内容

### DB
- `index_groups` に `units_filter_order` / `people_filter_order` カラムを追加（integer, NULL=非表示、数値=表示順）
- 既存データ: id:1（カナ索引）→ `units_filter_order = 1`、id:2（個人カナ索引）→ `people_filter_order = 1`

### admin
- `/admin/index_groups` 一覧に両カラムを表示
- 編集フォームで表示順を数値入力できるように

### コントローラー
- `UnitsController` / `PeopleController` のハードコード（`index_group_id: 1/2`）を廃止
- `IndexGroup.for_units` / `IndexGroup.for_people` スコープで動的に取得

### ビュー（Units / People 一覧）
- フィルターを複数グループ対応に変更（グループごとに行を分けて表示）
- パラメーター形式を `?tag_ids[group_id]=tag_index_id` に変更
- グループをまたいだ AND 条件の複合絞り込みに対応（サブクエリ方式）
- タグ名の `/` より前のプレフィックスを省略表示
- 非アクティブなタグは表示しない
- グループ 1・2 以外はラベルを先頭に表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)