### PR TITLE
プロフィール下部スクエア広告を別スロットIDに分離する (#768)

### DIFF
--- a/app/views/layouts/_google_adsense_square2.html.erb
+++ b/app/views/layouts/_google_adsense_square2.html.erb
@@ -1,0 +1,13 @@
+<% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
+  <div class="adsense-container">
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
+         data-ad-slot="7915453923"
+         data-ad-format="auto"
+         data-full-width-responsive="true"></ins>
+    <script>
+      (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+  </div>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -164,7 +164,7 @@
       <% end %>
 
       <div class="mt-8">
-        <%= render 'layouts/google_adsense_square' %>
+        <%= render 'layouts/google_adsense_square2' %>
       </div>
 
       <%= render SameKanaSuggestionComponent.new(resource: @resource, same_kana_resources: @same_kana_resources, same_kana_total: @same_kana_total) %>


### PR DESCRIPTION
## Summary

- `_google_adsense_square2.html.erb` を新規作成（スロット: `7915453923`）
- `profiles/show.html.erb` 下部の広告を `square` → `square2` に変更

## 背景

同一スロットID（`490467213`）を1ページに2回配置すると AdSense が2回目の配信を拒否し `unfilled` になる問題への対応（#768 の続き）。

## Test plan

- [ ] プロフィールページで Ad 2（左カラム）と Ad 3（下部）が別スロットIDになっていることをコンソールで確認
- [ ] 両スロットに広告が配信されること（`data-ad-status="filled"`）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)