### PR TITLE
crass を 1.0.7 に更新してセキュリティ脆弱性を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       highline (~> 3.0.0)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     css_parser (3.0.0)
       addressable
       ssrf_filter (~> 1.5)


### PR DESCRIPTION
## Summary

- crass gem を 1.0.6 → 1.0.7 に更新
- bundler-audit で検出された4件のセキュリティ脆弱性に対応
  - GHSA-6jxj-px6v-747w: 深くネストされた CSS ブロックによる SystemStackError
  - GHSA-6wmf-3r64-vcwv: 大きな数値指数による CPU/メモリ DoS
  - GHSA-8vfg-2r28-hvhj: 非 ASCII 文字による超線形 CPU 消費
  - GHSA-wwpr-jff3-395c: 大量の隣接 CSS コメントによる SystemStackError

## Test plan

- [x] `bundle exec bin/bundler-audit` がパスすること
- [x] テスト全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)