### PR TITLE
プロフィールページで同じヨミガナのページを「Did You Mean?」としてサジェストする (#720)

### DIFF
--- a/app/components/same_kana_suggestion_component.html.erb
+++ b/app/components/same_kana_suggestion_component.html.erb
@@ -1,0 +1,25 @@
+<section class="mt-8">
+  <div class="flex items-center justify-between mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
+    <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+      Did You Mean?
+      <span class="ml-1 font-normal normal-case tracking-normal text-slate-400 dark:text-slate-500">— 同じヨミガナ「<%= @resource.name_kana %>」</span>
+    </h2>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+    <% if @resource.is_a?(Unit) %>
+      <%= render UnitCardComponent.with_collection(@same_kana_resources) %>
+    <% else %>
+      <%= render PersonCardComponent.with_collection(@same_kana_resources, show_history: true) %>
+    <% end %>
+  </div>
+  <% if remaining_count > 0 %>
+    <div class="mt-3 text-center">
+      <%= link_to search_path, class: "inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 font-medium transition-colors" do %>
+        もっと見る
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+        </svg>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/components/same_kana_suggestion_component.rb
+++ b/app/components/same_kana_suggestion_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class SameKanaSuggestionComponent < ViewComponent::Base
+  def initialize(resource:, same_kana_resources:, same_kana_total:)
+    super()
+    @resource = resource
+    @same_kana_resources = same_kana_resources
+    @same_kana_total = same_kana_total
+  end
+
+  def render?
+    @same_kana_resources.present?
+  end
+
+  private
+
+  def search_path
+    if @resource.is_a?(Unit)
+      helpers.units_path(q: @resource.name_kana, anchor: 'results')
+    else
+      helpers.people_path(q: @resource.name_kana, anchor: 'results')
+    end
+  end
+
+  def remaining_count
+    @same_kana_total - @same_kana_resources.size
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,6 +14,7 @@ class ProfilesController < ApplicationController
 
     @resource.is_a?(Person) ? load_person_data : load_unit_data
     load_items
+    load_same_kana_resources
 
     respond_to do |format|
       format.html
@@ -83,6 +84,14 @@ class ProfilesController < ApplicationController
                           .active
                           .includes(snapshot_people: :person)
                           .order(past: :asc, current: :desc, snapshot_index: :asc)
+  end
+
+  def load_same_kana_resources
+    return if @resource.name_kana.blank?
+
+    scope = @resource.class.kept.where(name_kana: @resource.name_kana).where.not(id: @resource.id)
+    @same_kana_total = scope.count
+    @same_kana_resources = scope.order(updated_at: :desc).limit(6) if @same_kana_total > 0
   end
 
   def load_items

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -91,7 +91,7 @@ class ProfilesController < ApplicationController
 
     scope = @resource.class.kept.where(name_kana: @resource.name_kana).where.not(id: @resource.id)
     @same_kana_total = scope.count
-    @same_kana_resources = scope.order(updated_at: :desc).limit(6) if @same_kana_total > 0
+    @same_kana_resources = scope.order(updated_at: :desc).limit(6) if @same_kana_total.positive?
   end
 
   def load_items

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -64,7 +64,7 @@
     <% end %>
 
     <% if @people.any? %>
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <div id="results" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         <%= render PersonCardComponent.with_collection(@people, show_history: true, show_details: true) %>
       </div>
     <% else %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -167,6 +167,8 @@
         <%= render 'layouts/google_adsense_square' %>
       </div>
 
+      <%= render SameKanaSuggestionComponent.new(resource: @resource, same_kana_resources: @same_kana_resources, same_kana_total: @same_kana_total) %>
+
       <section id="update-log" class="mt-8">
         <details class="group"
                  hx-get="<%= profile_update_logs_path(@resource.key) %>"

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -64,7 +64,7 @@
     <% end %>
 
     <% if @units.any? %>
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <div id="results" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
         <%= render UnitCardComponent.with_collection(@units, show_details: true) %>
       </div>
     <% else %>


### PR DESCRIPTION
## Summary
- プロフィールページ（Unit/Person）で、同じ `name_kana` を持つ同タイプのレコードを「Did You Mean?」セクションとして表示
- 既存の `UnitCardComponent` / `PersonCardComponent` をコレクションレンダリングで再利用
- 最大6件を3列グリッドで表示、超過分は「もっと見る」リンクで検索結果ページ（`#results` アンカー）に誘導
- 検索結果ページ（Units/People index）のカードリストに `id="results"` アンカーを追加

## Test plan
- [ ] `bin/rails test` が全件パスすること
- [ ] ヨミガナ重複のある Person ページ（例: 「リョウ」「ユウ」）で「Did You Mean?」セクションが表示されること
- [ ] ヨミガナ重複のある Unit ページ（例: 「ルーシー」「シックス」）で同様に表示されること
- [ ] ヨミガナが一意、または未設定のページではセクションが表示されないこと
- [ ] 7件以上の重複がある場合「もっと見る」リンクが表示され、検索結果ページのカードリスト位置に遷移すること
- [ ] モバイル・デスクトップ両方でレイアウトが崩れないこと

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)