### PR TITLE
索引詳細ページの戻るリンクにタググループ名を表示

### DIFF
--- a/app/views/indices/show.html.erb
+++ b/app/views/indices/show.html.erb
@@ -1,12 +1,13 @@
 <div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <div class="mb-6">
-      <%= link_to indices_group_path(params[:index_group] || @index.index_group || 1),
+      <% index_group = @index.index_group %>
+      <%= link_to index_group ? indices_group_path(index_group.id) : indices_groups_path,
             class: "inline-flex items-center gap-1 text-sm font-bold text-slate-400 dark:text-slate-500 hover:text-indigo-500 dark:hover:text-indigo-400 transition-colors" do %>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
         </svg>
-        索引一覧に戻る
+        <%= index_group ? "「#{index_group.name}」索引一覧に戻る" : "索引グループ一覧に戻る" %>
       <% end %>
     </div>
 


### PR DESCRIPTION
## 概要

`/index/show/:id` の「索引一覧に戻る」導線テキストを改善しました。

## 変更内容

- タググループに属している場合: `「{グループ名}」索引一覧に戻る` を表示し、そのグループ一覧ページへリンク
- タগগループに属していない場合: `索引グループ一覧に戻る` を表示し、`/index`（全グループ一覧）へリンク
- 旧実装にあった `params[:index_group] || 1` という曖昧なフォールバックも削除し、`@index.index_group` を直接参照するよう整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)