### PR TITLE
feat: TrendsにNEWEST順を追加・サイドバーをRecent Trendsに刷新

### DIFF
--- a/app/controllers/custom_pages_controller.rb
+++ b/app/controllers/custom_pages_controller.rb
@@ -23,7 +23,9 @@ class CustomPagesController < ApplicationController
     ttl = Time.current.end_of_day - Time.current
 
     @weekly_trends = Rails.cache.fetch("sidebar/weekly_trends/#{today}", expires_in: ttl) do
-      Trend.where(date: (today - 7)..(today + 7)).order(date: :desc).to_a
+      from_today = Trend.where(date: today..).order(date: :asc).limit(5).to_a
+      recent     = Trend.where(date: (today - 2)..(today - 1)).order(date: :desc).limit(5).to_a
+      (from_today + recent).sort_by(&:date).reverse
     end
 
     unit_ids   = @weekly_trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq

--- a/app/controllers/custom_pages_controller.rb
+++ b/app/controllers/custom_pages_controller.rb
@@ -22,16 +22,7 @@ class CustomPagesController < ApplicationController
     today = Date.current
     ttl = Time.current.end_of_day - Time.current
 
-    @weekly_trends = Rails.cache.fetch("sidebar/weekly_trends/#{today}", expires_in: ttl) do
-      from_today = Trend.where(date: today..).order(date: :asc).limit(5).to_a
-      recent     = Trend.where(date: (today - 2)..(today - 1)).order(date: :desc).limit(5).to_a
-      (from_today + recent).sort_by(&:date).reverse
-    end
-
-    unit_ids   = @weekly_trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
-    person_ids = @weekly_trends.flat_map { |t| t.people&.map { |p| p['person_id'] } }.compact.uniq
-    @weekly_trend_units   = Unit.where(id: unit_ids).index_by(&:id)
-    @weekly_trend_people  = Person.where(id: person_ids).index_by(&:id)
+    load_recent_trends(today, ttl)
 
     @recently_updated = Rails.cache.fetch('sidebar/recently_updated', expires_in: 10.minutes) do
       pages   = CustomPage.published.order(updated_at: :desc).limit(10).to_a
@@ -43,5 +34,18 @@ class CustomPagesController < ApplicationController
     @birthday_people = Rails.cache.fetch("sidebar/birthday_people/#{today}", expires_in: ttl) do
       Person.kept.birthday_on(today).or(Person.kept.birthday_on(today + 1)).order(:name_kana).to_a
     end
+  end
+
+  def load_recent_trends(today, ttl)
+    @weekly_trends = Rails.cache.fetch("sidebar/weekly_trends/#{today}", expires_in: ttl) do
+      from_today = Trend.where(date: today..).order(date: :asc).limit(5).to_a
+      recent     = Trend.where(date: (today - 2)..(today - 1)).order(date: :desc).limit(5).to_a
+      (from_today + recent).sort_by(&:date).reverse
+    end
+
+    unit_ids   = @weekly_trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
+    person_ids = @weekly_trends.flat_map { |t| t.people&.map { |p| p['person_id'] } }.compact.uniq
+    @weekly_trend_units  = Unit.where(id: unit_ids).index_by(&:id)
+    @weekly_trend_people = Person.where(id: person_ids).index_by(&:id)
   end
 end

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -17,8 +17,10 @@ class TrendsController < ApplicationController
       end_date = month ? start_date.end_of_month : start_date.end_of_year
 
       scope = Trend.order(date: :desc).where(date: start_date..end_date)
-    else
+    elsif params[:sort] == 'update'
       scope = Trend.order(id: :desc)
+    else
+      scope = Trend.order(date: :desc)
     end
 
     @pagy, @trends = pagy(scope, limit: 20)

--- a/app/views/custom_pages/_sidebar.html.erb
+++ b/app/views/custom_pages/_sidebar.html.erb
@@ -1,42 +1,35 @@
 <div class="space-y-4">
-  <%# Weekly Trends %>
+  <%# Recent Trends %>
   <div class="bg-white dark:bg-slate-800 shadow rounded-2xl overflow-hidden">
     <div class="bg-slate-50 dark:bg-slate-900/30 px-4 py-3 border-b border-slate-100 dark:border-slate-700">
-      <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Weekly Trends<br><span class="text-xs font-normal">前後一週間の動向</span></h2>
+      <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Recent Trends<br><span class="text-xs font-normal">最近の動向</span></h2>
     </div>
     <ul class="divide-y divide-slate-100 dark:divide-slate-700">
       <% if @weekly_trends.any? %>
         <% @weekly_trends.each do |trend| %>
           <li>
             <%= link_to trend_path(trend),
-                class: "flex items-start gap-2 px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors #{'font-bold' if trend.date == Date.current}" do %>
-              <span class="text-slate-600 dark:text-slate-300 tabular-nums text-xs w-10 shrink-0 pt-0.5 leading-tight text-center">
-                <span class="block text-slate-400 dark:text-slate-500"><%= trend.date.strftime('%Y') %></span>
-                <span class="block text-sm"><%= trend.date.strftime('%-m/%d') %></span>
-              </span>
-              <span class="text-slate-800 dark:text-slate-100 leading-snug min-w-0">
+                class: "block px-4 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors #{'font-bold' if trend.date == Date.current}" do %>
+              <div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 mb-1">
+                <span class="tabular-nums text-sm font-extrabold text-slate-700 dark:text-slate-300 shrink-0 w-10"><%= trend.date.strftime('%-m/%-d') %></span>
                 <% if trend.units.present? %>
