### PR TITLE
GC.auto_compact を本番環境で有効化してメモリ断片化を抑制する

### DIFF
--- a/config/initializers/gc_tuning.rb
+++ b/config/initializers/gc_tuning.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Render free tier (512MB) ではヒープ断片化が OOM の一因になりうるため、
+# 本番環境では世代別 GC のタイミングでヒープを自動コンパクションする。
+GC.auto_compact = true if Rails.env.production?


### PR DESCRIPTION
## Summary
- `config/initializers/gc_tuning.rb` を追加し、production 環境でのみ `GC.auto_compact = true` を設定する

## 背景
jemalloc 削除（#738）により glibc malloc に戻ったため、ヒープ断片化が再び OOM の一因になりうる。`GC.auto_compact = true`（Ruby 2.7+）により世代別 GC のタイミングでヒープを自動コンパクションし、断片化を抑制する。development/test のテスト実行速度に影響しないよう production 限定にした。

## Test plan
- [x] `bundle exec rubocop config/initializers/gc_tuning.rb` で offense なし
- [x] `ruby -e "GC.auto_compact = true; puts GC.auto_compact"` で API 自体が動作することを確認
- [x] development 環境では `GC.auto_compact` が `false` のままであることを確認（production 限定の条件分岐が機能）
- [x] 全テストスイート（78 tests）通過
- [ ] 本番デプロイ後、メモリ使用量の推移を計測して効果を確認（要観測）

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)