### PR TITLE
jemalloc (LD_PRELOAD) を無効化して OOM 再起動ループを解消する

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -2,11 +2,6 @@
 # exit on error
 set -o errexit
 
-# Install jemalloc for reduced memory fragmentation
-if ! dpkg -s libjemalloc2 > /dev/null 2>&1; then
-  sudo apt-get update -qq && sudo apt-get install -yq libjemalloc2
-fi
-
 bundle install
 bundle exec rails tailwindcss:build
 bundle exec rails assets:precompile

--- a/render.yaml
+++ b/render.yaml
@@ -28,7 +28,5 @@ services:
         value: 2
       - key: MALLOC_ARENA_MAX
         value: 2
-      - key: LD_PRELOAD
-        value: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
     region: singapore
     plan: free # Web service has a free tier.


### PR DESCRIPTION
## Summary
- `render.yaml` から `LD_PRELOAD` 環境変数を削除
- `bin/render-build.sh` から jemalloc インストール処理を削除
- `MALLOC_ARENA_MAX=2` は glibc malloc 向けの有効な設定なので維持

## 背景
6/28 リリースで jemalloc を導入後、512MB 制限下で OOM キルが頻発し 112 回の再起動ループが発生。jemalloc は glibc malloc より RSS が増える傾向があり、512MB では逆効果だった。

## 注意
デプロイ後、Render ダッシュボードからも `LD_PRELOAD` 環境変数を手動削除してください。

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)