### PR TITLE
fix: モバイル広告バナーを幅100%・高さ固定50pxに変更

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -11,14 +11,13 @@
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
   </div>
-  <%# Mobile: responsive horizontal banner (sm未満) %>
+  <%# Mobile: full-width fixed-height banner (sm未満) %>
   <div class="sm:hidden adsense-container adsense-container--horizontal">
     <ins class="adsbygoogle"
-         style="display:block"
+         style="display:inline-block;width:100%;height:50px"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="2361507820"
-         data-ad-format="horizontal"
-         data-full-width-responsive="true"></ins>
+         data-full-width-responsive="false"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>


### PR DESCRIPTION
## Summary

- レスポンシブ設定（`data-full-width-responsive="true"`）で大型広告が配信される問題を修正
- `width:100%` で画面幅いっぱいに表示しつつ、`height:50px` 固定で AdSense に50px高のバナー広告を選ばせる
- `data-full-width-responsive="false"` に戻すことで AdSense がコンテナサイズに合わせた広告を選択する

## Test plan

- [ ] モバイル幅で広告が画面幅いっぱいに表示されること
- [ ] 広告の高さが50px程度に収まること（大型広告が表示されないこと）
- [ ] デスクトップ幅では従来通りの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)