### PR TITLE
feat: People/Unit一覧に「リダイレクト元」フィルターとdestination_keyインデックスを追加 (#822)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -9,10 +9,15 @@ module Admin
       @q = params[:q]
       @tag_index_id = params[:tag_index_id]
       @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
-      scope = case @show_discarded
-              when 'only' then Person.discarded
-              when 'all'  then Person.with_discarded
-              else             Person.kept
+      @redirect_source = params[:redirect_source]
+      scope = if @redirect_source == 'only'
+                Person.with_discarded.where.not(destination_key: nil)
+              else
+                case @show_discarded
+                when 'only' then Person.discarded
+                when 'all'  then Person.with_discarded
+                else             Person.kept
+                end
               end
       if @q.present?
         scope = scope.where(

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -12,12 +12,15 @@ module Admin
       @tag_index_id = params[:tag_index_id]
       @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
       @unit_type_filter = params[:unit_type]
+      @redirect_source = params[:redirect_source]
       scope = case @show_discarded
               when 'only' then Unit.discarded
               when 'all'  then Unit.with_discarded
               else             Unit.kept
               end
-      if @unit_type_filter == 'moved'
+      if @redirect_source == 'only'
+        scope = Unit.with_discarded.where.not(destination_key: nil)
+      elsif @unit_type_filter == 'moved'
         scope = scope.where(unit_type: :moved)
       elsif @show_discarded.blank? && @tag_index_id.blank?
         scope = scope.where.not(unit_type: :moved)

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -18,6 +18,13 @@
     </div>
   <% end %>
 
+  <div class="flex space-x-2 mb-3 border-b border-gray-200 pb-3">
+    <%= link_to "Unit管理", admin_units_path,
+        class: "px-4 py-1.5 rounded-t text-sm font-medium text-gray-500 hover:text-gray-700" %>
+    <%= link_to "People管理", admin_people_path,
+        class: "px-4 py-1.5 rounded-t text-sm font-medium border-b-2 border-indigo-600 text-indigo-600" %>
+  </div>
+
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_people_path(q: params[:q]),
         class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? && params[:redirect_source].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -20,11 +20,13 @@
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_people_path(q: params[:q]),
-        class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? && params[:redirect_source].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "削除済みのみ", admin_people_path(q: params[:q], discarded: "only"),
         class: "px-3 py-1 rounded text-sm #{params[:discarded] == 'only' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "全件", admin_people_path(q: params[:q], discarded: "all"),
         class: "px-3 py-1 rounded text-sm #{params[:discarded] == 'all' ? 'bg-gray-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+    <%= link_to "リダイレクト元", admin_people_path(q: params[:q], redirect_source: "only"),
+        class: "px-3 py-1 rounded text-sm #{params[:redirect_source] == 'only' ? 'bg-amber-500 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
   </div>
 
   <div class="mb-4">

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -1,6 +1,10 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0">People Management</h1>
+    <div class="flex items-center gap-3 mb-4 md:mb-0">
+      <h1 class="text-2xl font-bold">People Management</h1>
+      <%= link_to "Unit管理", admin_units_path,
+          class: "text-sm text-gray-500 hover:text-indigo-600 hover:underline" %>
+    </div>
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_people_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.hidden_field :discarded, value: params[:discarded] %>
@@ -17,13 +21,6 @@
       <%= link_to "フィルター解除", admin_people_path, class: "text-indigo-600 hover:text-indigo-800 underline" %>
     </div>
   <% end %>
-
-  <div class="flex space-x-2 mb-3 border-b border-gray-200 pb-3">
-    <%= link_to "Unit管理", admin_units_path,
-        class: "px-4 py-1.5 rounded-t text-sm font-medium text-gray-500 hover:text-gray-700" %>
-    <%= link_to "People管理", admin_people_path,
-        class: "px-4 py-1.5 rounded-t text-sm font-medium border-b-2 border-indigo-600 text-indigo-600" %>
-  </div>
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_people_path(q: params[:q]),

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
     <div class="flex items-center gap-3 mb-4 md:mb-0">
-      <h1 class="text-2xl font-bold">People Management</h1>
+      <h1 class="text-2xl font-bold">People管理</h1>
       <%= link_to "Unit管理", admin_units_path,
           class: "text-sm text-gray-500 hover:text-indigo-600 hover:underline" %>
     </div>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -19,6 +19,13 @@
     </div>
   <% end %>
 
+  <div class="flex space-x-2 mb-3 border-b border-gray-200 pb-3">
+    <%= link_to "Unit管理", admin_units_path,
+        class: "px-4 py-1.5 rounded-t text-sm font-medium border-b-2 border-indigo-600 text-indigo-600" %>
+    <%= link_to "People管理", admin_people_path,
+        class: "px-4 py-1.5 rounded-t text-sm font-medium text-gray-500 hover:text-gray-700" %>
+  </div>
+
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_units_path(q: params[:q]),
         class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? && params[:unit_type].blank? && params[:redirect_source].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -1,6 +1,10 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0">Unit Management</h1>
+    <div class="flex items-center gap-3 mb-4 md:mb-0">
+      <h1 class="text-2xl font-bold">Unit Management</h1>
+      <%= link_to "People管理", admin_people_path,
+          class: "text-sm text-gray-500 hover:text-indigo-600 hover:underline" %>
+    </div>
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_units_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.hidden_field :discarded, value: params[:discarded] %>
@@ -18,13 +22,6 @@
       <%= link_to "フィルター解除", admin_units_path, class: "text-indigo-600 hover:text-indigo-800 underline" %>
     </div>
   <% end %>
-
-  <div class="flex space-x-2 mb-3 border-b border-gray-200 pb-3">
-    <%= link_to "Unit管理", admin_units_path,
-        class: "px-4 py-1.5 rounded-t text-sm font-medium border-b-2 border-indigo-600 text-indigo-600" %>
-    <%= link_to "People管理", admin_people_path,
-        class: "px-4 py-1.5 rounded-t text-sm font-medium text-gray-500 hover:text-gray-700" %>
-  </div>
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_units_path(q: params[:q]),

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
     <div class="flex items-center gap-3 mb-4 md:mb-0">
-      <h1 class="text-2xl font-bold">Unit Management</h1>
+      <h1 class="text-2xl font-bold">Unit管理</h1>
       <%= link_to "People管理", admin_people_path,
           class: "text-sm text-gray-500 hover:text-indigo-600 hover:underline" %>
     </div>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -21,13 +21,15 @@
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_units_path(q: params[:q]),
-        class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? && params[:unit_type].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        class: "px-3 py-1 rounded text-sm #{params[:discarded].blank? && params[:unit_type].blank? && params[:redirect_source].blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "moved のみ", admin_units_path(q: params[:q], unit_type: "moved"),
         class: "px-3 py-1 rounded text-sm #{params[:unit_type] == 'moved' ? 'bg-amber-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "削除済みのみ", admin_units_path(q: params[:q], discarded: "only"),
         class: "px-3 py-1 rounded text-sm #{params[:discarded] == 'only' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
     <%= link_to "全件", admin_units_path(q: params[:q], discarded: "all"),
         class: "px-3 py-1 rounded text-sm #{params[:discarded] == 'all' ? 'bg-gray-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+    <%= link_to "リダイレクト元", admin_units_path(q: params[:q], redirect_source: "only"),
+        class: "px-3 py-1 rounded text-sm #{params[:redirect_source] == 'only' ? 'bg-amber-500 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
   </div>
 
   <div class="mb-4">

--- a/db/migrate/20260704064057_add_index_on_destination_key_to_people_and_units.rb
+++ b/db/migrate/20260704064057_add_index_on_destination_key_to_people_and_units.rb
@@ -2,7 +2,7 @@
 
 class AddIndexOnDestinationKeyToPeopleAndUnits < ActiveRecord::Migration[8.1]
   def change
-    add_index :units, :destination_key, where: "destination_key IS NOT NULL"
-    add_index :people, :destination_key, where: "destination_key IS NOT NULL"
+    add_index :units, :destination_key, where: 'destination_key IS NOT NULL'
+    add_index :people, :destination_key, where: 'destination_key IS NOT NULL'
   end
 end

--- a/db/migrate/20260704064057_add_index_on_destination_key_to_people_and_units.rb
+++ b/db/migrate/20260704064057_add_index_on_destination_key_to_people_and_units.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexOnDestinationKeyToPeopleAndUnits < ActiveRecord::Migration[8.1]
+  def change
+    add_index :units, :destination_key, where: "destination_key IS NOT NULL"
+    add_index :people, :destination_key, where: "destination_key IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_033215) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_064057) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -152,6 +152,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_033215) do
     t.integer "status", default: 1, null: false
     t.datetime "updated_at", null: false
     t.index ["aliases"], name: "index_people_on_aliases", using: :gin
+    t.index ["destination_key"], name: "index_people_on_destination_key", where: "(destination_key IS NOT NULL)"
     t.index ["discarded_at"], name: "index_people_on_discarded_at"
     t.index ["key"], name: "index_people_on_key", unique: true
     t.index ["name"], name: "index_people_on_name", opclass: :gin_trgm_ops, using: :gin
@@ -343,6 +344,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_033215) do
     t.integer "unit_type"
     t.datetime "updated_at", null: false
     t.index ["aliases"], name: "index_units_on_aliases", using: :gin
+    t.index ["destination_key"], name: "index_units_on_destination_key", where: "(destination_key IS NOT NULL)"
     t.index ["discarded_at"], name: "index_units_on_discarded_at"
     t.index ["key"], name: "index_units_on_key", unique: true
     t.index ["name"], name: "index_units_on_name", opclass: :gin_trgm_ops, using: :gin


### PR DESCRIPTION
## Summary

- `units.destination_key` / `people.destination_key` に部分インデックス（`WHERE destination_key IS NOT NULL`）を追加
- Unit・People 管理画面の一覧フィルターに「リダイレクト元」ボタンを追加
  - `destination_key` が設定されているレコードを kept/discarded 問わず表示
  - アクティブ時はアンバー色で強調
- Unit管理・People管理の画面タイトルを「◯◯管理」に統一
- タイトル横に相互ナビゲーションリンクを追加（Unit管理 ↔ People管理）

## Test plan

- [ ] 「リダイレクト元」ボタンを押すと `destination_key` が設定されたレコードのみ表示されること
- [ ] kept・discarded 両方のレコードが表示されること
- [ ] 他のフィルター（通常・削除済みのみ・全件）との切り替えが正しく動作すること
- [ ] 検索クエリと組み合わせて絞り込めること
- [ ] Unit管理からPeople管理、People管理からUnit管理へリンクで移動できること

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)