### PR TITLE
feat: index_groups の Items 表示を Unit Management への導線リンクにする (issue #611)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -7,7 +7,8 @@ module Admin
 
     def index
       @q = params[:q]
-      @show_discarded = params[:discarded]
+      @tag_index_id = params[:tag_index_id]
+      @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
       scope = case @show_discarded
               when 'only' then Person.discarded
               when 'all'  then Person.with_discarded
@@ -18,6 +19,10 @@ module Admin
           'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q OR old_history ILIKE :q',
           q: "%#{@q}%"
         )
+      end
+      if @tag_index_id.present?
+        @tag_index = TagIndex.find_by(id: @tag_index_id)
+        scope = scope.joins(:tag_index_items).where(tag_index_items: { tag_index_id: @tag_index_id })
       end
       @pagy, @people = pagy(scope.order(updated_at: :desc))
     end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class UnitsController < Admin::BaseController
+  class UnitsController < Admin::BaseController # rubocop:disable Metrics/ClassLength
     include LoggableLinkChanges
 
     before_action :set_unit, only: %i[show edit update destroy undiscard]
@@ -9,6 +9,7 @@ module Admin
 
     def index
       @q = params[:q]
+      @tag_index_id = params[:tag_index_id]
       @show_discarded = params[:discarded]
       scope = case @show_discarded
               when 'only' then Unit.discarded
@@ -20,6 +21,10 @@ module Admin
           'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',
           q: "%#{@q}%"
         )
+      end
+      if @tag_index_id.present?
+        @tag_index = TagIndex.find_by(id: @tag_index_id)
+        scope = scope.joins(:tag_index_items).where(tag_index_items: { tag_index_id: @tag_index_id })
       end
       @pagy, @units = pagy(scope.order(updated_at: :desc))
     end

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -10,7 +10,7 @@ module Admin
     def index
       @q = params[:q]
       @tag_index_id = params[:tag_index_id]
-      @show_discarded = params[:discarded]
+      @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
       scope = case @show_discarded
               when 'only' then Unit.discarded
               when 'all'  then Unit.with_discarded

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -67,7 +67,7 @@
               <% end %>
             </div>
             <div class="flex items-center gap-4">
-              <span class="text-sm text-gray-500">Items: <%= index.items.count %></span>
+              <%= link_to "Items: #{index.items.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
               <%= button_to index.active? ? "非表示" : "表示", admin_tag_index_path(index, tag_index: { active: !index.active? }), method: :patch, class: "text-xs px-2 py-1 rounded border #{index.active? ? 'text-red-600 border-red-200 hover:bg-red-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'}" %>
             </div>
           </li>
@@ -121,7 +121,7 @@
               <% end %>
             </div>
             <div class="flex items-center gap-4">
-              <span class="text-sm text-gray-500">Items: <%= index.items.count %></span>
+              <%= link_to "Items: #{index.items.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
               <%= button_to index.active? ? "非表示" : "表示", admin_tag_index_path(index, tag_index: { active: !index.active? }), method: :patch, class: "text-xs px-2 py-1 rounded border #{index.active? ? 'text-red-600 border-red-200 hover:bg-red-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'}" %>
             </div>
           </li>

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -67,7 +67,8 @@
               <% end %>
             </div>
             <div class="flex items-center gap-4">
-              <%= link_to "Items: #{index.items.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
+              <%= link_to "Units: #{index.units.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
+              <%= link_to "People: #{index.people.count}", admin_people_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
               <%= button_to index.active? ? "非表示" : "表示", admin_tag_index_path(index, tag_index: { active: !index.active? }), method: :patch, class: "text-xs px-2 py-1 rounded border #{index.active? ? 'text-red-600 border-red-200 hover:bg-red-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'}" %>
             </div>
           </li>
@@ -121,7 +122,8 @@
               <% end %>
             </div>
             <div class="flex items-center gap-4">
-              <%= link_to "Items: #{index.items.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
+              <%= link_to "Units: #{index.units.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
+              <%= link_to "People: #{index.people.count}", admin_people_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
               <%= button_to index.active? ? "非表示" : "表示", admin_tag_index_path(index, tag_index: { active: !index.active? }), method: :patch, class: "text-xs px-2 py-1 rounded border #{index.active? ? 'text-red-600 border-red-200 hover:bg-red-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'}" %>
             </div>
           </li>

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -11,6 +11,13 @@
     </div>
   </div>
 
+  <% if @tag_index %>
+    <div class="mb-4 px-4 py-2 bg-indigo-50 border border-indigo-200 rounded-md flex items-center justify-between text-sm">
+      <span class="text-indigo-800">タグ「<strong><%= @tag_index.name %></strong>」でフィルター中</span>
+      <%= link_to "フィルター解除", admin_people_path, class: "text-indigo-600 hover:text-indigo-800 underline" %>
+    </div>
+  <% end %>
+
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_people_path(q: params[:q]),
         class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -11,6 +11,13 @@
     </div>
   </div>
 
+  <% if @tag_index %>
+    <div class="mb-4 px-4 py-2 bg-indigo-50 border border-indigo-200 rounded-md flex items-center justify-between text-sm">
+      <span class="text-indigo-800">タグ「<strong><%= @tag_index.name %></strong>」でフィルター中</span>
+      <%= link_to "フィルター解除", admin_units_path, class: "text-indigo-600 hover:text-indigo-800 underline" %>
+    </div>
+  <% end %>
+
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_units_path(q: params[:q]),
         class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>


### PR DESCRIPTION
## Summary
- `index_groups` の各タグ行の「Items: n」を「Units: n」「People: n」の2つのリンクに変更し、それぞれ Unit Management / People Management に遷移
- `Admin::UnitsController#index` に `tag_index_id` パラメーターによるフィルタリングを追加
- `Admin::PeopleController#index` に `tag_index_id` パラメーターによるフィルタリングを追加
- タグ条件付きの場合は削除済みも含めた全件表示（discarded=all）にする
- フィルター中は各管理ページ上部にタグ名とフィルター解除リンクを表示

Closes #611

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `/admin/index_groups/:id` でタグ行の「Units: n」をクリック → Unit Management に遷移し該当タグのユニット（削除済み含む）のみ表示される
- [ ] 「People: n」をクリック → People Management に遷移し該当タグの人物（削除済み含む）のみ表示される
- [ ] フィルター中は「タグ「xxx」でフィルター中」バナーとフィルター解除リンクが表示される
- [ ] フィルター解除リンクで全件表示に戻る
- [ ] `id == 0`（未分類グループ）でも同様に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)