### PR TITLE
Rack::Attack のキャッシュを Redis 化し、既知クローラーを即時ブロックする

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,16 +1,33 @@
 # frozen_string_literal: true
 
+# 再起動をまたいでスロットリング・ブロックリストの状態を保持するため Redis ベースの
+# キャッシュを使う（デフォルトのインメモリストアだと OOM 再起動のたびにカウンターが
+# リセットされ、クローラーが再び閾値までリクエストを通せてしまう）
+Rack::Attack.cache.store = Rails.cache
+
 # オートコンプリート・全文検索: IP ごとに 60 秒間 30 リクエストまで
 Rack::Attack.throttle('search/ip', limit: 30, period: 60) do |req|
   req.ip if req.path.start_with?('/people/search', '/units/search', '/search')
 end
 
-# /people, /units の q・tag_ids 絞り込み: IP ごとに 60 秒間 20 リクエストまで
-# tag_ids は組み合わせが事実上無限大になり、ILIKE 全文検索と合わさって重いクエリになるため、
-# クローラーによる総当たりクロールから保護する（プレーンな一覧表示・ページネーションは対象外）
-Rack::Attack.throttle('people_units_filter/ip', limit: 20, period: 60) do |req|
-  req.ip if req.get? && %w[/people /units].include?(req.path) &&
-            (req.params['q'].present? || req.params['tag_ids'].present?)
+# /people, /units の q・tag_ids 絞り込みリクエストか判定する
+# tag_ids は組み合わせが事実上無限大になり、ILIKE 全文検索と合わさって重いクエリになる
+people_units_filter_request = lambda do |req|
+  req.get? && %w[/people /units].include?(req.path) &&
+    (req.params['q'].present? || req.params['tag_ids'].present?)
+end
+
+# 既知の AI/SEO クローラーは絞り込み検索の組み合わせクロールから得るものがなく、
+# 重いクエリを大量に発生させるため、クエリ実行前に即座にブロックする
+crawler_ua_pattern = /GPTBot|ChatGPT-User|CCBot|Amazonbot|ClaudeBot|anthropic-ai|Bytespider|PerplexityBot|Google-Extended|Applebot-Extended/i
+Rack::Attack.blocklist('block_crawlers/people_units_filter') do |req|
+  people_units_filter_request.call(req) && req.user_agent.to_s.match?(crawler_ua_pattern)
+end
+
+# ブロックリスト対象外のクライアントも IP ごとに 60 秒間 5 リクエストまでに制限する
+# （プレーンな一覧表示・ページネーションは対象外）
+Rack::Attack.throttle('people_units_filter/ip', limit: 5, period: 60) do |req|
+  req.ip if people_units_filter_request.call(req)
 end
 
 # ログイン: IP ごとに 20 秒間 5 回まで（ブルートフォース対策）


### PR DESCRIPTION
## Summary
- `Rack::Attack.cache.store = Rails.cache`（Redis）に変更し、OOM 再起動をまたいでスロットリング状態を保持する
- GPTBot/Amazonbot 等の既知クローラーを `/people`・`/units` の q・tag_ids 絞り込みリクエストでブロックリスト（403、クエリ実行前に即時拒否）
- 残りのクライアント向けスロットリングを 20req/分 → 5req/分 に強化

## 背景

#762 でスロットリングを追加してデプロイ（10:39 PM live）したが、3分後の 10:42 PM に同じ OOM クラッシュが再発した。原因は Rack::Attack のデフォルトキャッシュストア（インメモリ）が OOM 再起動のたびにリセットされ、クローラーが毎回ゼロからカウントを始められてしまうこと。また `responseTimeMS=7828` のような重いクエリは1〜2件の同時実行だけでも 512MB/2スレッドの環境ではクラッシュしうるため、20req/分という閾値も緩すぎた。

GPTBot・Amazonbot は自己申告の User-Agent でリクエストしており（robots.txt も尊重する既知の行儀の良いクローラー）、絞り込み検索の組み合わせクロールから得るものがないため、UA マッチによる即時ブロックが最も確実な対策と判断した。

## Test plan
- [x] `bundle exec rubocop config/initializers/rack_attack.rb` で offense なし
- [x] 開発サーバーで GPTBot/Amazonbot の UA で `/people?q=...`・`/people?tag_ids[1]=1` が即座に 403 になることを確認
- [x] GPTBot UA でもプレーンな `/people`（パラメータなし）は 200 のままであることを確認（誤ブロックなし）
- [x] 通常ブラウザ UA で `/people?q=...` を6回連続リクエストし、6回目で 429 が返ることを確認（5req/分の閾値が機能）
- [x] 全テストスイート（78 tests）通過
- [ ] 本番デプロイ後、Render のメトリクス・ログで OOM クラッシュが収まることを確認（要観測）

Refs #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)