### PR TITLE
上部横バナー広告のフォーマットを horizontal に変更する (#775)

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -4,7 +4,7 @@
          style="display:block"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="5770025949"
-         data-ad-format="auto"
+         data-ad-format="horizontal"
          data-full-width-responsive="true"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});


### PR DESCRIPTION
## Summary

- `_google_adsense_horizontal.html.erb` の `data-ad-format` を `auto` → `horizontal` に変更

## 背景

`auto` フォーマットではショッピング広告グリッドなど縦に大きいフォーマットが選ばれやすく、ページ上部の広告の存在感が大きすぎる問題があった。`horizontal` に変更することで薄い横長バナーが優先されるようになる。

`data-full-width-responsive="true"` は維持されるため、PC/モバイル両対応のまま。

Closes #775

## Test plan

- [ ] デプロイ後、上部広告が以前より薄い横長バナーになっていることを確認
- [ ] モバイルでも広告が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)