### PR TITLE
未使用 gem を development グループに移動して production メモリを削減する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,7 @@ gem 'rails', '>= 8.1.2.1', '~> 8.1.2'
 gem 'propshaft'
 # Use pg as the database for Active Record
 gem 'pg', '~> 1.5'
-# Temporarily keep mysql2 for data migration from legacy vkdb MySQL database
-gem 'mysql2', '~> 0.5'
+# mysql2 is in :development group (legacy data migration only)
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma', '>= 5.0'
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
@@ -32,10 +31,7 @@ gem 'bcrypt', '~> 3.1.22'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-# Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
-gem 'solid_cable'
-gem 'solid_cache'
-gem 'solid_queue'
+# solid_cable, solid_cache, solid_queue are in :development group (production uses Redis)
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
@@ -76,6 +72,14 @@ group :development do
   gem 'web-console'
 
   gem 'lookbook'
+
+  # Legacy data migration from vkdb MySQL database
+  gem 'mysql2', '~> 0.5'
+
+  # Rails 8 defaults — not used in production (Redis is used instead)
+  gem 'solid_cable'
+  gem 'solid_cache'
+  gem 'solid_queue'
 end
 
 group :test do

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,7 +37,8 @@ port ENV.fetch('PORT', 3000)
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV['SOLID_QUEUE_IN_PUMA']
+# solid_queue gem is only available in development group.
+plugin :solid_queue if ENV['SOLID_QUEUE_IN_PUMA'] && defined?(SolidQueue)
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.


### PR DESCRIPTION
## Summary
- `solid_cable`, `solid_cache`, `solid_queue` を `group :development` に移動（production では Redis を使用しており不要）
- `mysql2` を `group :development` に移動（レガシーデータ移行専用で production では不要）
- `config/puma.rb` の `solid_queue` プラグイン参照に `defined?(SolidQueue)` ガードを追加

Closes #726

## Test plan
- [x] `bundle install` 成功
- [x] `bundle exec rails runner` で Rails 起動確認
- [x] RuboCop パス
- [x] テスト全件パス（78 tests, 201 assertions, 0 failures）
- [ ] Render デプロイ後にメモリ使用量を監視

🤖 Generated with [Claude Code](https://claude.com/claude-code)