### PR TITLE
TrendsController#show の @unit_trends に select を追加してメモリ消費を削減する

### DIFF
--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -59,6 +59,7 @@ class TrendsController < ApplicationController
     @items = scopes.reduce(:or).order(release_date: :desc).limit(8) if scopes.any?
 
     @unit_trends = Trend.where('units @> ?', [{ unit_id: unit.id }].to_json)
+                        .select(:id, :date, :title)
                         .order(date: :asc)
   end
 end


### PR DESCRIPTION
## Summary
- `TrendsController#show` の `@unit_trends` に `.select(:id, :date, :title)` を追加

## 背景
`@unit_trends`（ユニットの全トレンド履歴を `UnitTrendsComponent` 経由で表示）には件数制限がなく、`content`/`quote` など大きいテキストカラムを含む全カラムをロードしていた。表示に使われるのは `id`/`date`/`title` のみのため、件数を制限せず（ユニットの全履歴を見せる機能のため）select で不要なカラムのロードを避ける形にした。

## Test plan
- [x] `bundle exec rubocop app/controllers/trends_controller.rb` で offense なし
- [x] 開発サーバーで `/trends/:id`（units 紐付きの trend）が 200 で表示されることを確認
- [x] 全テストスイート（78 tests）通過

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)