### PR TITLE
fix: アイテム画像が小さい場合の極端な拡大を防ぐ (#794)

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -14,7 +14,7 @@
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer" do %>
           <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="160px"
                width="160" height="160"
-               alt="<%= @item.title %>" class="w-40 h-40 object-cover hover:opacity-90 transition-opacity">
+               alt="<%= @item.title %>" class="w-40 h-40 object-scale-down hover:opacity-90 transition-opacity">
         <% end %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer",
             style: "position:absolute; bottom:8px; left:50%; transform:translateX(-50%);",
@@ -27,7 +27,7 @@
       <% else %>
         <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="160px"
              width="160" height="160"
-             alt="<%= @item.title %>" class="w-40 h-40 object-cover">
+             alt="<%= @item.title %>" class="w-40 h-40 object-scale-down">
       <% end %>
     </div>
   <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -41,12 +41,12 @@
               <%= link_to amazon_url, target: "_blank", rel: "noopener noreferrer" do %>
                 <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="<%= img_sizes %>"
                      width="256" height="256"
-                     alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-cover shadow-md hover:opacity-90 transition-opacity">
+                     alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-scale-down shadow-md hover:opacity-90 transition-opacity">
               <% end %>
             <% else %>
               <img src="<%= img_src %>" srcset="<%= img_srcset %>" sizes="<%= img_sizes %>"
                    width="256" height="256"
-                   alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-cover shadow-md">
+                   alt="<%= @item.title %>" class="w-64 h-64 sm:w-52 sm:h-52 object-scale-down shadow-md">
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
## Summary

- `object-cover` → `object-scale-down` に変更（詳細ページ・一覧ページ）
- 元画像が小さい場合はネイティブサイズで表示し、大きい場合はコンテナに収まるようスケールダウンする

## 変更ファイル

- `app/views/items/show.html.erb` — 詳細ページの画像
- `app/components/item_card_component.html.erb` — 一覧ページのカード画像

## Test plan

- [ ] 小さい画像を持つアイテム（例: `/items/55547`）で拡大されないことを確認
- [ ] 通常サイズの画像が正常に表示されることを確認
- [ ] 一覧ページ（`/items`）でも同様に確認

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)