### PR TITLE
AdSenseコンテナのCSSを修正し手動配置広告が表示されるようにする (#768)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       .admin-dropdown:hover .admin-dropdown-menu {
         display: block;
       }
-      .adsense-container:not(:has(ins[data-ad-status="filled"])) {
+      .adsense-container:has(ins[data-ad-status="unfilled"]) {
         display: none;
       }
     </style>


### PR DESCRIPTION
## Summary

- `.adsense-container` の CSS を `:not(:has([data-ad-status="filled"]))` から `:has([data-ad-status="unfilled"])` に変更
- ページ読み込み直後は非表示にせず、AdSense が `unfilled` と確定した後にのみ非表示とする

## 背景

従来のCSSはページ読み込み直後（AdSense 処理前）から `display: none` を適用していたため、AdSense が width:0 の要素を配信対象外と判断し `data-ad-status` が永遠にセットされないチキンエッグ問題が発生していた。Auto ads はAdSense 自身がDOMに挿入するためこの影響を受けず正常動作していた。

Closes #768

## Test plan

- [ ] ハードリロード後にブラウザコンソールで `document.querySelectorAll('ins.adsbygoogle')` を確認し、`data-ad-status` が `"filled"` または `"unfilled"` になることを確認
- [ ] 未配信時に広告コンテナが非表示になることを確認（レイアウト崩れがないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)