### PR TITLE
feat: People編集画面に論理削除ボタンを追加 (#559)

### DIFF
--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -14,11 +14,11 @@
         <%= render "links_form", person: @person %>
         <%= render "admin/sections/list", sectionable: @person, sections: @person.sections.with_discarded.order(:sort_order) %>
         <% if current_user.super_operator_or_above? && !@person.discarded? %>
-          <div class="mt-4 pt-4 border-t border-gray-200">
+          <div class="mt-4 mb-4 flex justify-end">
             <%= button_to "論理削除", admin_person_path(@person), method: :delete,
                 form_class: "inline",
                 onclick: "return confirm('#{@person.name} を論理削除しますか？')",
-                class: "w-full px-3 py-2 text-sm text-red-600 hover:text-red-900 border border-red-300 rounded hover:bg-red-50 bg-transparent cursor-pointer" %>
+                class: "px-3 py-1.5 text-sm text-white bg-red-600 hover:bg-red-700 rounded cursor-pointer border-0" %>
           </div>
         <% end %>
         <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports, import_target: @person %>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -2,7 +2,15 @@
   <div class="max-w-7xl mx-auto">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold dark:text-white">Edit Person: <%= @person.name %></h1>
-      <%= link_to "Back to Public Page", profile_path(@person.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+      <div class="flex items-center gap-4">
+        <%= link_to "Back to Public Page", profile_path(@person.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+        <% if current_user.super_operator_or_above? && !@person.discarded? %>
+          <%= button_to "論理削除", admin_person_path(@person), method: :delete,
+              form_class: "inline",
+              onclick: "return confirm('#{@person.name} を論理削除しますか？')",
+              class: "px-3 py-1.5 text-sm text-red-600 hover:text-red-900 border border-red-300 rounded hover:bg-red-50 bg-transparent cursor-pointer" %>
+        <% end %>
+      </div>
     </div>
     
     <div class="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-8 items-start">

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -2,17 +2,9 @@
   <div class="max-w-7xl mx-auto">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold dark:text-white">Edit Person: <%= @person.name %></h1>
-      <div class="flex items-center gap-4">
-        <%= link_to "Back to Public Page", profile_path(@person.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
-        <% if current_user.super_operator_or_above? && !@person.discarded? %>
-          <%= button_to "論理削除", admin_person_path(@person), method: :delete,
-              form_class: "inline",
-              onclick: "return confirm('#{@person.name} を論理削除しますか？')",
-              class: "px-3 py-1.5 text-sm text-red-600 hover:text-red-900 border border-red-300 rounded hover:bg-red-50 bg-transparent cursor-pointer" %>
-        <% end %>
-      </div>
+      <%= link_to "Back to Public Page", profile_path(@person.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
-    
+
     <div class="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-8 items-start">
       <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
         <%= render "form", person: @person %>
@@ -21,6 +13,14 @@
       <div>
         <%= render "links_form", person: @person %>
         <%= render "admin/sections/list", sectionable: @person, sections: @person.sections.with_discarded.order(:sort_order) %>
+        <% if current_user.super_operator_or_above? && !@person.discarded? %>
+          <div class="mt-4 pt-4 border-t border-gray-200">
+            <%= button_to "論理削除", admin_person_path(@person), method: :delete,
+                form_class: "inline",
+                onclick: "return confirm('#{@person.name} を論理削除しますか？')",
+                class: "w-full px-3 py-2 text-sm text-red-600 hover:text-red-900 border border-red-300 rounded hover:bg-red-50 bg-transparent cursor-pointer" %>
+          </div>
+        <% end %>
         <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports, import_target: @person %>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- `admin/people/edit` のヘッダー右側に論理削除ボタンを追加
- `super_operator_or_above?` かつ未削除のレコードのみ表示
- 確認ダイアログ（`return confirm(...)`）あり
- 論理削除済みの場合はボタン非表示（復元は一覧画面から）

## Test plan

- [ ] `super_operator_or_above?` ユーザーに論理削除ボタンが表示されること
- [ ] それ以外のロールには表示されないこと
- [ ] 既に論理削除済みのレコードではボタンが表示されないこと
- [ ] ボタン押下で確認ダイアログが表示され、OKで論理削除されること
- [ ] 論理削除後に一覧画面にリダイレクトされること

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)