### PR TITLE
fix: リンクセクションと Spotify セクションの間に余白を追加 (#797)

### DIFF
--- a/app/components/spotify_embed_component.html.erb
+++ b/app/components/spotify_embed_component.html.erb
@@ -1,5 +1,5 @@
 <% if render? %>
-  <section class="mb-6">
+  <section class="mt-8 mb-6">
     <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
       Spotify
     </h2>


### PR DESCRIPTION
## Summary

- `SpotifyEmbedComponent` のルート要素に `mt-8` を追加し、Links セクションとの間に余白を設ける

## Test plan

- [x] Spotify リンクがあるプロフィールページで、Links セクションと Spotify セクションの間に余白が表示されることを確認

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)