### PR TITLE
feat: Person にも destination_key によるリダイレクト機能を追加する (#810)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -102,7 +102,7 @@ module Admin
 
     def person_params
       params.require(:person).permit(
-        :name, :name_kana, :birthday, :birth_year, :blood, :hometown, :status, :old_history, :note,
+        :name, :name_kana, :birthday, :birth_year, :blood, :hometown, :status, :old_history, :destination_key, :note,
         parts: [],
         tag_index_ids: [],
         links_attributes: %i[id text url active _destroy],

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,7 @@ class ProfilesController < ApplicationController
     @resource = Unit.kept.includes(:links).find_by(key: params[:key]) ||
                 Person.kept.includes(:links).find_by!(key: params[:key])
 
-    if @resource.is_a?(Unit) && @resource.destination_key.present?
+    if @resource.destination_key.present?
       redirect_to profile_path(@resource.destination_key), status: :moved_permanently
       return
     end

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -90,6 +90,12 @@
         </div>
       </div>
 
+      <div>
+        <%= form.label :destination_key, "転送先キー (destination_key)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+        <%= form.text_field :destination_key, placeholder: "統合先 Person の key（旧URL転送用）", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-2 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">設定すると <code>/profile/{key}</code> へのアクセスが <code>/profile/{destination_key}</code> へ 301 リダイレクトされます。Person のマージ・統合時に使用。</p>
+      </div>
+
       <div class="grid grid-cols-2 gap-4">
         <div>
           <%= form.label :birthday, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>

--- a/db/migrate/20260704033215_add_destination_key_to_people.rb
+++ b/db/migrate/20260704033215_add_destination_key_to_people.rb
@@ -1,0 +1,5 @@
+class AddDestinationKeyToPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_column :people, :destination_key, :string
+  end
+end

--- a/db/migrate/20260704033215_add_destination_key_to_people.rb
+++ b/db/migrate/20260704033215_add_destination_key_to_people.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDestinationKeyToPeople < ActiveRecord::Migration[8.1]
   def change
     add_column :people, :destination_key, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_125835) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_033215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_125835) do
     t.date "birthday"
     t.string "blood"
     t.datetime "created_at", null: false
