### PR TITLE
perf: Amazon画像URLにsrcsetでレスポンシブ画像を適用 (issue #676)

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -2,9 +2,19 @@
   <!-- 画像（左側） -->
   <% if @item.image_url.present? %>
     <div class="relative shrink-0 w-40 h-40 bg-zinc-50 dark:bg-zinc-950">
+      <% img_src, img_srcset =
+          if amazon_image?(@item.image_url)
+            [amazon_image_url(@item.image_url, 160),
+             "#{amazon_image_url(@item.image_url, 160)} 160w, #{amazon_image_url(@item.image_url, 320)} 320w"]
+          else
+            [@item.image_url, nil]
+          end
+      %>
       <% if @item.link_url.present? %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer" do %>
-          <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-40 h-40 object-cover hover:opacity-90 transition-opacity">
+          <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="160px"
+               width="160" height="160"
+               alt="<%= @item.title %>" class="w-40 h-40 object-cover hover:opacity-90 transition-opacity">
         <% end %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer",
             style: "position:absolute; bottom:8px; left:50%; transform:translateX(-50%);",
@@ -15,7 +25,9 @@
           Amazonで購入
         <% end %>
       <% else %>
-        <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-40 h-40 object-cover">
+        <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="160px"
+             width="160" height="160"
+             alt="<%= @item.title %>" class="w-40 h-40 object-cover">
       <% end %>
     </div>
   <% else %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
   end
 
   def amazon_image_url(url, size)
-    url.sub(/(\._[A-Z][A-Z0-9_]*_)?(\.(jpe?g|png|gif|webp))$/i) { "._SL#{size}_#{$2}" }
+    url.sub(/(\._[A-Z][A-Z0-9_]*_)?(\.(jpe?g|png|gif|webp))$/i) { "._SL#{size}_#{::Regexp.last_match(2)}" }
   end
 
   def logged_in?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,16 +41,6 @@ module ApplicationHelper
     html << '</nav>'
   end
 
-  AMAZON_IMAGE_CDN = %r{https?://(?:[a-z0-9-]+\.)?(?:images-amazon\.com|m\.media-amazon\.com)/}i
-
-  def amazon_image?(url)
-    url.present? && AMAZON_IMAGE_CDN.match?(url)
-  end
-
-  def amazon_image_url(url, size)
-    url.sub(/(\._[A-Z][A-Z0-9_]*_)?(\.(jpe?g|png|gif|webp))$/i) { "._SL#{size}_#{::Regexp.last_match(2)}" }
-  end
-
   def logged_in?
     false
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,16 @@ module ApplicationHelper
     html << '</nav>'
   end
 
+  AMAZON_IMAGE_CDN = %r{https?://(?:[a-z0-9-]+\.)?(?:images-amazon\.com|m\.media-amazon\.com)/}i
+
+  def amazon_image?(url)
+    url.present? && AMAZON_IMAGE_CDN.match?(url)
+  end
+
+  def amazon_image_url(url, size)
+    url.sub(/(\._[A-Z][A-Z0-9_]*_)?(\.(jpe?g|png|gif|webp))$/i) { "._SL#{size}_#{$2}" }
+  end
+
   def logged_in?
     false
   end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -3,6 +3,16 @@
 require 'cgi'
 
 module ItemsHelper
+  AMAZON_IMAGE_CDN = %r{https?://(?:[a-z0-9-]+\.)?(?:images-amazon\.com|m\.media-amazon\.com)/}i
+
+  def amazon_image?(url)
+    url.present? && AMAZON_IMAGE_CDN.match?(url)
+  end
+
+  def amazon_image_url(url, size)
+    url.sub(/(\._[A-Z][A-Z0-9_]*_)?(\.(jpe?g|png|gif|webp))$/i) { "._SL#{size}_#{::Regexp.last_match(2)}" }
+  end
+
   # アーティストのプロフィールページへのパスを生成
   # 優先順位: key > old_key > name(EUCエンコード)
   def artist_profile_path(artist_data)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,12 +23,30 @@
         <% if @item.image_url.present? %>
           <div class="shrink-0">
             <% amazon_url = safe_url(@item.link_url) %>
+            <% img_src, img_srcset, img_sizes =
+                if amazon_image?(@item.image_url)
+                  src = amazon_image_url(@item.image_url, 256)
+                  srcset = [
+                    "#{amazon_image_url(@item.image_url, 208)} 208w",
+                    "#{amazon_image_url(@item.image_url, 256)} 256w",
+                    "#{amazon_image_url(@item.image_url, 416)} 416w",
+                    "#{amazon_image_url(@item.image_url, 512)} 512w",
+                  ].join(", ")
+                  [src, srcset, "(min-width: 640px) 208px, 256px"]
+                else
+                  [@item.image_url, nil, nil]
+                end
+            %>
             <% if amazon_url %>
               <%= link_to amazon_url, target: "_blank", rel: "noopener noreferrer" do %>
-                <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-cover shadow-md hover:opacity-90 transition-opacity">
+                <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="<%= img_sizes %>"
+                     width="256" height="256"
+                     alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-cover shadow-md hover:opacity-90 transition-opacity">
               <% end %>
             <% else %>
-              <img src="<%= @item.image_url %>" alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-cover shadow-md">
+              <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="<%= img_sizes %>"
+                   width="256" height="256"
+                   alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-cover shadow-md">
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
## Summary

- `ItemsHelper` に `amazon_image?` / `amazon_image_url` ヘルパーを追加（`ApplicationHelper` から移動）
- `items/show.html.erb`: 208w / 256w / 416w / 512w の srcset、`sizes="(min-width: 640px) 208px, 256px"`
- `ItemCardComponent`: 160w / 320w の srcset、`sizes="160px"`（固定サイズのため）
- Amazon CDN URL のみ変換、それ以外は従来通り
- `width` / `height` 属性も追加し CLS（レイアウトシフト）を防止

## Test plan

- [ ] `/items/42594` 等のアイテム詳細ページで `srcset` が出力されることを確認
- [ ] `/shazna` 等のユニット詳細ページの Items 一覧で `srcset` が出力されることを確認
- [ ] DevTools Network タブで画像がレンダリングサイズに合ったものを取得していることを確認
- [ ] 非Amazon URLのアイテムで `srcset` が出力されないことを確認

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)