### PR TITLE
feat(issue-316): 非推奨の import:units タスクを削除

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -78,48 +78,6 @@ def format_skip_log(wikipage)
 end
 
 namespace :import do # rubocop:disable Metrics/BlockLength
-  # DEPRECATED: Use import:units_v2 instead.
-  desc '[DEPRECATED] Import units from Wikipages. Use import:units_v2 instead.'
-  task units: :environment do
-    warn '[DEPRECATED] import:units is deprecated. Use import:units_v2 instead.'
-    puts 'Starting unit import from Wikipages...'
-    count = 0
-    skipped = 0
-
-    query = Wikipage.all
-    if ENV['ID']
-      query = query.where(id: ENV['ID'])
-      puts "Targeting single ID: #{ENV['ID']}"
-    elsif ENV['START']
-      query = query.where('id >= ?', ENV['START'])
-      puts "Starting from ID: #{ENV['START']}"
-    end
-
-    limit = ENV['LIMIT']&.to_i
-    puts "Limit: #{limit}" if limit
-
-    query.find_each.with_index do |wp, _index|
-      break if limit && count >= limit
-
-      if WikipageImporter.ignored?(wp)
-        skipped += 1
-        # Silent skip for ignored pages
-        next
-      elsif WikipageImporter.valid_unit?(wp)
-        WikipageImporter.import(wp)
-        count += 1
-      else
-        skipped += 1
-        # 個人候補の場合はログ出力しない
-        puts format_skip_log(wp) if wp.title.present? && !PersonImporter.valid_person?(wp)
-      end
-    end
-
-    puts 'Import complete!'
-    puts "  Imported: #{count} units"
-    puts "  Skipped:  #{skipped} pages"
-  end
-
   desc 'Import people from Wikipages'
   task people: :environment do # rubocop:disable Metrics/BlockLength
     mode = ENV['MODE']


### PR DESCRIPTION
## Summary

- `import:units` タスク（`WikipageImporter` を使用する非推奨タスク）を削除
- `import:units_v2`（`WikipageImporterV2` を使用）に完全移行済みのため不要

## 残作業（最終ステップで対応）

以下は `unit_people` テーブルに FK 制約があるため、テーブル drop 時に合わせて削除する：

- `import:people MODE=FIX_UNIT_AS_PERSON` 内の `unit.unit_people.destroy_all`
- `import:reset` 内の `UnitPerson.delete_all`

## Test plan

- [ ] `bundle exec rails import:units` が `undefined` エラーになること（タスク削除確認）
- [ ] RuboCop・テストがすべて通過すること（CI 確認）

Closes の一部: #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)