+    t.string "destination_key"
     t.datetime "discarded_at"
     t.string "hometown"
     t.string "key"

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -1,0 +1,106 @@
+# リダイレクト仕様
+
+旧URLから新URLへのリダイレクト処理の仕様をまとめたドキュメント。
+
+## リダイレクト一覧
+
+| 旧URLパターン | 新URLパターン | ステータス | 担当 |
+|---|---|---|---|
+| `/{old_key}.html` | `/profile/{key}` | 301 | `LegacyRedirectsController#show` |
+| `/NEWS_{id}` | `/trends/{id}` | 301 | `LegacyRedirectsController#news_redirect` |
+| `/ITEM_{asin}` | `/items/{id}` | 301 | `LegacyRedirectsController#item_redirect` |
+| `/profile/{unit_key}` (destination_key あり) | `/profile/{destination_key}` | 301 | `ProfilesController#show` |
+| `/profile/{person_key}` (destination_key あり) | `/profile/{destination_key}` | 301 | `ProfilesController#show` |
+
+---
+
+## 各リダイレクトの詳細
+
+### 1. `.html` 拡張子つきURL → プロフィールページ
+
+**旧URL形式:** `/{old_key}.html`  
+**新URL形式:** `/profile/{key}`
+
+旧システムで使われていた `.html` 拡張子付きURLを、現行プロフィールページへ転送する。
+
+**検索順序（Unit → Person の順で探す）:**
+
+1. `Unit.old_key` が一致
+2. `Unit.old_key` がURLエンコード済み old_key と一致
+3. `Unit.aliases` 配列内の `old_key` フィールドが一致
+4. `Unit.aliases` 配列内の `old_key` フィールドがURLエンコード済み old_key と一致
+5. 上記4パターンを Person でも同様に確認
+
+**見つからない場合:** 404ページを表示（EUC-JP デコードを試みてユニット名を表示）
+
+**Canonicalヘッダー:** リダイレクト時に `Link: <新URL>; rel="canonical"` レスポンスヘッダーを付与
+
+**関連ファイル:**
+- [config/routes.rb:168](../config/routes.rb) — ルート定義
+- [app/controllers/legacy_redirects_controller.rb:4](../app/controllers/legacy_redirects_controller.rb) — 処理実装
+
+---
+
+### 2. `/NEWS_{id}` → トレンドページ
+
+**旧URL形式:** `/NEWS_{id}`（id は数字）  
+**新URL形式:** `/trends/{id}`
+
+旧システムのニュースURL（NEWS_123 形式）を現行のトレンドページへ転送する。Trend の ID はそのまま引き継ぐ。
+
+**見つからない場合:** 404ページを表示
+
+**関連ファイル:**
+- [config/routes.rb:171](../config/routes.rb) — ルート定義
+- [app/controllers/legacy_redirects_controller.rb:42](../app/controllers/legacy_redirects_controller.rb) — 処理実装
+
+---
+
+### 3. `/ITEM_{asin}` → アイテムページ
+
+**旧URL形式:** `/ITEM_{asin}`（asin は英大文字・数字）  
+**新URL形式:** `/items/{id}`
+
+旧システムのアイテムURL（ITEM_B001234567 形式）を現行のアイテムページへ転送する。ASIN コードで Item を検索し、Item の ID で新URLを生成する。
+
+**見つからない場合:** 404ページを表示
+
+**関連ファイル:**
+- [config/routes.rb:174](../config/routes.rb) — ルート定義
+- [app/controllers/legacy_redirects_controller.rb:51](../app/controllers/legacy_redirects_controller.rb) — 処理実装
+
+---
+
+### 4. `destination_key` によるプロフィール転送（Unit / Person 共通）
+
+**旧URL形式:** `/profile/{key}`  
+**新URL形式:** `/profile/{destination_key}`
+
+Unit または Person のマージ・統合時に使用。`destination_key` が設定されている場合、統合先のプロフィールページへ転送する。Unit・Person どちらにも対応。
+
+**条件:** `destination_key` が存在する場合のみ発動（Unit・Person 共通の処理）
+
+**関連ファイル:**
+- [app/controllers/profiles_controller.rb:8](../app/controllers/profiles_controller.rb) — 処理実装
+- `units.destination_key` カラム（migration: `20260328031736_add_destination_key_to_units.rb`）
+- `people.destination_key` カラム（migration: `20260704033215_add_destination_key_to_people.rb`）
+
+---
+
+## EUC-JP URLのデコード処理
+
+旧システムのURLが EUC-JP エンコードされている場合に対応するためのミドルウェアが存在する。
+
+**ミドルウェア:** `Middleware::EucJpUrlFixer`  
+**挿入位置:** Rackミドルウェアスタックの先頭（`ActionableExceptions` より前）
+
+**処理内容:**
+
+1. **無効な UTF-8 バイト列:** `PATH_INFO` に無効な UTF-8 が含まれる場合、高ビットバイトを `%25HH` 形式に変換
+2. **EUC-JP エンコード済みURL:** `%80`〜`%FF` のパターンを `%25HH` に二重エンコードし、Rails のデコード後も `%HH` 文字列として保持
+
+**対象:** GET・HEAD リクエストのみ。`/admin` ルートはスキップ。
+
+**関連ファイル:**
+- [lib/middleware/euc_jp_url_fixer.rb](../lib/middleware/euc_jp_url_fixer.rb)
+- [config/application.rb:26](../config/application.rb)


### PR DESCRIPTION
## Summary

- `people` テーブルに `destination_key` カラムを追加（マイグレーション）
- `ProfilesController#show` の `destination_key` チェックを Unit 限定から Unit/Person 共通に変更
- 管理画面の Person 編集フォームに `destination_key` 入力欄を追加
- `Admin::PeopleController#person_params` に `destination_key` を追加
- `docs/redirects.md` を Person 対応に合わせて更新

## Test plan

- [ ] Person 編集画面で `destination_key` フィールドが表示されること
- [ ] `destination_key` を入力して保存すると DB に反映されること
- [ ] 設定後、`/profile/{key}` へアクセスすると `/profile/{destination_key}` へ 301 リダイレクトされること
- [ ] 空欄で保存すると `destination_key` がクリアされること
- [ ] Unit の既存リダイレクト動作が変わらないこと

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)