### PR TITLE
vkdby.onrender.com へのアクセスを next.vkdb.jp にリダイレクトする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,9 +11,16 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Method
 
+  before_action :redirect_to_canonical_domain
   before_action :load_footer_page
 
   private
+
+  def redirect_to_canonical_domain
+    return unless request.host == "vkdby.onrender.com"
+
+    redirect_to request.url.sub("vkdby.onrender.com", "next.vkdb.jp"), status: :moved_permanently, allow_other_host: true
+  end
 
   def load_footer_page
     @footer_page = CustomPage.published.find_by(key: 'footer')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,9 +17,9 @@ class ApplicationController < ActionController::Base
   private
 
   def redirect_to_canonical_domain
-    return unless request.host == "vkdby.onrender.com"
+    return unless request.host == 'vkdby.onrender.com'
 
-    redirect_to request.url.sub("vkdby.onrender.com", "next.vkdb.jp"), status: :moved_permanently, allow_other_host: true
+    redirect_to request.url.sub('vkdby.onrender.com', 'next.vkdb.jp'), status: :moved_permanently, allow_other_host: true
   end
 
   def load_footer_page


### PR DESCRIPTION
fixes #790

## 変更内容

`ApplicationController` に `before_action :redirect_to_canonical_domain` を追加。

`vkdby.onrender.com` へのリクエストをパスとクエリ文字列を保持したまま `next.vkdb.jp` へ 301 リダイレクトする。

- 対象ホスト: `vkdby.onrender.com` のみ（PR プレビュー URL には影響しない）
- `allow_other_host: true` を指定して Rails のホストチェックをバイパス

## テスト観点

- `vkdby.onrender.com/xxx?q=yyy` → `next.vkdb.jp/xxx?q=yyy` に 301 リダイレクトされること
- `next.vkdb.jp` へのアクセスはリダイレクトされないこと