### PR TITLE
TimelineController#index のキャッシュを AR オブジェクトからプレーンデータに変更する

### DIFF
--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -2,11 +2,19 @@
 
 # rubocop:disable Metrics/ClassLength
 class TimelineController < ApplicationController
-  CACHE_KEY = 'timeline/major_units/v4'
+  CACHE_KEY = 'timeline/major_units/v5'
   CACHE_TTL = 1.hour
 
   VALID_ZOOMS = { '2' => 48 }.freeze
   DEFAULT_YEAR_PX = 24
+
+  # Unit の全属性を持つ AR オブジェクトをキャッシュ・保持するとメモリを圧迫するため、
+  # タイムライン表示に必要な属性のみを持つ軽量な値オブジェクトとして扱う。
+  TimelineUnit = Struct.new(:id, :name, :key, :name_kana, :activity_period, keyword_init: true) do
+    def activity_periods
+      (activity_period || []).map { |h| OpenStruct.new(h) }
+    end
+  end
 
   # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
   def index
@@ -24,7 +32,8 @@ class TimelineController < ApplicationController
                   .where(id: major_debut_unit_ids)
                   .where.not(activity_period: nil)
                   .distinct
-                  .to_a
+                  .pluck(:id, :name, :key, :name_kana, :activity_period)
+                  .map { |id, name, key, name_kana, activity_period| TimelineUnit.new(id:, name:, key:, name_kana:, activity_period:) }
 
       all_years = units.flat_map do |unit|
         unit.activity_periods.map { |p| parse_year(p.from) }
@@ -79,10 +88,10 @@ class TimelineController < ApplicationController
         end
       end
 
-      { units:, year_min:, year_max:, trend_markers: }
+      { units: units.map(&:to_h), year_min:, year_max:, trend_markers: }
     end
 
-    @units          = @timeline_data[:units]
+    @units          = @timeline_data[:units].map { |attrs| TimelineUnit.new(**attrs) }
     @year_min       = @timeline_data[:year_min]
     @year_max       = @timeline_data[:year_max]
     @year_range     = (@year_min..@year_max).to_a


### PR DESCRIPTION
## Summary
- `TimelineController#index` で Unit の ActiveRecord オブジェクトをそのまま Redis キャッシュしていたのをやめ、タイムライン表示に必要な属性（id/name/key/name_kana/activity_period）のみを持つ軽量な `TimelineUnit` Struct + プレーン Hash としてキャッシュするように変更
- キャッシュ構造変更に伴い `CACHE_KEY` を v4 → v5 に更新（古いキャッシュとの混在を防ぐ）

## 背景
キャッシュに AR オブジェクトを格納すると、シリアライズ・デシリアライズ時に不要な属性を含む全カラムのオーバーヘッドが発生する。タイムライン表示（TimelineRowComponent）が実際に使うのは `id`/`name`/`key`/`activity_periods` のみのため、それらに絞ったプレーンデータに変更しメモリ消費を削減する。

## Test plan
- [x] `bundle exec rubocop app/controllers/timeline_controller.rb` で offense なし
- [x] 開発サーバーで `/timeline` が 200 で表示されることを確認（キャッシュ書き込み・読み込み両方）
- [x] 全テストスイート（78 tests）通過

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)