### PR TITLE
fix: モバイルでリンクと Spotify セクションを Update Log 直前に移動 (#796)

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -36,8 +36,10 @@
         <div>
           <%= render BasicAttributesComponent.new(resource: @resource) %>
           <%= render NameHistoryComponent.new(resource: @resource) %>
-          <%= render LinksComponent.new(links: @links) %>
-          <%= render SpotifyEmbedComponent.new(links: @links) %>
+          <div class="hidden md:block">
+            <%= render LinksComponent.new(links: @links) %>
+            <%= render SpotifyEmbedComponent.new(links: @links) %>
+          </div>
           <div class="mt-4">
             <%= render 'layouts/google_adsense_square' %>
           </div>
@@ -168,6 +170,11 @@
       </div>
 
       <%= render SameKanaSuggestionComponent.new(resource: @resource, same_kana_resources: @same_kana_resources, same_kana_total: @same_kana_total) %>
+
+      <div class="md:hidden">
+        <%= render LinksComponent.new(links: @links) %>
+        <%= render SpotifyEmbedComponent.new(links: @links) %>
+      </div>
 
       <section id="update-log" class="mt-8">
         <details class="group"

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,6 +27,9 @@
         <% if @resource.is_a?(Unit) %>
           <a href="#relationship-graph" class="flex items-center py-3 text-xs text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors shrink-0">Graph</a>
         <% end %>
+        <% if @links.present? %>
+          <a href="#links" class="flex items-center py-3 text-xs text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors shrink-0">Links</a>
+        <% end %>
         <a href="#update-log" class="flex items-center py-3 text-xs text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors shrink-0">Update Log</a>
       </div>
     </nav>
@@ -171,7 +174,7 @@
 
       <%= render SameKanaSuggestionComponent.new(resource: @resource, same_kana_resources: @same_kana_resources, same_kana_total: @same_kana_total) %>
 
-      <div class="md:hidden">
+      <div id="links" class="md:hidden">
         <%= render LinksComponent.new(links: @links) %>
         <%= render SpotifyEmbedComponent.new(links: @links) %>
       </div>


### PR DESCRIPTION
## Summary

- `LinksComponent` と `SpotifyEmbedComponent` を左カラムで `hidden md:block` でラップし、デスクトップのみ表示
- `#update-log` 直前に `md:hidden` で同じコンポーネントを追加し、モバイルのみ表示
- モバイル用ページ内ナビに `@links.present?` のときのみ `Links` リンクを追加（Graph 直後、Update Log 直前）
- モバイル用リンクブロックに `id="links"` を付与してアンカーリンクを機能させる

## Test plan

- [ ] モバイル幅（768px 未満）でリンクセクションと Spotify が Update Log の直前に表示されること
- [ ] デスクトップ幅（768px 以上）でリンクセクションと Spotify が左カラムに表示されること
- [ ] デスクトップでリンクセクションが Update Log 直前に重複して表示されないこと
- [ ] モバイルナビに「Links」が表示され、タップするとリンクセクションまでスクロールされること
- [ ] リンクが存在しないプロフィールではナビに「Links」が表示されないこと

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)