### PR TITLE
feat: カスタムページに {{include}} 記法でセクション埋め込み機能を実装

### DIFF
--- a/app/controllers/admin/sections_controller.rb
+++ b/app/controllers/admin/sections_controller.rb
@@ -67,8 +67,9 @@ module Admin
         type = params[:sectionable_type]
         id   = params[:sectionable_id]
         @sectionable = case type
-                       when 'Unit'   then Unit.find(id)
-                       when 'Person' then Person.find(id)
+                       when 'Unit'       then Unit.find(id)
+                       when 'Person'     then Person.find(id)
+                       when 'CustomPage' then CustomPage.with_discarded.find(id)
                        else raise ActionController::BadRequest, 'Invalid sectionable_type'
                        end
       end
@@ -80,8 +81,9 @@ module Admin
 
     def sectionable_edit_path
       case @sectionable
-      when Unit   then edit_admin_unit_path(@sectionable)
-      when Person then edit_admin_person_path(@sectionable)
+      when Unit       then edit_admin_unit_path(@sectionable)
+      when Person     then edit_admin_person_path(@sectionable)
+      when CustomPage then edit_admin_custom_page_path(@sectionable)
       end
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,8 +45,10 @@ module ApplicationHelper
     false
   end
 
-  def markdown(text)
+  def markdown(text, sectionable: nil)
     return '' if text.blank?
+
+    text = expand_include_macros(text, sectionable:)
 
     renderer = Redcarpet::Render::HTML.new(
       hard_wrap: true,
@@ -58,5 +60,32 @@ module ApplicationHelper
                             fenced_code_blocks: true,
                             strikethrough: true,
                             no_intra_emphasis: true).render(text).html_safe
+  end
+
+  private
+
+  # {{include key,セクション名}}       → CustomPage (key指定)
+  # {{include unit:ID,セクション名}}   → Unit (ID指定)
+  # {{include person:ID,セクション名}} → Person (ID指定)
+  # {{include ,セクション名}}          → 自身のページ (key省略・カンマあり)
+  # {{include セクション名}}           → 自身のページ (key省略・カンマなし)
+  def expand_include_macros(text, sectionable: nil)
+    text.gsub(/\{\{include\s+(?:([a-z0-9_:-]*),)?(.+?)\}\}/) do
+      identifier = Regexp.last_match(1)&.strip
+      section_name = Regexp.last_match(2).strip
+
+      owner = if identifier.nil? || identifier.empty?
+                sectionable
+              elsif identifier.start_with?('unit:')
+                Unit.find_by(id: identifier.delete_prefix('unit:'))
+              elsif identifier.start_with?('person:')
+                Person.find_by(id: identifier.delete_prefix('person:'))
+              else
+                CustomPage.published.find_by(key: identifier)
+              end
+
+      section = owner&.sections&.kept&.find_by(name: section_name)
+      section&.markdown.presence || section&.wiki_text.presence || ''
+    end
   end
 end

--- a/app/models/custom_page.rb
+++ b/app/models/custom_page.rb
@@ -23,6 +23,9 @@ class CustomPage < ApplicationRecord
   include Discard::Model
 
   has_many_attached :images
+  has_many :sections, as: :sectionable, dependent: :destroy
+  has_many :custom_page_includes, foreign_key: :source_custom_page_id, dependent: :destroy, inverse_of: :source_custom_page
+  has_many :included_by, class_name: 'CustomPageInclude', foreign_key: :target_custom_page_id, dependent: :destroy, inverse_of: :target_custom_page
 
   # 削除不可のページkey一覧（ルートとして使用されるなど、システム上必須のページ）
   PROTECTED_KEYS = %w[index].freeze
@@ -30,17 +33,65 @@ class CustomPage < ApplicationRecord
   validates :key, presence: true, uniqueness: true,
                   format: { with: /\A[a-z0-9_-]+\z/, message: '半角英数字・アンダースコア・ハイフンのみ使用可' }
   validates :title, presence: true
+  validate :no_circular_includes, if: :body_changed?
 
   scope :published, -> { kept.where(active: true) }
 
   after_commit :expire_sidebar_cache
   after_commit :expire_blocked_ips_cache, if: -> { key == Middleware::IpBlocker::CUSTOM_PAGE_KEY }
