### PR TITLE
モバイル広告コンテナを320px制約してAdSenseのサイズ誤検出を修正する (#779)

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -13,12 +13,15 @@
   </div>
   <%# Mobile: 320x50 fixed banner (sm未満) %>
   <div class="sm:hidden flex justify-center adsense-container">
+    <div style="width:320px;overflow:hidden;">
     <ins class="adsbygoogle"
          style="display:inline-block;width:320px;height:50px"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
-         data-ad-slot="2361507820"></ins>
+         data-ad-slot="2361507820"
+         data-full-width-responsive="false"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary

モバイル用 320×50 スロット（`2361507820`）が AdSense に `format=410x410` で認識され、大きな空白スペースが生じる問題を修正。

## 原因

`flex justify-center` の親コンテナがフル幅（410px）のため、AdSense が `<ins>` の `style="width:320px"` を無視して `fwr=1`（full width responsive）として処理していた。

## 修正

`<ins>` を `style="width:320px;overflow:hidden;"` のラッパー div で包み、AdSense が正しく 320px を検出できるようにした。また `data-full-width-responsive="false"` を追加。

Closes #779

## Test plan

- [ ] 本番でモバイルの上部広告が 50px 程度に収まることを確認
- [ ] `format=320x50` でリクエストされることをコンソールで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)