-                  <span class="flex flex-wrap gap-1 mb-1">
-                    <% trend.units.each do |u| %>
-                      <% unit = @weekly_trend_units[u['unit_id']] %>
-                      <span class="inline-block px-1.5 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 border border-slate-200 dark:border-slate-600">
-                        <%= unit&.name || u['name'] %>
-                      </span>
-                    <% end %>
-                  </span>
+                  <% trend.units.each do |u| %>
+                    <% unit = @weekly_trend_units[u['unit_id']] %>
+                    <span class="inline-block px-1.5 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 border border-slate-200 dark:border-slate-600">
+                      <%= unit&.name || u['name'] %>
+                    </span>
+                  <% end %>
                 <% end %>
-                <%= format_wiki_title(trend.title.sub(/[（(][^）)]*[）)]\z/u, '').rstrip, link: false) %>
                 <% if trend.people.present? %>
-                  <span class="flex flex-wrap gap-1 mt-1">
-                    <% trend.people.each do |p| %>
-                      <% person = @weekly_trend_people[p['person_id']] %>
-                      <span class="inline-block px-1.5 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600">
-                        <%= person&.name || p['name'] %>
-                      </span>
-                    <% end %>
-                  </span>
+                  <% trend.people.each do |p| %>
+                    <% person = @weekly_trend_people[p['person_id']] %>
+                    <span class="inline-block px-1.5 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600">
+                      <%= person&.name || p['name'] %>
+                    </span>
+                  <% end %>
                 <% end %>
-              </span>
+              </div>
+              <span class="text-indigo-600 dark:text-indigo-400 leading-snug"><%= format_wiki_title(trend.title.sub(/[（(][^）)]*[）)]\z/u, '').rstrip, link: false) %></span>
             <% end %>
           </li>
         <% end %>
@@ -51,10 +44,10 @@
     </div>
   </div>
 
-  <%# Recently Updated %>
+  <%# Recent Updates %>
   <div class="bg-white dark:bg-slate-800 shadow rounded-2xl overflow-hidden">
     <div class="bg-slate-50 dark:bg-slate-900/30 px-4 py-3 border-b border-slate-100 dark:border-slate-700">
-      <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Recently Updated<br><span class="text-xs font-normal">最近の更新</span></h2>
+      <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Recent Updates<br><span class="text-xs font-normal">最近の更新</span></h2>
     </div>
     <ul class="divide-y divide-slate-100 dark:divide-slate-700">
       <% if @recently_updated.any? %>
@@ -76,7 +69,7 @@
                 </svg>
               <% end %>
               <span class="flex-1 text-sm text-slate-700 dark:text-slate-200 truncate"><%= item.is_a?(CustomPage) ? item.title : item.name %></span>
-              <span class="shrink-0 text-xs text-slate-400 dark:text-slate-500"><%= item.updated_at.strftime('%-m/%-d') %></span>
+              <span class="shrink-0 text-xs text-slate-400 dark:text-slate-500"><%= item.updated_at.strftime('%-m/%-d') %>更新</span>
             <% end %>
           </li>
         <% end %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -16,11 +16,13 @@
           inactive_classes = "bg-white text-slate-600 border-slate-300 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600 dark:hover:bg-slate-700"
           
           current_year = params[:year].presence&.to_i
-          
+          sort_param = params[:sort]
+
           years_by_decade = @years.group_by { |y| (y / 10) * 10 }
         %>
 
-        <%= link_to "UPDATE", trends_path, class: "#{base_classes} #{current_year.nil? ? active_classes : inactive_classes}" %>
+        <%= link_to "UPDATE", trends_path(sort: 'update'), class: "#{base_classes} #{current_year.nil? && sort_param == 'update' ? active_classes : inactive_classes}" %>
+        <%= link_to "NEWEST", trends_path, class: "#{base_classes} #{current_year.nil? && sort_param != 'update' ? active_classes : inactive_classes}" %>
 
         <% years_by_decade.each do |decade, years| %>
           <% is_active_decade = years.include?(current_year) %>
@@ -95,7 +97,7 @@
               <%= link_to trend_path(trend), class: "inline" do %>
                 <span class="font-bold text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 transition-colors"><%= format_wiki_title(trend.title, link: false) %></span>
               <% end %>
-              <% if current_year.nil? %>
+              <% if current_year.nil? && sort_param == 'update' %>
                 <div class="text-xs text-slate-500 dark:text-slate-400 mt-0.5">更新日: <%= trend.updated_at.strftime('%Y/%m/%d') %></div>
               <% end %>
             </div>


### PR DESCRIPTION
## Summary
- `/trends` 一覧に NEWEST ソート（date降順）を追加し、デフォルト順に変更
- UPDATE ソートは `?sort=update` で引き続き利用可能
- サイドバーの Weekly Trends を **Recent Trends** にリネーム（日本語「最近の動向」を併記）
- サイドバーのトレンド取得ロジックを「当日以降5件 + 前日・前々日の最大5件」に変更
- Recently Updated を **Recent Updates** にリネームし、日付表示を「M/D更新」形式に変更
- サイドバーのトレンド表示を2段レイアウト（日付・バッジ行 / タイトル行）に変更

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] `/trends` を開いて NEWEST ボタンがデフォルトでアクティブになっていること
- [ ] UPDATE ボタンをクリックして更新日順に切り替わること
- [ ] サイドバーに「Recent Trends」が表示され、当日前後のトレンドが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)