### PR TITLE
feat: index_group show 画面の検索フォームに表示・非表示フィルターを追加

### DIFF
--- a/app/controllers/admin/index_groups_controller.rb
+++ b/app/controllers/admin/index_groups_controller.rb
@@ -87,9 +87,9 @@ module Admin
 
     def filter_by_active(scope)
       case params[:active]
-      when 'true'  then scope.where(active: true)
       when 'false' then scope.where(active: false)
-      else scope
+      when 'all'   then scope
+      else              scope.where(active: true)
       end
     end
   end

--- a/app/controllers/admin/index_groups_controller.rb
+++ b/app/controllers/admin/index_groups_controller.rb
@@ -25,11 +25,13 @@ module Admin
       if @index_group.id.zero?
         base_scope = TagIndex.where(index_group_id: nil)
         base_scope = base_scope.where('name LIKE ?', "%#{params[:q]}%") if params[:q].present?
+        base_scope = filter_by_active(base_scope)
         @indices = base_scope.order(:name)
         @groups = IndexGroup.ordered
       else
         indices_scope = @index_group.tag_indices
         indices_scope = indices_scope.where('name LIKE ?', "%#{params[:q]}%") if params[:q].present?
+        indices_scope = filter_by_active(indices_scope)
         @indices = indices_scope.ordered
       end
     end
@@ -81,6 +83,14 @@ module Admin
 
     def index_group_params
       params.require(:index_group).permit(:name, :sort_order, :active, :units_filter_order, :people_filter_order)
+    end
+
+    def filter_by_active(scope)
+      case params[:active]
+      when 'true'  then scope.where(active: true)
+      when 'false' then scope.where(active: false)
+      else scope
+      end
     end
   end
 end

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -29,12 +29,22 @@
   <div class="bg-white shadow rounded-lg p-6">
     <% if @index_group.id == 0 %>
       <div class="mb-4">
-        <%= form_with url: admin_index_group_path(@index_group), method: :get, local: true, class: "flex gap-2" do |f| %>
-          <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
-          <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
-          <% if params[:q].present? %>
-            <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
-          <% end %>
+        <%= form_with url: admin_index_group_path(@index_group), method: :get, local: true, class: "flex flex-col gap-3" do |f| %>
+          <div class="flex gap-2">
+            <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
+            <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
+            <% if params[:q].present? || params[:active].present? %>
+              <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
+            <% end %>
+          </div>
+          <div class="flex items-center gap-4">
+            <% [['すべて', ''], ['表示中', 'true'], ['非表示', 'false']].each do |label, value| %>
+              <label class="inline-flex items-center gap-1.5 cursor-pointer">
+                <%= radio_button_tag :active, value, params[:active].to_s == value, class: "form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300" %>
+                <span class="text-sm text-gray-700"><%= label %></span>
+              </label>
+            <% end %>
+          </div>
         <% end %>
       </div>
 
@@ -76,12 +86,22 @@
       </ul>
     <% else %>
       <div class="mb-4">
-        <%= form_with url: admin_index_group_path(@index_group), method: :get, local: true, class: "flex gap-2" do |f| %>
-          <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
-          <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
-          <% if params[:q].present? %>
-            <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
-          <% end %>
+        <%= form_with url: admin_index_group_path(@index_group), method: :get, local: true, class: "flex flex-col gap-3" do |f| %>
+          <div class="flex gap-2">
+            <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
+            <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
+            <% if params[:q].present? || params[:active].present? %>
+              <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
+            <% end %>
+          </div>
+          <div class="flex items-center gap-4">
+            <% [['すべて', ''], ['表示中', 'true'], ['非表示', 'false']].each do |label, value| %>
+              <label class="inline-flex items-center gap-1.5 cursor-pointer">
+                <%= radio_button_tag :active, value, params[:active].to_s == value, class: "form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300" %>
+                <span class="text-sm text-gray-700"><%= label %></span>
+              </label>
+            <% end %>
+          </div>
         <% end %>
       </div>
 

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -33,14 +33,14 @@
           <div class="flex gap-2">
             <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
             <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
-            <% if params[:q].present? || params[:active].present? %>
+            <% if params[:q].present? || params[:active].in?(%w[false all]) %>
               <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
             <% end %>
           </div>
           <div class="flex items-center gap-4">
-            <% [['すべて', ''], ['表示中', 'true'], ['非表示', 'false']].each do |label, value| %>
+            <% [['表示中', 'true'], ['非表示', 'false'], ['すべて', 'all']].each do |label, value| %>
               <label class="inline-flex items-center gap-1.5 cursor-pointer">
-                <%= radio_button_tag :active, value, params[:active].to_s == value, class: "form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300" %>
+                <%= radio_button_tag :active, value, (params[:active].presence || 'true') == value, class: "form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300" %>
                 <span class="text-sm text-gray-700"><%= label %></span>
               </label>
             <% end %>
@@ -90,14 +90,14 @@
           <div class="flex gap-2">
             <%= f.text_field :q, value: params[:q], placeholder: "Search tags...", class: "flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 text-sm" %>
             <%= f.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 cursor-pointer" %>
-            <% if params[:q].present? || params[:active].present? %>
+            <% if params[:q].present? || params[:active].in?(%w[false all]) %>
               <%= link_to "Clear", admin_index_group_path(@index_group), class: "px-4 py-2 bg-gray-100 text-gray-700 text-sm font-medium rounded-md hover:bg-gray-200" %>
             <% end %>
           </div>
           <div class="flex items-center gap-4">
-            <% [['すべて', ''], ['表示中', 'true'], ['非表示', 'false']].each do |label, value| %>
+            <% [['表示中', 'true'], ['非表示', 'false'], ['すべて', 'all']].each do |label, value| %>
               <label class="inline-flex items-center gap-1.5 cursor-pointer">
-                <%= radio_button_tag :active, value, params[:active].to_s == value, class: "form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300" %>
+                <%= radio_button_tag :active, value, (params[:active].presence || 'true') == value, class: "form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300" %>
                 <span class="text-sm text-gray-700"><%= label %></span>
               </label>
             <% end %>


### PR DESCRIPTION
## Summary
- `admin/index_groups/:id` の検索フォームにラジオボタン（表示中 / 非表示 / すべて）を追加
- デフォルトは「表示中」（`active: true`）でフィルター
- 「すべて」選択時はフィルターなし（全件表示）
- Clear ボタンはデフォルト以外のフィルター適用時のみ表示
- 未分類（id=0）ページ・通常グループページ両方に適用

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] デフォルトで「表示中」が選択されており、表示中タグのみ一覧に出ること
- [ ] 「非表示」を選択すると非表示タグのみ表示されること
- [ ] 「すべて」を選択すると全タグが表示されること
- [ ] キーワード検索と組み合わせて絞り込みできること
- [ ] Clear リンクをクリックするとデフォルト（表示中）に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)