### PR TITLE
ProfilesController で snapshot_people の person eager load をカレントに限定する

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -82,8 +82,14 @@ class ProfilesController < ApplicationController
 
     @snapshots = @resource.unit_snapshots
                           .active
-                          .includes(snapshot_people: :person)
+                          .includes(:snapshot_people)
                           .order(past: :asc, current: :desc, snapshot_index: :asc)
+
+    # MemberRowComponent（カレントスナップショットの表示）は person 関連が必要だが、
+    # 非カレントは member_names のテキストのみ参照するため、person の eager load を
+    # カレントスナップショットの snapshot_people に限定してメモリ消費を抑える。
+    current_snapshot_people = @snapshots.select(&:current?).flat_map(&:snapshot_people)
+    ActiveRecord::Associations::Preloader.new(records: current_snapshot_people, associations: :person).call
   end
 
   def load_same_kana_resources


### PR DESCRIPTION
## Summary
- `load_unit_data` で全スナップショットの `snapshot_people: :person` を eager load していたのをやめ、`snapshot_people` のみ eager load するように変更
- カレントスナップショットの `snapshot_people` のみ、別途 `ActiveRecord::Associations::Preloader` で `person` を限定的にプリロード

## 背景
ビュー（UnitSnapshotsComponent）では非カレントのスナップショットは `member_names`（テキストのみ）しか参照せず、`person` 関連は不要。htmx で展開された際は `ProfilesController#snapshot_members` が別途 `includes(:person)` するため重複もない。スナップショット数・メンバー数が多いユニットでの無駄なメモリ消費を削減する。

## Test plan
- [x] `bundle exec rails test test/controllers/profiles_controller_test.rb` 通過
- [x] 開発サーバーでプロフィールページ（スナップショットありのユニット）が 200 で表示されることを確認
- [x] 全テストスイート（78 tests）通過

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)