### PR TITLE
titleタグを「ページタイトル - サイト名」形式に統一 (#629)

### DIFF
--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @year_agnostic ? @date.strftime('%-m/%-d') : @date.strftime('%Y/%-m/%-d') %>
 <div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 

--- a/app/views/indices/groups.html.erb
+++ b/app/views/indices/groups.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Index Groups" %>
 <div class="flex justify-center items-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8">

--- a/app/views/indices/index.html.erb
+++ b/app/views/indices/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @group_name %>
 <div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <div class="mb-6">

--- a/app/views/indices/show.html.erb
+++ b/app/views/indices/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @index.name %>
 <div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <div class="mb-6">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @artist ? "#{@artist.name} - アイテム一覧" : "アイテム一覧" %>
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-amber-500 px-5 py-6 md:px-8 text-center">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, [@item.title, @item.artists.map { |a| a['alias'].presence || a['name'] }.join(' / ')].reject(&:blank?).join(' / ') %>
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <!-- ヘッダー（タイトル） -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Vkdby" %></title>
+    <title><%= content_for?(:title) ? "#{yield(:title)} - #{Rails.application.config.site_name}" : Rails.application.config.site_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Vkdby">

--- a/app/views/monthly/show.html.erb
+++ b/app/views/monthly/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @date.strftime('%Y/%m') %>
 <div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "個人一覧" %>
 <div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8 text-center flex flex-col items-center">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @resource.name_kana.present? ? "#{@resource.name}（#{@resource.name_kana}）" : @resource.name %>
 <div class="flex justify-center items-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <%= render ProfileHeaderComponent.new(resource: @resource) %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Search" %>
 <div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8 text-center flex flex-col items-center">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Sign in" %>
 <div class="flex items-center justify-center min-h-screen bg-gray-100 px-4">
   <div class="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-lg">
     <h2 class="text-3xl font-bold text-center text-gray-900">Sign in</h2>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "年表 - メジャーバンド | Vkdby" %>
+<% content_for :title, "年表" %>
 <% content_for :head do %>
 <style>
   :root { --timeline-name-col-w: 176px; }

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "動向一覧" %>
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-amber-500 px-5 py-6 md:px-8 text-center">

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @trend.title %>
 <div class="flex justify-center items-start min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30 relative">

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "バンド索引" %>
 <div class="flex justify-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8 text-center flex flex-col items-center">

--- a/app/views/yearly/index.html.erb
+++ b/app/views/yearly/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "年別" %>
 <div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 

--- a/app/views/yearly/show.html.erb
+++ b/app/views/yearly/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, @year.to_s %>
 <div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,9 @@ module Vkdby
     # Set default locale to Japanese
     config.i18n.default_locale = :ja
 
+    # Site name used in page titles
+    config.site_name = ENV.fetch('SITE_NAME', 'vkdb.jp')
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## Summary
- `config/application.rb` にサイト名設定を追加（`SITE_NAME` 環境変数で上書き可能、デフォルト `vkdb.jp`）
- レイアウトの title タグを `ページタイトル - サイト名` 形式に変更
- 各ページに `content_for :title` を追加（Units→バンド索引、People→個人一覧、Items→アイテム一覧、Trends→動向一覧）
- プロフィールページのタイトルに `name_kana` をカッコ書きで付加
- 日付系ページのタイトルを `YYYY/MM/DD` 形式に統一
- timeline の既存タイトルからサイト名部分を除去

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] 各ページの `<title>` タグが `ページタイトル - vkdb.jp` になっていること
- [ ] トップページ（`/`）はタイトルが `vkdb.jp` のみになっていること（未対応・別途対応予定）
- [ ] プロフィールページで `name_kana` ありの場合に括弧付きカナが表示されること

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)