### PR TITLE
feat(issue-316): people_controller#units を snapshot_people 経由に切り替え

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -53,8 +53,8 @@ class PeopleController < ApplicationController
 
   def units
     person = Person.kept.find_by!(key: params[:key])
-    unit_keys = person.unit_people
-                      .joins(:unit)
+    unit_keys = person.snapshot_people
+                      .joins(unit_snapshot: :unit)
                       .merge(Unit.kept)
                       .distinct
                       .pluck('units.key')


### PR DESCRIPTION
## Summary

- `people_controller#units` の `unit_people` 参照を `snapshot_people` に切り替え

```ruby
# before
person.unit_people.joins(:unit).merge(Unit.kept).distinct.pluck('units.key')

# after
person.snapshot_people.joins(unit_snapshot: :unit).merge(Unit.kept).distinct.pluck('units.key')
```

タイムライン画面の「人物名でバンドをまとめて追加する」機能（`GET /people/:key/units`）で使用されるエンドポイント。

## Test plan

- [ ] タイムライン画面（`/timeline`）で人物名を検索し、サジェストから選択してバンドが追加されること
- [ ] RuboCop・テストがすべて通過すること（CI 確認）

Closes の一部: #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)