### PR TITLE
feat: 本番環境の画像ストレージを Cloudflare R2 に移行 (issue #689)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,8 +48,8 @@ gem 'tailwindcss-rails'
 gem 'thruster', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem 'image_processing', '~> 2.0'
 gem 'aws-sdk-s3', require: false
+gem 'image_processing', '~> 2.0'
 gem 'mini_magick'
 gem 'view_component'
 

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'thruster', require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem 'image_processing', '~> 2.0'
+gem 'aws-sdk-s3', require: false
 gem 'mini_magick'
 gem 'view_component'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,25 @@ GEM
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1258.0)
+    aws-sdk-core (3.251.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.129.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.225.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     backport (1.2.0)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -149,6 +168,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    jmespath (1.6.2)
     json (2.19.8)
     kamal (2.11.0)
       activesupport (>= 7.0)
@@ -482,6 +502,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotaterb
+  aws-sdk-s3
   bcrypt (~> 3.1.22)
   bootsnap
   brakeman

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,8 +23,8 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files on Cloudflare R2 (S3-compatible).
+  config.active_storage.service = :cloudflare_r2
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,6 +14,15 @@ local:
 #   region: us-east-1
 #   bucket: your_own_bucket-<%= Rails.env %>
 
+cloudflare_r2:
+  service: S3
+  access_key_id: <%= ENV["CLOUDFLARE_R2_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["CLOUDFLARE_R2_SECRET_ACCESS_KEY"] %>
+  region: auto
+  bucket: <%= ENV["CLOUDFLARE_R2_BUCKET"] %>
+  endpoint: https://<%= ENV["CLOUDFLARE_R2_ACCOUNT_ID"] %>.r2.cloudflarestorage.com
+  force_path_style: true
+
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS


### PR DESCRIPTION
## Summary

- `aws-sdk-s3` gem を追加（R2 は S3 互換 API）
- `config/storage.yml` に `cloudflare_r2` サービス設定を追加
- 本番環境の Active Storage サービスを `:local` → `:cloudflare_r2` に変更

## 背景

Render のエフェメラルファイルシステムにより、デプロイのたびにローカルディスクがリセットされ、アップロード済み画像が消える問題があった。Cloudflare R2 は S3 互換で、かつ Cloudflare CDN 経由のエグレスが無料のため採用。

## 必要な環境変数（Render に設定済み）

- `CLOUDFLARE_R2_ACCESS_KEY_ID`
- `CLOUDFLARE_R2_SECRET_ACCESS_KEY`
- `CLOUDFLARE_R2_ACCOUNT_ID`
- `CLOUDFLARE_R2_BUCKET`

## Test plan

- [ ] デプロイ後に画像をアップロードして表示されることを確認
- [ ] 再デプロイ後も画像が保持されることを確認

Closes #689