### PR TITLE
perf: ロゴ画像に width/height を明示して CLS を改善 (issue #681)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
           <div class="flex">
             <div class="flex-shrink-0 flex items-center">
               <%= link_to root_path, class: "flex items-center" do %>
-                <%= image_tag "vkdb_logo.png", alt: "VKDB.jp", class: "max-h-10 w-auto" %>
+                <%= image_tag "vkdb_logo.png", alt: "VKDB.jp", class: "max-h-10 w-auto", width: 400, height: 147 %>
               <% end %>
             </div>
             <!-- Search Form (Desktop) - Next to logo -->


### PR DESCRIPTION
## Summary

- `vkdb_logo.png` の `image_tag` に `width: 400, height: 147`（元画像の実寸）を追加
- CSS の `max-h-10 w-auto` はそのまま維持し、表示サイズに影響なし
- ブラウザが画像読み込み前にアスペクト比を計算できるようになり CLS を改善

## Test plan

- [ ] ナビゲーションバーのロゴが正常に表示されることを確認
- [ ] レンダリングされた HTML に `width="400" height="147"` が含まれることを確認

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)