### PR TITLE
feat: 検索画面の下部にAdSenseレスポンシブ広告を追加 (#827)

### DIFF
--- a/app/views/layouts/_google_adsense_responsive.html.erb
+++ b/app/views/layouts/_google_adsense_responsive.html.erb
@@ -1,0 +1,13 @@
+<% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
+  <div class="adsense-container">
+    <ins class="adsbygoogle"
+         style="display:block"
+         data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
+         data-ad-slot="9008168033"
+         data-ad-format="auto"
+         data-full-width-responsive="true"></ins>
+    <script>
+      (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+  </div>
+<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -74,5 +74,9 @@
         <p class="text-slate-400 dark:text-slate-500 font-bold">検索キーワードを入力してください</p>
       </div>
     <% end %>
+
+    <div class="mt-8">
+      <%= render "layouts/google_adsense_responsive" %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- `layouts/_google_adsense_responsive` パーシャルを新規作成（slot: `9008168033`、レスポンシブ・サイズ制限なし）
- `/search` 画面のコンテンツ末尾に広告を追加
  - 検索前・検索結果あり・検索結果なし、すべての状態で表示

## Test plan

- [ ] 検索前（クエリなし）の状態で広告枠が表示されること
- [ ] 検索結果がある状態で広告枠が表示されること
- [ ] 検索結果がない状態で広告枠が表示されること
- [ ] ログイン中は広告が表示されないこと

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)