### PR TITLE
fix: カスタムページ保存後の遷移先を編集画面に変更し、実ページへのリンクを追加

### DIFF
--- a/app/controllers/admin/custom_pages_controller.rb
+++ b/app/controllers/admin/custom_pages_controller.rb
@@ -40,7 +40,7 @@ module Admin
 
     def update
       if @custom_page.update(custom_page_params)
-        redirect_to admin_custom_pages_path, notice: 'ページを更新しました。'
+        redirect_to edit_admin_custom_page_path(@custom_page), notice: 'ページを更新しました。'
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/views/admin/custom_pages/edit.html.erb
+++ b/app/views/admin/custom_pages/edit.html.erb
@@ -2,8 +2,13 @@
   <div class="max-w-none">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">カスタムページを編集</h1>
-      <%= link_to "一覧に戻る", admin_custom_pages_path,
-          class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
+      <div class="flex items-center gap-4">
+        <%= link_to "ページを開く", custom_page_path(@custom_page.key),
+            target: "_blank", rel: "noopener noreferrer",
+            class: "text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200" %>
+        <%= link_to "一覧に戻る", admin_custom_pages_path,
+            class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
+      </div>
     </div>
 
     <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">


### PR DESCRIPTION
## Summary
- カスタムページの更新保存後、一覧ではなく編集画面にリダイレクトするよう変更
- 編集画面のヘッダーに「ページを開く」リンクを追加（別タブで実ページを開く）

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] カスタムページを編集・保存後、編集画面に留まることを確認
- [ ] 「ページを開く」リンクが別タブで実ページ（/pages/:key）を開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)