### PR TITLE
ログイン時にAdSense広告を非表示にする

### DIFF
--- a/app/views/layouts/_google_adsense.html.erb
+++ b/app/views/layouts/_google_adsense.html.erb
@@ -1,5 +1,5 @@
 <% adsense_client = ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>
-<% if adsense_client.present? %>
+<% if adsense_client.present? && !(defined?(logged_in?) && logged_in?) %>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=<%= adsense_client %>"
        crossorigin="anonymous"></script>
 <% end %>


### PR DESCRIPTION
## Summary
- ログイン時に `_google_adsense.html.erb` の AdSense JS 読み込みを抑止
- 既存の horizontal / square パーシャルには `logged_in?` チェックがあったが、JS 本体の読み込みにはなかったため自動広告が表示されていた

closes #716

## Test plan
- [ ] ログインしていない状態で広告が表示されることを確認
- [ ] ログイン状態で広告が表示されないことを確認
- [ ] ページのソースに AdSense の `<script>` タグが含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)