+  after_save :rebuild_include_relations, if: :saved_change_to_body?
 
   def protected?
     PROTECTED_KEYS.include?(key)
   end
 
+  def expire_cache
+    # 現時点ではページ固有のキャッシュはないが、将来的な拡張に備えたフック
+    # サイドバーキャッシュも念のため削除
+    Rails.cache.delete('sidebar/recently_updated')
+  end
+
+  def rebuild_include_relations
+    custom_page_includes.delete_all
+    body.to_s.scan(/\{\{include\s+([a-z0-9_-]+),(.+?)\}\}/) do |page_key, section_name|
+      target = CustomPage.find_by(key: page_key.strip)
+      next unless target
+
+      custom_page_includes.create!(
+        target_custom_page: target,
+        section_name: section_name.strip
+      )
+    end
+  end
+
   private
+
+  def no_circular_includes
+    return if body.blank?
+
+    keys_in_body = body.scan(/\{\{include\s+([a-z0-9_-]+),/).flatten.map(&:strip).uniq
+    return if keys_in_body.empty?
+
+    # このページの key が、インクルード先のページから（直接・間接を問わず）参照されていないか確認
+    keys_in_body.each do |target_key|
+      target_page = CustomPage.find_by(key: target_key)
+      next unless target_page
+
+      errors.add(:body, "循環インクルードが検出されました（#{target_key} → #{key} のパスが存在します）") if reachable_from?(target_page, self, visited: Set.new)
+    end
+  end
+
+  # target_page から辿ってベースページ（base）に到達できるか確認（循環参照検出）
+  def reachable_from?(current_page, base, visited:)
+    return false if visited.include?(current_page.id)
+
+    visited.add(current_page.id)
+    current_page.custom_page_includes.includes(:target_custom_page).each do |rel|
+      return true if rel.target_custom_page_id == base.id
+      return true if reachable_from?(rel.target_custom_page, base, visited:)
+    end
+    false
+  end
 
   def expire_sidebar_cache
     Rails.cache.delete('sidebar/recently_updated')

--- a/app/models/custom_page_include.rb
+++ b/app/models/custom_page_include.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: custom_page_includes
+#
+#  id                    :bigint           not null, primary key
+#  section_name          :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  source_custom_page_id :bigint           not null
+#  target_custom_page_id :bigint           not null
+#
+# Indexes
+#
+#  index_custom_page_includes_on_source_custom_page_id  (source_custom_page_id)
+#  index_custom_page_includes_on_target_custom_page_id  (target_custom_page_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (source_custom_page_id => custom_pages.id)
+#  fk_rails_...  (target_custom_page_id => custom_pages.id)
+#
+
+class CustomPageInclude < ApplicationRecord
+  belongs_to :source_custom_page, class_name: 'CustomPage'
+  belongs_to :target_custom_page, class_name: 'CustomPage'
+
+  validates :section_name, presence: true
+end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -24,4 +24,17 @@ class Section < ApplicationRecord
   has_many_attached :images
 
   validates :name, presence: true
+
+  after_commit :expire_including_pages_cache, on: %i[create update destroy]
+
+  private
+
+  def expire_including_pages_cache
+    return unless sectionable.is_a?(CustomPage)
+
+    CustomPageInclude
+      .where(target_custom_page: sectionable, section_name: name)
+      .includes(:source_custom_page)
+      .each { |rel| rel.source_custom_page.expire_cache }
+  end
 end

--- a/app/views/admin/custom_pages/edit.html.erb
+++ b/app/views/admin/custom_pages/edit.html.erb
@@ -9,5 +9,11 @@
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
       <%= render "form", custom_page: @custom_page %>
     </div>
+
+    <div class="mt-6">
+      <%= render "admin/sections/list",
+            sectionable: @custom_page,
+            sections: @custom_page.sections.with_discarded.order(sort_order: :asc, id: :asc) %>
+    </div>
   </div>
 </div>

--- a/app/views/admin/sections/_form.html.erb
+++ b/app/views/admin/sections/_form.html.erb
@@ -70,7 +70,12 @@
   </div>
 
   <div class="flex justify-end gap-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-    <%= link_to "キャンセル", (sectionable.is_a?(Unit) ? edit_admin_unit_path(sectionable) : edit_admin_person_path(sectionable)),
+    <% cancel_path = case sectionable
+                     when Unit       then edit_admin_unit_path(sectionable)
+                     when Person     then edit_admin_person_path(sectionable)
+                     when CustomPage then edit_admin_custom_page_path(sectionable)
+                     end %>
+    <%= link_to "キャンセル", cancel_path,
           class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
     <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
   </div>

--- a/app/views/custom_pages/show.html.erb
+++ b/app/views/custom_pages/show.html.erb
@@ -20,7 +20,7 @@
         </div>
         <div class="p-5 md:p-8">
           <div class="markdown-content max-w-none">
-            <%= markdown(@page.body) %>
+            <%= markdown(@page.body, sectionable: @page) %>
           </div>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -384,7 +384,7 @@
       <footer class="border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 mt-8">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div class="markdown-content text-sm">
-            <%= markdown(@footer_page.body) %>
+            <%= markdown(@footer_page.body, sectionable: @footer_page) %>
           </div>
         </div>
       </footer>

--- a/db/migrate/20260421125835_create_custom_page_includes.rb
+++ b/db/migrate/20260421125835_create_custom_page_includes.rb
@@ -1,0 +1,11 @@
+class CreateCustomPageIncludes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :custom_page_includes do |t|
+      t.references :source_custom_page, null: false, foreign_key: { to_table: :custom_pages }
+      t.references :target_custom_page, null: false, foreign_key: { to_table: :custom_pages }
+      t.string :section_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260421125835_create_custom_page_includes.rb
+++ b/db/migrate/20260421125835_create_custom_page_includes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCustomPageIncludes < ActiveRecord::Migration[8.1]
   def change
     create_table :custom_page_includes do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_105114) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_125835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -41,6 +41,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_105114) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "custom_page_includes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "section_name", null: false
