### PR TITLE
UnitGraphBuilder#build_graph で Unit を AR オブジェクトとして全件ロードしないようにする

### DIFF
--- a/app/services/unit_graph_builder.rb
+++ b/app/services/unit_graph_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UnitGraphBuilder # rubocop:disable Metrics/ClassLength
+  GraphUnit = Struct.new(:id, :name, :key, keyword_init: true)
+
   def initialize(unit, track_past: false)
     @unit = unit
     @track_past = track_past
@@ -185,7 +187,11 @@ class UnitGraphBuilder # rubocop:disable Metrics/ClassLength
   end
 
   def build_graph(unit_ids_by_person, current_edge_pairs, relevant_unit_ids, hop1_unit_ids_set = Set.new, base_unit_ids = nil)
-    related_units = Unit.where(id: relevant_unit_ids).index_by(&:id)
+    # ノード描画には id/name/key のみ必要なため、Unit を AR オブジェクトとして
+    # 全件ロードせず必要な列のみ取得する
+    related_units = Unit.where(id: relevant_unit_ids)
+                        .pluck(:id, :name, :key)
+                        .to_h { |id, name, key| [id, GraphUnit.new(id:, name:, key:)] }
 
     nodes = { "unit_#{@unit.id}" => center_node }
     edges = {}


### PR DESCRIPTION
## Summary
- `build_graph` 内の `Unit.where(id: relevant_unit_ids).index_by(&:id)` を pluck ベースに変更
- ノード描画（`unit_node`）に必要な `id`/`name`/`key` のみを持つ軽量な `GraphUnit` Struct を導入

## 背景
グラフ構築に必要なのは id/name/key の3属性のみだが、Unit の全カラムを持つ AR オブジェクトとしてロードしていた。24時間キャッシュ（`Rails.cache.fetch`）のミス時（TTL切れ、データ変更時）に発生する計算コストを削減する。

## Test plan
- [x] `bundle exec rubocop app/services/unit_graph_builder.rb` で offense なし
- [x] `Rails.cache.clear` 後に `UnitGraphBuilder.new(unit).call` を直接実行し、ノード・エッジが正しく構築されることを確認
- [x] 全テストスイート（78 tests）通過

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)