### PR TITLE
perf: Cytoscape.js をグラフ表示時のみ動的読み込みに変更 (issue #672)

### DIFF
--- a/app/javascript/controllers/unit_graph_controller.js
+++ b/app/javascript/controllers/unit_graph_controller.js
@@ -39,6 +39,16 @@ export default class extends Controller {
     this.placeholderTarget.innerHTML =
       '<span class="text-sm text-slate-400 dark:text-slate-500">読み込み中...</span>'
 
+    if (!window.cytoscape) {
+      try {
+        await this._loadCytoscape()
+      } catch (e) {
+        console.error("unit-graph: cytoscape load failed", e)
+        this.placeholderTarget.innerHTML =
+          '<span class="text-sm text-slate-400 dark:text-slate-500">グラフの読み込みに失敗しました</span>'
+        return
+      }
+    }
     const cytoscape = window.cytoscape
     if (!cytoscape) {
       console.error("unit-graph: cytoscape not loaded")
@@ -292,6 +302,16 @@ export default class extends Controller {
 
     existingNodes.unlock()
     node.data("expanding", false)
+  }
+
+  _loadCytoscape() {
+    return new Promise((resolve, reject) => {
+      const script = document.createElement("script")
+      script.src = "https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"
+      script.onload = resolve
+      script.onerror = reject
+      document.head.appendChild(script)
+    })
   }
 
   disconnect() {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,6 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-    <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
     <%= javascript_importmap_tags %>
     <style>
       .admin-dropdown:hover .admin-dropdown-menu {


### PR DESCRIPTION
## Summary

- `application.html.erb` から `<script src="...cytoscape.min.js">` を削除し、全ページでのレンダリングブロックを解消
- `unit_graph_controller.js` の `load()` 内で `_loadCytoscape()` を呼び出し、グラフ表示時にのみ動的にスクリプトをロード
- ロード失敗時のエラーハンドリングを追加（プレースホルダーにエラーメッセージを表示）

## Test plan

- [ ] ユニット詳細ページ（例: `/shazna`）を通常表示し、ページロード時に cytoscape が読み込まれないことを DevTools の Network タブで確認
- [ ] 「関連ユニット」タブを開いたときにグラフが正常に描画されることを確認
- [ ] `#relationship-graph` ハッシュ付きURLで直接アクセスしてもグラフが正常表示されることを確認
- [ ] グラフを使わないページ（トップページ等）で cytoscape のネットワークリクエストが発生しないことを確認

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)