### PR TITLE
feat: 管理画面から Unit の destination_key を設定できるようにする (#808)

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -118,7 +118,7 @@ module Admin
     end
 
     def unit_params
-      params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key, :note,
+      params.require(:unit).permit(:name, :name_kana, :key, :status, :unit_type, :old_key, :destination_key, :note,
                                    tag_index_ids: [],
                                    links_attributes: %i[id text url active sort_order _destroy],
                                    name_logs_attributes: %i[name name_kana],

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -31,6 +31,12 @@
   </div>
 
   <div>
+    <%= form.label :destination_key, "転送先キー (destination_key)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <%= form.text_field :destination_key, placeholder: "統合先 Unit の key（旧URL転送用）", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">設定すると <code>/profile/{key}</code> へのアクセスが <code>/profile/{destination_key}</code> へ 301 リダイレクトされます。Unit のマージ・統合時に使用。</p>
+  </div>
+
+  <div>
     <%= form.label :unit_type, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <div class="mt-2 space-x-4">
       <% Unit.unit_types.keys.each do |type| %>


### PR DESCRIPTION
## Summary

- `Admin::UnitsController#unit_params` に `destination_key` を追加
- Unit 編集フォームに `destination_key` 入力欄を追加（`old_key` の直下）
- フィールドには用途の説明文を表示（301リダイレクトの仕様）

## Test plan

- [ ] Unit 編集画面で `destination_key` フィールドが表示されること
- [ ] `destination_key` を入力して保存すると DB に反映されること
- [ ] 設定後、`/profile/{key}` へアクセスすると `/profile/{destination_key}` へ 301 リダイレクトされること
- [ ] 空欄で保存すると `destination_key` がクリアされること

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)