### PR TITLE
feat: Google AdSense 対応 (issue #635)

### DIFF
--- a/app/views/layouts/_google_adsense.html.erb
+++ b/app/views/layouts/_google_adsense.html.erb
@@ -1,0 +1,5 @@
+<% adsense_client = ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>
+<% if adsense_client.present? %>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=<%= adsense_client %>"
+       crossorigin="anonymous"></script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
       }
     </style>
     <%= render 'layouts/google_analytics' %>
+    <%= render 'layouts/google_adsense' %>
   </head>
 
   <body class="bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">


### PR DESCRIPTION
## Summary

- `app/views/layouts/_google_adsense.html.erb` を新規作成し、`GOOGLE_ADSENSE_CLIENT_ID` 環境変数が設定されている場合のみ AdSense スクリプトタグを出力する
- `application.html.erb` の `<head>` 内（Google Analytics の直後）に partial を追加

## 本番設定

Render 等の環境変数に以下を設定することで AdSense が有効になります：

```
GOOGLE_ADSENSE_CLIENT_ID=ca-pub-5025267338594728
```

## Test plan

- [x] `GOOGLE_ADSENSE_CLIENT_ID` 未設定時にスクリプトタグが出力されないことを確認
- [x] `GOOGLE_ADSENSE_CLIENT_ID` 設定時に `<head>` 内にスクリプトタグが出力されることを確認

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)