### PR TITLE
fix: Cloudflare R2 チェックサムエラーを修正 (issue #689)

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -22,6 +22,8 @@ cloudflare_r2:
   bucket: <%= ENV["CLOUDFLARE_R2_BUCKET"] %>
   endpoint: https://<%= ENV["CLOUDFLARE_R2_ACCOUNT_ID"] %>.r2.cloudflarestorage.com
   force_path_style: true
+  request_checksum_calculation: "when_required"
+  response_checksum_validation: "when_required"
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## Summary

`aws-sdk-s3` v1.170+ がデフォルトで送るチェックサムヘッダーを Cloudflare R2 が拒否するエラーを修正。
`request_checksum_calculation` / `response_checksum_validation` を `when_required` に設定。

## エラー内容

```
Aws::S3::Errors::InvalidRequest (You can only specify one non-default checksum at a time.)
```

Closes #689