+    t.bigint "source_custom_page_id", null: false
+    t.bigint "target_custom_page_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["source_custom_page_id"], name: "index_custom_page_includes_on_source_custom_page_id"
+    t.index ["target_custom_page_id"], name: "index_custom_page_includes_on_target_custom_page_id"
   end
 
   create_table "custom_pages", force: :cascade do |t|
@@ -395,6 +405,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_105114) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "custom_page_includes", "custom_pages", column: "source_custom_page_id"
+  add_foreign_key "custom_page_includes", "custom_pages", column: "target_custom_page_id"
   add_foreign_key "snapshot_people", "people"
   add_foreign_key "snapshot_people", "unit_snapshots"
   add_foreign_key "tag_index_items", "tag_indices"


### PR DESCRIPTION
## Summary
- `custom_page_includes` テーブルを追加し、インクルード関係を管理
- `CustomPageInclude` モデルを新規作成
- `CustomPage` モデルに `has_many :sections` と `has_many :custom_page_includes` を追加
- `CustomPage#body` 保存時に `{{include}}` 記法を解析してインクルード関係を自動更新 (`rebuild_include_relations`)
- 循環インクルードのバリデーション（A→B→A を body 保存時に検出）
- `Section` モデルに `after_commit` を追加し、インクルード元ページのキャッシュを削除
- `Admin::SectionsController` に `CustomPage` 対応を追加（`set_sectionable` / `sectionable_edit_path`）
- `application_helper#markdown` に `{{include}}` 展開を追加。以下の記法をサポート:
  - `{{include key,セクション名}}` — CustomPage（key指定）
  - `{{include unit:ID,セクション名}}` — Unit（ID指定）
  - `{{include person:ID,セクション名}}` — Person（ID指定）
  - `{{include ,セクション名}}` / `{{include セクション名}}` — 自身のページ（key省略）
- `admin/custom_pages/edit` にセクション一覧・追加 UI を追加
- `sections/_form` のキャンセルリンクを `CustomPage` に対応

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] カスタムページの編集画面でセクションを追加・編集・削除できること
- [ ] `{{include key,セクション名}}` でカスタムページのセクションが展開されること
- [ ] `{{include unit:ID,セクション名}}` で Unit のセクションが展開されること
- [ ] `{{include person:ID,セクション名}}` で Person のセクションが展開されること
- [ ] `{{include セクション名}}` で自身のページのセクションが展開されること
- [ ] 存在しない key・セクション名の場合は空文字が返ること
- [ ] 非公開・削除済みの CustomPage のセクションはインクルードされないこと
- [ ] 循環インクルード（A→B→A）を設定しようとするとバリデーションエラーになること

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)