### PR TITLE
perf: 本番アセットの Cache-Control に immutable を追加 (issue #683)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = true
 
   # Cache assets for far-future expiry since they are all digest stamped.
-  config.public_file_server.headers = { 'cache-control' => "public, max-age=#{1.year.to_i}" }
+  config.public_file_server.headers = { 'cache-control' => "public, max-age=#{1.year.to_i}, immutable" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## Summary

- `production.rb` の `cache-control` に `immutable` を追加
- フィンガープリント付きアセットはキャッシュ期間中にブラウザが再検証リクエストを送らなくなる
- `public, max-age=31536000` はそのまま維持

## Test plan

- [ ] 本番デプロイ後、アセットのレスポンスヘッダーに `immutable` が含まれることを確認
  ```
  Cache-Control: public, max-age=31536000, immutable
  ```

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)