### PR TITLE
fix: モバイル広告バナーをレスポンシブ対応に変更

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -11,17 +11,16 @@
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
   </div>
-  <%# Mobile: 320x50 fixed banner (sm未満) %>
-  <div class="sm:hidden flex justify-center adsense-container">
-    <div style="width:320px;overflow:hidden;">
+  <%# Mobile: responsive horizontal banner (sm未満) %>
+  <div class="sm:hidden adsense-container adsense-container--horizontal">
     <ins class="adsbygoogle"
-         style="display:inline-block;width:320px;height:50px"
+         style="display:block"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="2361507820"
-         data-full-width-responsive="false"></ins>
+         data-ad-format="horizontal"
+         data-full-width-responsive="true"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
-    </div>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary

- モバイル向け横長広告バナーが 320×50px 固定サイズで表示域に対して小さく見えていた問題を修正
- `data-full-width-responsive="true"` + `data-ad-format="horizontal"` に変更し、画面幅に合わせたレスポンシブ表示に対応
- 固定幅ラッパー (`width:320px;overflow:hidden`) と `flex justify-center` を削除し、デスクトップ版と同じ構造に統一

## Test plan

- [ ] モバイル幅（375px / 390px 等）で広告バナーが画面幅いっぱいに表示されることを確認
- [ ] デスクトップ幅では従来通りの表示を確認
- [ ] 広告が unfill の場合に非表示になること（`adsense-container--horizontal` クラスによる制御）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)