### PR TITLE
AdSense余白とモバイル広告サイズの問題を修正する (#779)

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -1,5 +1,5 @@
 <% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container adsense-container--horizontal">
     <ins class="adsbygoogle"
          style="display:block"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"

--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -1,11 +1,22 @@
 <% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container adsense-container--horizontal">
+  <%# Desktop: horizontal banner (sm以上) %>
+  <div class="hidden sm:block max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container adsense-container--horizontal">
     <ins class="adsbygoogle"
          style="display:block"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="5770025949"
          data-ad-format="horizontal"
          data-full-width-responsive="true"></ins>
+    <script>
+      (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+  </div>
+  <%# Mobile: 320x50 fixed banner (sm未満) %>
+  <div class="sm:hidden flex justify-center adsense-container">
+    <ins class="adsbygoogle"
+         style="display:inline-block;width:320px;height:50px"
+         data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
+         data-ad-slot="2361507820"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,8 +29,14 @@
       .admin-dropdown:hover .admin-dropdown-menu {
         display: block;
       }
-      .adsense-container:has(ins[data-ad-status="unfilled"]) {
+      .adsense-container:has(ins[data-ad-status^="unfill"]) {
         display: none;
+      }
+      @media (max-width: 640px) {
+        .adsense-container--horizontal {
+          max-height: 120px;
+          overflow: hidden;
+        }
       }
     </style>
     <%= render 'layouts/google_analytics' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,12 +32,6 @@
       .adsense-container:has(ins[data-ad-status^="unfill"]) {
         display: none;
       }
-      @media (max-width: 640px) {
-        .adsense-container--horizontal {
-          max-height: 120px;
-          overflow: hidden;
-        }
-      }
     </style>
     <%= render 'layouts/google_analytics' %>
     <%= render 'layouts/google_adsense' %>


### PR DESCRIPTION
## Summary

- `unfill-optimized` ステータスのコンテナも非表示にする（`^="unfill"` で前方一致）
- PC/モバイルで広告スロットを出し分け（`overflow: hidden` によるクリッピングは廃止）

## 変更内容

**application.html.erb**
```css
/* unfilled + unfill-optimized 両方を非表示 */
.adsense-container:has(ins[data-ad-status^="unfill"]) { display: none; }
```

**_google_adsense_horizontal.html.erb**

| | スロット | 表示条件 |
|---|---|---|
| デスクトップ横バナー | `5770025949`（レスポンシブ・horizontal） | `sm:` 以上 |
| モバイルバナー | `2361507820`（固定 320×50） | `sm:` 未満 |

Closes #779

## Test plan

- [ ] `unfill-optimized` 時に空白スペースが出ないことを確認
- [ ] デスクトップで横バナーが表示されることを確認
- [ ] モバイルで 320×50 バナーが欠けずに表示されることを確認
- [ ] モバイルでデスクトップ用広告が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)