### PR TITLE
feat: Unit Management に moved のみフィルターを追加し、通常モードから moved を除外

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -11,11 +11,17 @@ module Admin
       @q = params[:q]
       @tag_index_id = params[:tag_index_id]
       @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
+      @unit_type_filter = params[:unit_type]
       scope = case @show_discarded
               when 'only' then Unit.discarded
               when 'all'  then Unit.with_discarded
               else             Unit.kept
               end
+      if @unit_type_filter == 'moved'
+        scope = scope.where(unit_type: :moved)
+      elsif @show_discarded.blank? && @tag_index_id.blank?
+        scope = scope.where.not(unit_type: :moved)
+      end
       if @q.present?
         scope = scope.where(
           'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -4,6 +4,7 @@
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_units_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.hidden_field :discarded, value: params[:discarded] %>
+        <%= f.hidden_field :unit_type, value: params[:unit_type] %>
         <%= f.text_field :q, value: params[:q], placeholder: "Search by name or key...", class: "rounded-l-md border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500" %>
         <%= f.submit "Search", class: "px-4 py-2 bg-white text-gray-700 border border-l-0 border-gray-300 rounded-r-md hover:bg-gray-50 cursor-pointer" %>
       <% end %>
@@ -20,7 +21,9 @@
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_units_path(q: params[:q]),
-        class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? && params[:unit_type].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+    <%= link_to "moved のみ", admin_units_path(q: params[:q], unit_type: "moved"),
+        class: "px-3 py-1 rounded text-sm #{params[:unit_type] == 'moved' ? 'bg-amber-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "削除済みのみ", admin_units_path(q: params[:q], discarded: "only"),
         class: "px-3 py-1 rounded text-sm #{params[:discarded] == 'only' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "全件", admin_units_path(q: params[:q], discarded: "all"),


### PR DESCRIPTION
## Summary
- Unit Management の一覧画面に「moved のみ」フィルターボタンを追加
- 通常モード（デフォルト）では `unit_type = moved` のユニットを除外
- 「moved のみ」ボタン選択時は moved のみ表示（amber 色で区別）
- 検索フォームに `unit_type` パラメーターを hidden field として保持（検索時にフィルターが維持される）
- `削除済みのみ` / `全件` モードでは moved も含めて表示（変更なし）

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 通常モードで moved ユニットが表示されないこと
- [ ] 「moved のみ」ボタンで moved ユニットのみ表示されること
- [ ] 「moved のみ」モードで検索しても unit_type フィルターが維持されること
- [ ] 「削除済みのみ」「全件」モードでは moved も含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)