### PR TITLE
/people, /units の q・tag_ids 絞り込みリクエストにスロットリングを追加する

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,6 +5,14 @@ Rack::Attack.throttle('search/ip', limit: 30, period: 60) do |req|
   req.ip if req.path.start_with?('/people/search', '/units/search', '/search')
 end
 
+# /people, /units の q・tag_ids 絞り込み: IP ごとに 60 秒間 20 リクエストまで
+# tag_ids は組み合わせが事実上無限大になり、ILIKE 全文検索と合わさって重いクエリになるため、
+# クローラーによる総当たりクロールから保護する（プレーンな一覧表示・ページネーションは対象外）
+Rack::Attack.throttle('people_units_filter/ip', limit: 20, period: 60) do |req|
+  req.ip if req.get? && %w[/people /units].include?(req.path) &&
+            (req.params['q'].present? || req.params['tag_ids'].present?)
+end
+
 # ログイン: IP ごとに 20 秒間 5 回まで（ブルートフォース対策）
 Rack::Attack.throttle('login/ip', limit: 5, period: 20) do |req|
   req.ip if req.path == '/login' && req.post?


### PR DESCRIPTION
## Summary
- `config/initializers/rack_attack.rb` に `/people`・`/units` の q・tag_ids 絞り込みリクエストに対するスロットリングを追加（IP ごとに60秒20リクエストまで）

## 背景

Render のリクエストログで、OOM クラッシュ（502連発）直前に GPTBot・Amazonbot が `/people?q=...&tag_ids[10]=...&tag_ids[11]=...&tag_ids[2]=...` のような大量のタグ ID 組み合わせ URL を同時多発的にクロールしていたことが判明（#762）。

`PeopleController#index`/`UnitsController#index` は:
- `q` による ILIKE 全文検索（5カラム、先頭ワイルドカードのためインデックス不可）
- `tag_ids` パラメータごとのサブクエリ追加（組み合わせ数に応じてコスト増大）

という特性があり、これらの組み合わせは事実上無限大かつキャッシュされていない。既存の rack_attack スロットリングは `/people/search` 等のオートコンプリート用エンドポイントのみが対象で、index アクション自体は対象外だった。

robots.txt によるクロール制限も検討したが、正規のページネーション・検索結果ページの SEO クロールを妨げる懸念があるため見送り、アプリ側のレート制限のみで対応する方針とした。

## Test plan
- [x] `bundle exec rubocop config/initializers/rack_attack.rb` で offense なし
- [x] 開発サーバーで `/people?q=test` を25回連続リクエストし、21回目以降に `429` が返ることを確認
- [x] `/people`（パラメータなし）・`/people?page=2` がスロットリングされないことを確認
- [x] 全テストスイート（78 tests）通過

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)