### PR TITLE
関連図の初期表示にプレビュー背景を追加し、ホイールズームの感度を調整する

### DIFF
--- a/app/javascript/controllers/unit_graph_controller.js
+++ b/app/javascript/controllers/unit_graph_controller.js
@@ -84,6 +84,7 @@ export default class extends Controller {
     this.cy = cytoscape({
       container: this.containerTarget,
       elements: [...nodes, ...edges],
+      wheelSensitivity: 0.3,
       style: [
         {
           selector: 'node[type="unit"]',

--- a/app/views/profiles/_relationship_graph.html.erb
+++ b/app/views/profiles/_relationship_graph.html.erb
@@ -19,11 +19,60 @@
     </div>
   </div>
 
-  <%# 初期表示: ボタンのみ %>
-  <div data-unit-graph-target="placeholder" class="flex justify-center py-8">
+  <%# 初期表示: 関連図プレビュー背景 + ボタン %>
+  <div data-unit-graph-target="placeholder"
+       class="relative flex items-center justify-center rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 overflow-hidden"
+       style="height: 260px;">
+    <svg class="absolute inset-0 w-full h-full text-slate-300 dark:text-slate-700 opacity-60" viewBox="0 0 800 400" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" preserveAspectRatio="xMidYMid slice">
+      <%# エッジ（線）%>
+      <line x1="400" y1="200" x2="220" y2="100" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="400" y1="200" x2="580" y2="100" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="400" y1="200" x2="260" y2="300" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="400" y1="200" x2="560" y2="280" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="400" y1="200" x2="160" y2="200" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="400" y1="200" x2="640" y2="200" stroke="currentColor" stroke-width="1.5"/>
+      <line x1="220" y1="100" x2="100" y2="60" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="220" y1="100" x2="120" y2="160" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="220" y1="100" x2="300" y2="40" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="580" y1="100" x2="700" y2="60" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="580" y1="100" x2="680" y2="160" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="580" y1="100" x2="520" y2="40" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="260" y1="300" x2="140" y2="340" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="260" y1="300" x2="300" y2="370" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="560" y1="280" x2="660" y2="340" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="560" y1="280" x2="500" y2="350" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="160" y1="200" x2="60" y2="160" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="160" y1="200" x2="60" y2="240" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="640" y1="200" x2="740" y2="160" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <line x1="640" y1="200" x2="740" y2="240" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/>
+      <%# 中心ノード %>
+      <rect x="360" y="178" width="80" height="44" rx="6" fill="currentColor" opacity="0.5"/>
+      <%# 直接の関連ノード（hop 1）%>
+      <rect x="180" y="80" width="80" height="36" rx="5" fill="currentColor" opacity="0.35"/>
+      <rect x="540" y="80" width="80" height="36" rx="5" fill="currentColor" opacity="0.35"/>
+      <rect x="220" y="282" width="80" height="36" rx="5" fill="currentColor" opacity="0.35"/>
+      <rect x="520" y="262" width="80" height="36" rx="5" fill="currentColor" opacity="0.35"/>
+      <rect x="120" y="182" width="80" height="36" rx="5" fill="currentColor" opacity="0.35"/>
+      <rect x="600" y="182" width="80" height="36" rx="5" fill="currentColor" opacity="0.35"/>
+      <%# 間接の関連ノード（hop 2）%>
+      <rect x="65" y="44" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="85" y="146" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="266" y="24" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="666" y="44" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="646" y="146" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="486" y="24" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="106" y="326" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="266" y="354" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="626" y="326" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="466" y="336" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="26" y="146" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="26" y="226" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="706" y="146" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+      <rect x="706" y="226" width="68" height="30" rx="4" fill="currentColor" opacity="0.18"/>
+    </svg>
     <button
       data-action="click->unit-graph#load"
-      class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-lg transition-colors">
+      class="relative z-10 inline-flex items-center gap-2 px-5 py-2.5 text-sm font-bold text-slate-700 dark:text-slate-200 bg-white dark:bg-slate-800 hover:bg-indigo-50 hover:text-indigo-700 hover:border-indigo-400 dark:hover:bg-indigo-950 dark:hover:text-indigo-300 dark:hover:border-indigo-500 rounded-lg shadow-md border-2 border-slate-400 dark:border-slate-500 transition-all duration-200 cursor-pointer">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
       </svg>


### PR DESCRIPTION
## Summary
- 関連図（RELATIONSHIP GRAPH）のボタン表示前に、ネットワークグラフを模した装飾SVGを背景に表示するようにした
- ボタンのスタイルを改善（視認性向上、ホバー時のインディゴカラー変化、cursor: pointer）
- マウスホイールによるズームの感度を調整（`wheelSensitivity: 0.3`）

close #722

## Test plan
- [ ] ユニットのプロフィールページで RELATIONSHIP GRAPH セクションにプレビュー背景が表示されること
- [ ] 「関連図を表示」ボタンが背景の上に見やすく表示されること
- [ ] ボタンホバー時にインディゴ色に変化すること
- [ ] ボタンクリックで従来通り関連図が表示されること
- [ ] ダークモードでも適切に表示されること
- [ ] 関連図表示後、マウスホイールでの拡大縮小が緩やかになっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)