### PR TITLE
feat: GA4タグを埋め込み、アクセス解析を有効化 (issue #664)

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,17 @@
+<% ga_id = ENV['GOOGLE_ANALYTICS_ID'] %>
+<% if ga_id.present? %>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ga_id %>"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '<%= ga_id %>', { send_page_view: false });
+
+    document.addEventListener('turbo:load', function() {
+      gtag('event', 'page_view', {
+        page_location: window.location.href,
+        page_title: document.title
+      });
+    });
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
         display: block;
       }
     </style>
+    <%= render 'layouts/google_analytics' %>
   </head>
 
   <body class="bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">


### PR DESCRIPTION
## Summary

- 環境変数 `GOOGLE_ANALYTICS_ID` が設定されている場合のみ GA4 の gtag.js を出力する `_google_analytics` パーシャルを追加
- Turbo Drive のページ遷移（SPA的な画面遷移）にも対応し、`turbo:load` イベントで `page_view` を送信
- ローカル開発環境では `GOOGLE_ANALYTICS_ID` を未設定にすることで、開発中のトラフィックが GA4 に混入しない

## 設定方法

本番環境（Render）の環境変数に以下を追加してください：

```
GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX
```

## Test plan

- [ ] `GOOGLE_ANALYTICS_ID` を設定しない状態で、ページソースに gtag.js が含まれないことを確認
- [ ] 本番環境に `GOOGLE_ANALYTICS_ID` を設定後、GA4 リアルタイムレポートでアクセスが計測されることを確認
- [ ] Turbo Drive でのページ遷移時に page_view イベントが送信されることを確認（GA4 リアルタイム → イベント）

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)