### PR TITLE
feat: People/Unit管理画面の一覧にdestination_keyをリンク付きで表示 (#820)

### DIFF
--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -60,6 +60,9 @@
               <% else %>
                 <span class="text-gray-400 italic">No Key</span>
               <% end %>
+              <% if person.destination_key.present? %>
+                <div class="text-xs text-amber-600 dark:text-amber-400 mt-0.5">→ <%= link_to person.destination_key, profile_path(person.destination_key), class: "hover:underline", target: "_blank" %></div>
+              <% end %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
               <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -79,7 +79,7 @@
               <% else %>
                 <%= link_to "Edit", edit_admin_person_path(person), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
                 <% if current_user.super_operator_or_above? %>
-                  <%= button_to "Delete", admin_person_path(person), method: :delete,
+                  <%= button_to "論理削除", admin_person_path(person), method: :delete,
                     form_class: "inline",
                     onclick: "return confirm('Are you sure?')",
                     class: "text-red-600 hover:text-red-900 bg-transparent border-0 cursor-pointer p-0" %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -79,7 +79,7 @@
                 <%= link_to "Logs", admin_unit_unit_logs_path(unit), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
                 <%= link_to "Edit", edit_admin_unit_path(unit), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
                 <% if current_user.super_operator_or_above? %>
-                  <%= button_to "Delete", admin_unit_path(unit), method: :delete,
+                  <%= button_to "論理削除", admin_unit_path(unit), method: :delete,
                     form_class: "inline",
                     onclick: "return confirm('Are you sure?')",
                     class: "text-red-600 hover:text-red-900 bg-transparent border-0 cursor-pointer p-0" %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -59,6 +59,9 @@
             </td>
             <td class="px-6 py-4 text-sm text-gray-500 max-w-xs break-all">
               <%= link_to unit.key, profile_path(unit.key), class: "text-indigo-600 hover:text-indigo-900", target: "_blank" %>
+              <% if unit.destination_key.present? %>
+                <div class="text-xs text-amber-600 dark:text-amber-400 mt-0.5">→ <%= link_to unit.destination_key, profile_path(unit.destination_key), class: "hover:underline", target: "_blank" %></div>
+              <% end %>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
               <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">


### PR DESCRIPTION
## Summary

- Unit・People 管理画面の一覧で、Key 列の下に `destination_key` をアンバー色で表示
- `destination_key` はプロフィールページへのリンク（別タブ）
- 設定がない場合は表示しない

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)