### PR TITLE
fix: 論理削除済みUnit/PersonでもdestinationKeyがあれば301リダイレクト (#818)

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,7 +3,17 @@
 class ProfilesController < ApplicationController
   def show
     @resource = Unit.kept.includes(:links).find_by(key: params[:key]) ||
-                Person.kept.includes(:links).find_by!(key: params[:key])
+                Person.kept.includes(:links).find_by(key: params[:key])
+
+    if @resource.nil?
+      discarded = Unit.with_discarded.find_by(key: params[:key], discarded_at: ..Time.current) ||
+                  Person.with_discarded.find_by(key: params[:key], discarded_at: ..Time.current)
+      if discarded&.destination_key.present?
+        redirect_to profile_path(discarded.destination_key), status: :moved_permanently
+        return
+      end
+      raise ActiveRecord::RecordNotFound
+    end
 
     if @resource.destination_key.present?
       redirect_to profile_path(@resource.destination_key), status: :moved_permanently

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,23 +2,17 @@
 
 class ProfilesController < ApplicationController
   def show
-    @resource = Unit.kept.includes(:links).find_by(key: params[:key]) ||
-                Person.kept.includes(:links).find_by(key: params[:key])
+    @resource = Unit.with_discarded.includes(:links).find_by(key: params[:key]) ||
+                Person.with_discarded.includes(:links).find_by(key: params[:key])
 
-    if @resource.nil?
-      discarded = Unit.with_discarded.find_by(key: params[:key], discarded_at: ..Time.current) ||
-                  Person.with_discarded.find_by(key: params[:key], discarded_at: ..Time.current)
-      if discarded&.destination_key.present?
-        redirect_to profile_path(discarded.destination_key), status: :moved_permanently
-        return
-      end
-      raise ActiveRecord::RecordNotFound
-    end
+    raise ActiveRecord::RecordNotFound unless @resource
 
     if @resource.destination_key.present?
       redirect_to profile_path(@resource.destination_key), status: :moved_permanently
       return
     end
+
+    raise ActiveRecord::RecordNotFound if @resource.discarded?
 
     @links = @resource.links.where(active: true).order(:sort_order)
 


### PR DESCRIPTION
## 問題

`ProfilesController#show` が `kept` スコープのみで検索するため、`destination_key` を設定して discard した Unit/Person の旧URLが 404 になっていた。

## 修正

`with_discarded` で検索を一本化し、以下の順で判定するよう変更：

1. レコードが存在しない → 404
2. `destination_key` が設定されている → 301 リダイレクト（kept / discarded 問わず）
3. `discarded?` → 404
4. 通常表示

`kept` → `with_discarded` の二段クエリをやめることでクエリ数を削減し、コードもシンプルになった。

## Test plan

- [ ] 通常（kept）の Unit/Person は従来通りアクセスできること
- [ ] `destination_key` なしで discard した Unit/Person は 404 になること
- [ ] `destination_key` を設定して discard した Unit にアクセスすると転送先へ 301 リダイレクトされること
- [ ] `destination_key` を設定して discard した Person にアクセスすると転送先へ 301 リダイレクトされること
- [ ] `destination_key` が設定されている kept の Unit/Person も従来通りリダイレクトされること

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)