### PR TITLE
feat: Artistsサジェストで destination_key 設定済みを選択時に転送先を自動選択 (#813)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -90,7 +90,7 @@ module Admin
       @people = scope.limit(10).order(:name)
 
       render json: @people.map { |p|
-        { id: p.id, name: p.name.presence || p.key, name_kana: p.name_kana, key: p.key }
+        { id: p.id, name: p.name.presence || p.key, name_kana: p.name_kana, key: p.key, destination_key: p.destination_key }
       }
     end
 

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -108,7 +108,7 @@ module Admin
 
       @units = scope.limit(10).order(:name)
 
-      render json: @units.map { |u| { id: u.id, name: u.name, name_kana: u.name_kana, key: u.key } }
+      render json: @units.map { |u| { id: u.id, name: u.name, name_kana: u.name_kana, key: u.key, destination_key: u.destination_key } }
     end
 
     private

--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -202,22 +202,44 @@ export default class extends Controller {
            data-active="false"
            data-action="click->artist-rows#selectItem"
            data-name="${this.escapeHtml(item.name)}"
-           data-key="${this.escapeHtml(item.key || "")}">
+           data-key="${this.escapeHtml(item.key || "")}"
+           data-destination-key="${this.escapeHtml(item.destination_key || "")}">
         <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
         ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ""}
+        ${item.destination_key ? `<div class="text-xs text-amber-600 dark:text-amber-400">→ ${this.escapeHtml(item.destination_key)}</div>` : ""}
       </div>
     `).join("")
 
     resultsEl.classList.remove("hidden")
   }
 
-  selectItem(event) {
+  async selectItem(event) {
     const resultItem = event.currentTarget
     const row = resultItem.closest("[data-artist-rows-target='row']")
-    const name = resultItem.dataset.name
-    const key = resultItem.dataset.key || ""
+    const destinationKey = resultItem.dataset.destinationKey || ""
     const mode = row.dataset.mode || "unit"
 
+    if (destinationKey) {
+      const url = mode === "unit" ? this.urlUnitsValue : this.urlPeopleValue
+      try {
+        const response = await fetch(`${url}?q=${encodeURIComponent(destinationKey)}`, {
+          headers: { "Accept": "application/json", "X-Requested-With": "XMLHttpRequest" }
+        })
+        const data = await response.json()
+        const dest = data.find(item => item.key === destinationKey)
+        if (dest) {
+          this.applySelection(row, dest.name, dest.key, mode)
+          return
+        }
+      } catch (e) {
+        console.error("Destination key resolution failed", e)
+      }
+    }
+
+    this.applySelection(row, resultItem.dataset.name, resultItem.dataset.key || "", mode)
+  }
+
+  applySelection(row, name, key, mode) {
     row.querySelector(".artist-name-hidden").value = name
     row.querySelector(".artist-key-hidden").value = key
 

--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -246,7 +246,7 @@ export default class extends Controller {
     const selectedDisplay = row.querySelector(".artist-selected-display")
     const nameEl = selectedDisplay.querySelector(".artist-name-display")
     if (key) {
-      nameEl.innerHTML = `<a href="/profile/${this.escapeHtml(key)}" target="_blank" class="hover:underline">${this.escapeHtml(name)}</a>`
+      nameEl.innerHTML = `<a href="/${this.escapeHtml(key)}" target="_blank" class="hover:underline">${this.escapeHtml(name)}</a>`
     } else {
       nameEl.textContent = name
     }

--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -244,7 +244,12 @@ export default class extends Controller {
     row.querySelector(".artist-key-hidden").value = key
 
     const selectedDisplay = row.querySelector(".artist-selected-display")
-    selectedDisplay.querySelector(".artist-name-display").textContent = name
+    const nameEl = selectedDisplay.querySelector(".artist-name-display")
+    if (key) {
+      nameEl.innerHTML = `<a href="/profile/${this.escapeHtml(key)}" target="_blank" class="hover:underline">${this.escapeHtml(name)}</a>`
+    } else {
+      nameEl.textContent = name
+    }
     selectedDisplay.querySelector(".artist-chip").className = mode === "person" ? PERSON_CHIP_CLASS : UNIT_CHIP_CLASS
     selectedDisplay.classList.remove("hidden")
     selectedDisplay.classList.add("flex")

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -65,7 +65,13 @@
           <%# Selected display (visible only when already selected) %>
           <div class="artist-selected-display flex-1 <%= search_mode ? 'items-center hidden' : 'flex items-center' %>">
             <span class="artist-chip inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200">
-              <span class="artist-name-display"><%= artist['name'] %></span>
+              <span class="artist-name-display">
+                <% if artist['key'].present? %>
+                  <a href="/profile/<%= artist['key'] %>" target="_blank" class="hover:underline"><%= artist['name'] %></a>
+                <% else %>
+                  <%= artist['name'] %>
+                <% end %>
+              </span>
               <button type="button"
                       class="hover:text-red-600"
                       data-action="click->artist-rows#clearSelection">×</button>

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -67,7 +67,7 @@
             <span class="artist-chip inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200">
               <span class="artist-name-display">
                 <% if artist['key'].present? %>
-                  <a href="/profile/<%= artist['key'] %>" target="_blank" class="hover:underline"><%= artist['name'] %></a>
+                  <a href="/<%= artist['key'] %>" target="_blank" class="hover:underline"><%= artist['name'] %></a>
                 <% else %>
                   <%= artist['name'] %>
                 <% end %>


### PR DESCRIPTION
## Summary

- 検索 API（Units / People）のレスポンスに `destination_key` を追加
- 候補一覧に `destination_key` が設定されている場合、転送先キーをアンバー色で表示
- 選択時に `destination_key` があれば転送先エンティティを取得して自動的に差し替え
- `selectItem` から表示ロジックを `applySelection` に切り出して再利用

## 動作フロー

1. 統合済み Unit/Person を検索すると候補に `→ destination_key` が表示される
2. その候補を選択すると、転送先の Unit/Person を自動取得して選択状態にする

## Test plan

- [ ] `destination_key` が設定されていない Unit/Person は従来通り選択できること
- [ ] `destination_key` が設定されている Unit を選択すると転送先 Unit が選ばれること
- [ ] `destination_key` が設定されている Person を選択すると転送先 Person が選ばれること
- [ ] 候補リストに転送先キーがアンバー色で表示されること
- [ ] 転送先の取得に失敗した場合は元のエンティティが選択されること

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)