### PR TITLE
サイト内リンクを同タブで開くように修正する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  class ExternalAwareHtmlRenderer < Redcarpet::Render::HTML
+    def initialize(site_host:, **options)
+      @site_host = site_host
+      super(**options)
+    end
+
+    def link(link, title, content)
+      safe_link = CGI.escapeHTML(link.to_s)
+      title_attr = title.present? ? " title=\"#{CGI.escapeHTML(title)}\"" : ''
+      extra_attrs = external_url?(link) ? ' target="_blank" rel="noopener noreferrer"' : ''
+      "<a href=\"#{safe_link}\"#{title_attr}#{extra_attrs}>#{content}</a>"
+    end
+
+    def autolink(link, _link_type)
+      safe_link = CGI.escapeHTML(link.to_s)
+      extra_attrs = external_url?(link) ? ' target="_blank" rel="noopener noreferrer"' : ''
+      "<a href=\"#{safe_link}\"#{extra_attrs}>#{safe_link}</a>"
+    end
+
+    private
+
+    def external_url?(url)
+      return false if url.blank? || url.start_with?('/', '#', 'mailto:')
+      return true unless url.match?(%r{\Ahttps?://})
+
+      URI.parse(url).host != @site_host
+    rescue URI::InvalidURIError
+      true
+    end
+  end
+
   def pagy_tailwind_nav(pagy)
     html = +'<nav class="flex justify-center gap-1" aria-label="Pagination">'
 
@@ -50,10 +81,7 @@ module ApplicationHelper
 
     text = expand_include_macros(text, sectionable:)
 
-    renderer = Redcarpet::Render::HTML.new(
-      hard_wrap: true,
-      link_attributes: { target: '_blank', rel: 'noopener noreferrer' }
-    )
+    renderer = ExternalAwareHtmlRenderer.new(site_host: request.host, hard_wrap: true)
     Redcarpet::Markdown.new(renderer,
                             autolink: true,
                             tables: true,
@@ -63,6 +91,15 @@ module ApplicationHelper
   end
 
   private
+
+  def external_url?(url)
+    return false if url.blank? || url.start_with?('/', '#', 'mailto:')
+    return true unless url.match?(%r{\Ahttps?://})
+
+    URI.parse(url).host != request.host
+  rescue URI::InvalidURIError
+    true
+  end
 
   # {{include key,セクション名}}       → CustomPage (key指定)
   # {{include unit:ID,セクション名}}   → Unit (ID指定)

--- a/app/helpers/wiki_link_helper.rb
+++ b/app/helpers/wiki_link_helper.rb
@@ -273,7 +273,9 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
       display = Regexp.last_match(1)
       url = Regexp.last_match(2)
       link_class = 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline'
-      placeholders[key] = link ? link_to(display, url, target: '_blank', rel: 'noopener noreferrer', class: link_class) : display
+      link_opts = { class: link_class }
+      link_opts.merge!(target: '_blank', rel: 'noopener noreferrer') if external_url?(url)
+      placeholders[key] = link ? link_to(display, url, **link_opts) : display
       key
     end
 
@@ -281,7 +283,9 @@ module WikiLinkHelper # rubocop:disable Metrics/ModuleLength
     if link
       protected_text = protected_text.gsub(URI::DEFAULT_PARSER.make_regexp(%w[http https])) do |match|
         link_class = 'text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300 underline'
-        link_to(match, match, target: '_blank', rel: 'noopener noreferrer', class: link_class)
+        link_opts = { class: link_class }
+        link_opts.merge!(target: '_blank', rel: 'noopener noreferrer') if external_url?(match)
+        link_to(match, match, **link_opts)
       end
     end
 


### PR DESCRIPTION
fixes #784

## 変更内容

カスタムページ（および Markdown / Wiki テキスト全般）のリンクが、サイト内外を問わず一律 `target="_blank"` で別タブ遷移していた問題を修正。

### 修正箇所

**`app/helpers/application_helper.rb`**
- `ExternalAwareHtmlRenderer` を追加（`Redcarpet::Render::HTML` のサブクラス）
  - `link` メソッドをオーバーライド：Markdown の `[text](url)` 形式
  - `autolink` メソッドをオーバーライド：`autolink: true` による裸 URL の自動リンク化
- 外部 URL 判定の共用メソッド `external_url?` を追加（`wiki_link_helper.rb` でも利用）

**`app/helpers/wiki_link_helper.rb`**
- `[Display|URL]` 形式のリンク処理で `external_url?` を使って条件付与
- 生 URL の自動リンク化処理でも同様に条件付与

### 判定ルール

| URL の形式 | 結果 |
|---|---|
| `/` 始まりの相対パス | 同タブ |
| `#` 始まりのアンカー | 同タブ |
| `mailto:` | 同タブ |
| 同一ホストの絶対 URL | 同タブ |
| 別ホストの絶対 URL | 別タブ（`target="_blank" rel="noopener noreferrer"`）|

## テスト手順

1. カスタムページの本文に `/units/123` などの相対パスリンクを Markdown で記述
2. カスタムページを表示してリンクをクリック → 同タブで遷移することを確認
3. 外部リンク（`https://example.com`）は別タブで開くことを確認