### PR TITLE
jemalloc を導入して production のメモリ断片化を削減する

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -2,6 +2,11 @@
 # exit on error
 set -o errexit
 
+# Install jemalloc for reduced memory fragmentation
+if ! dpkg -s libjemalloc2 > /dev/null 2>&1; then
+  sudo apt-get update -qq && sudo apt-get install -yq libjemalloc2
+fi
+
 bundle install
 bundle exec rails tailwindcss:build
 bundle exec rails assets:precompile

--- a/render.yaml
+++ b/render.yaml
@@ -28,5 +28,7 @@ services:
         value: 2
       - key: MALLOC_ARENA_MAX
         value: 2
+      - key: LD_PRELOAD
+        value: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
     region: singapore
     plan: free # Web service has a free tier.


### PR DESCRIPTION
## Summary
- ビルド時に `libjemalloc2` をインストール（`bin/render-build.sh`）
- `LD_PRELOAD` 環境変数で Rails プロセスに jemalloc を適用（`render.yaml`）
- Ruby の標準 malloc によるメモリ断片化を抑え、10-30% のメモリ削減が期待できる

Closes #726

## Test plan
- [ ] Render デプロイが正常に完了すること
- [ ] デプロイ後にメモリ使用量が削減されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)