### PR TITLE
feat(issue-316): person_importer / Person モデルの unit_people 参照を削除

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -73,7 +73,7 @@ class Person < ApplicationRecord
   before_save :normalize_birthday_year
 
   validate :key_immutable, on: :update
-  after_create :auto_link_unit_people
+  after_create :auto_link_snapshot_people
   after_commit :expire_sidebar_cache
 
   def name
@@ -162,10 +162,10 @@ class Person < ApplicationRecord
     errors.add(:key, 'cannot be changed once set')
   end
 
-  def auto_link_unit_people
+  def auto_link_snapshot_people
     return if key.blank?
 
-    UnitPerson.where(person_key: key, person_id: nil).update_all(person_id: id)
+    SnapshotPerson.where(person_key: key, person_id: nil).update_all(person_id: id)
   end
 
   def expire_sidebar_cache

--- a/app/services/person_importer.rb
+++ b/app/services/person_importer.rb
@@ -98,8 +98,8 @@ class PersonImporter < BaseWikipageImporter
     # Save Person
     person.save!
 
-    # 2.5 Link existing UnitPerson records
-    link_existing_unit_people(person)
+    # 2.5 Link existing SnapshotPerson records
+    link_existing_snapshot_people(person)
 
     # 3. Associate TagIndex (Categories)
     update_tag_indices(person, categories_data[:raw_categories])
@@ -115,10 +115,9 @@ class PersonImporter < BaseWikipageImporter
     parse_sections(person)
   end
 
-  def link_existing_unit_people(person)
+  def link_existing_snapshot_people(person)
     return if person.old_key.blank?
 
-    UnitPerson.where(old_person_key: person.old_key).update_all(person_id: person.id, person_key: person.key)
     SnapshotPerson.where(old_person_key: person.old_key).update_all(person_id: person.id, person_key: person.key)
   end
 


### PR DESCRIPTION
## Summary

- `person_importer.rb`: `link_existing_unit_people` を `link_existing_snapshot_people` に改名し、`UnitPerson` への書き込みを削除
- `person.rb`: `auto_link_unit_people` コールバックを `auto_link_snapshot_people` に置き換え

### `auto_link_snapshot_people` について

`auto_link_unit_people` の直接の代替。ユニット（スナップショット）がインポートされた後に Person が登録された場合、`person_key` が一致する `SnapshotPerson` に `person_id` を自動リンクする。

## Test plan

- [ ] `import:people` 実行後、SnapshotPerson に `person_id` が正しくリンクされること
- [ ] RuboCop・テストがすべて通過すること（CI 確認）

Closes の一部: #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)