### PR TITLE
perf: CSP upgrade-insecure-requests で HTTP 画像を自動 HTTPS 化 (issue #674)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 
     <%= yield :head %>
 


### PR DESCRIPTION
## Summary

- `application.html.erb` の `<head>` に `<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">` を追加
- DB に存在する 9,059 件の `http://` 画像 URL をブラウザレベルで自動的に HTTPS にアップグレード
- DB 変更なし。全ページ・全リソースに一括適用

## Test plan

- [ ] ページを開き DevTools の Console に Mixed Content 警告が出ないことを確認
- [ ] `http://` 画像 URL を持つアイテム詳細ページで画像が正常表示されることを確認
- [ ] DevTools の Network タブで画像リクエストが `https://` で送信されていることを確認

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)