### PR TITLE
fix: Weekly TrendsのリンクテキストをTrendのtitleに変更

### DIFF
--- a/app/controllers/custom_pages_controller.rb
+++ b/app/controllers/custom_pages_controller.rb
@@ -23,7 +23,7 @@ class CustomPagesController < ApplicationController
     ttl = Time.current.end_of_day - Time.current
 
     @weekly_trends = Rails.cache.fetch("sidebar/weekly_trends/#{today}", expires_in: ttl) do
-      Trend.where(date: (today - 7)..(today + 7)).order(:date).to_a
+      Trend.where(date: (today - 7)..(today + 7)).order(date: :desc).to_a
     end
 
     @recently_updated = Rails.cache.fetch('sidebar/recently_updated', expires_in: 10.minutes) do

--- a/app/views/custom_pages/_sidebar.html.erb
+++ b/app/views/custom_pages/_sidebar.html.erb
@@ -9,12 +9,12 @@
         <% @weekly_trends.each do |trend| %>
           <li>
             <%= link_to trend_path(trend),
-                class: "flex items-center gap-2 px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors #{'font-bold text-indigo-600 dark:text-indigo-400' if trend.date == Date.current}" do %>
-              <span class="<%= trend.date == Date.current ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400 dark:text-slate-500' %> tabular-nums text-xs w-16 shrink-0">
+                class: "flex items-center gap-2 px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors #{'font-bold' if trend.date == Date.current}" do %>
+              <span class="text-slate-400 dark:text-slate-500 tabular-nums text-xs w-10 shrink-0">
                 <%= trend.date.strftime('%-m/%-d') %>
               </span>
-              <span class="<%= trend.date == Date.current ? 'text-indigo-700 dark:text-indigo-300' : 'text-slate-600 dark:text-slate-300' %> truncate">
-                <%= trend.date == Date.current ? '今日' : trend.date.strftime('%A').then { |d| %w[日 月 火 水 木 金 土][trend.date.wday] + '曜日' } %>
+              <span class="text-slate-600 dark:text-slate-300 leading-snug">
+                <%= format_wiki_title(trend.title.sub(/[（(][^）)]*[）)]\z/u, '').rstrip, link: false) %>
               </span>
             <% end %>
           </li>


### PR DESCRIPTION
## Summary
- Weekly Trends サイドバーのリンクテキストを「今日」「木曜日」などの曜日表示から `Trend#title` に変更
- `format_wiki_title` で wiki 記法を解析し、Trend#show ページと同じ表示にする
- タイトル末尾の括弧書き（全角・半角両対応）を省略して表示
- 表示順を新しい日付順（降順）に変更
- `truncate` を外して全体を折り返し表示、日付欄の幅を縮小（w-16 → w-10）
- 全エントリの文字色を統一し、今日のエントリは `font-bold` のみで強調

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] Weekly Trends にタイトルが表示されること（wiki 記法が解析されること）
- [ ] タイトル末尾の括弧が省略されること
- [ ] 新しい日付が上に表示されること
- [ ] 今日のエントリが太字で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)