### PR TITLE
perf: SortableJS・marked.js を動的インポートに変更 (issue #685)

### DIFF
--- a/app/javascript/controllers/markdown_preview_controller.js
+++ b/app/javascript/controllers/markdown_preview_controller.js
@@ -1,19 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
-import { marked } from "marked"
 
 export default class extends Controller {
   static targets = ["textarea", "previewContent", "imageInput", "uploadStatus"]
   static values = { uploadUrl: String }
 
-  connect() {
-    marked.use({ breaks: true, gfm: true })
+  async connect() {
+    const { marked } = await import("marked")
+    this._marked = marked
+    this._marked.use({ breaks: true, gfm: true })
     this.updatePreview()
   }
 
   updatePreview() {
     const text = this.textareaTarget.value
-    this.previewContentTarget.innerHTML = text
-      ? marked.parse(text)
+    this.previewContentTarget.innerHTML = text && this._marked
+      ? this._marked.parse(text)
       : '<p class="text-gray-400 dark:text-gray-500 italic">本文を入力するとプレビューが表示されます</p>'
   }
 

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -1,10 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
-import Sortable from "sortablejs"
 
 export default class extends Controller {
     static values = { url: String }
 
-    connect() {
+    async connect() {
+        const { default: Sortable } = await import("sortablejs")
         this.sortable = Sortable.create(this.element, {
             handle: ".drag-handle",
             onEnd: this.onEnd.bind(this)


### PR DESCRIPTION
## Summary

- `sortable_controller.js`: トップレベル `import Sortable from "sortablejs"` を `connect()` 内の `await import("sortablejs")` に変更
- `markdown_preview_controller.js`: トップレベル `import { marked } from "marked"` を `connect()` 内の `await import("marked")` に変更
- 両ライブラリとも admin ページ限定のため、公開ページでは一切読み込まれなくなる
- 推定削減: 約 97KB（SortableJS 56KB + marked.js 41KB）

## Test plan

- [ ] admin の並べ替えUI（sections・snapshots・index_groups）が正常に動作することを確認
- [ ] admin の Markdown プレビュー（sections/_form・custom_pages/_form）が正常に動作することを確認
- [ ] 公開ページ（トップページ等）の Network タブで sortablejs・marked が読み込まれないことを確認

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)