### PR TITLE
ProfilesController @history に select を追加してメモリ消費を削減する

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -74,7 +74,7 @@ class ProfilesController < ApplicationController
   end
 
   def load_unit_data
-    @history = @resource.unit_logs
+    @history = @resource.unit_logs.select(:id, :log_date, :phenomenon, :phenomenon_alias, :text)
 
     @trends = Trend.where('units @> ?', [{ unit_id: @resource.id }].to_json)
                    .order(date: :desc)


### PR DESCRIPTION
## Summary
- `load_unit_data` の `@history`（unit_logs）に `.select(:id, :log_date, :phenomenon, :phenomenon_alias, :text)` を追加

## 背景
`UnitHistoryItemComponent` の表示に必要なのは `log_date`/`phenomenon`/`phenomenon_alias`/`text` のみだが、`quote_text`/`source_url` を含む全カラムをロードしていた。ユニット履歴を全件表示する仕様のため件数制限は行わず、不要な大きいテキストカラム（quote_text）のロードのみを避ける。

## Test plan
- [x] `bundle exec rubocop app/controllers/profiles_controller.rb` で offense なし
- [x] 開発サーバーでプロフィールページが 200 で表示されることを確認
- [x] 全テストスイート（78 tests）通過

Closes #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)