### PR TITLE
msgpack を 1.8.3 に更新してセキュリティ脆弱性を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     mysql2 (0.5.7)
       bigdecimal
     net-imap (0.6.4.1)


### PR DESCRIPTION
## Summary
- msgpack を 1.8.1 → 1.8.3 に更新し、CVE-2026-54522（MessagePack::Buffer#clear の Use-After-Free）を解消する

## 背景
bundler-audit が CI (scan_ruby) で検出し、develop ブランチを含む全 PR の CI が失敗していた。

## Test plan
- [x] `bundle exec bundle-audit check` で脆弱性なしを確認
- [x] 全テストスイート（78 tests）通過

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)