### PR TITLE
DailyController#show の @trends/@birthdays に select を追加してメモリ消費を削減する

### DIFF
--- a/app/controllers/daily_controller.rb
+++ b/app/controllers/daily_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class DailyController < ApplicationController
+  # PersonCardComponent（show_history: true）の表示に必要な列のみを取得し、
+  # old_wiki_text/note など大きいテキスト列のロードを避ける
+  PERSON_CARD_COLUMNS = %i[id key name name_kana aliases old_history].freeze
+
   def show
     @year_agnostic = params[:year].nil?
 
@@ -12,12 +16,13 @@ class DailyController < ApplicationController
     if @year_agnostic
       month = @date.month
       day = @date.day
-      @trends = Trend.on_month_day(month, day).order(date: :asc)
-      @birthdays = Person.kept.birthday_on(@date).order(name_kana: :asc)
+      @trends = Trend.on_month_day(month, day).select(:id, :date, :title, :units).order(date: :asc)
+      @birthdays = Person.kept.birthday_on(@date).select(*PERSON_CARD_COLUMNS).order(name_kana: :asc)
       @releases = Item.released_on_month_day(month, day).order(release_date: :asc)
     else
-      @trends = Trend.on_date(@date).order(created_at: :desc)
-      @birthdays = Person.kept.birthday_on(@date).where(status: %i[active hiatus]).order(name_kana: :asc)
+      @trends = Trend.on_date(@date).select(:id, :date, :title, :units).order(created_at: :desc)
+      @birthdays = Person.kept.birthday_on(@date).where(status: %i[active hiatus])
+                         .select(*PERSON_CARD_COLUMNS).order(name_kana: :asc)
       @releases = Item.released_on(@date).order(created_at: :desc)
     end
 


### PR DESCRIPTION
## Summary
- `@trends`（Trend）に `.select(:id, :date, :title, :units)` を追加
- `@birthdays`（Person）に `.select(*PERSON_CARD_COLUMNS)`（id/key/name/name_kana/aliases/old_history）を追加

## 背景
4/1 のような人気の日付では Trend・Person が大量にヒットし、`content`/`quote`（Trend）や `old_wiki_text`/`note`（Person）といった大きいテキスト列を含む全カラムが無条件にロードされていた。日次サマリーとして全件表示する仕様のため件数制限は行わず、表示（TrendListRowComponent / PersonCardComponent with show_history: true）に必要な列のみに絞ることでメモリ消費を削減する。

`@releases`（Item）は大きいテキスト列を持たず、ItemCardComponent がほぼ全カラムを使用するため変更なし。

## Test plan
- [x] `bundle exec rubocop app/controllers/daily_controller.rb` で offense なし
- [x] 開発サーバーで year-agnostic（`/date/-/:month/:day`）・年指定（`/date/:year/:month/:day`）両方が 200 で表示されることを確認
- [x] 誕生日データのある日付で Birthdays セクションが正しくレンダリングされることを確認
- [x] 全テストスイート（78 tests）通過

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)