### PR TITLE
fix: AdSenseバナーによる右側余白を修正 (#831)

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -1,12 +1,12 @@
 <% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
   <%# Desktop: horizontal banner (sm以上) %>
-  <div class="hidden sm:block max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container adsense-container--horizontal">
+  <div class="hidden sm:block max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container adsense-container--horizontal" style="overflow: hidden">
     <ins class="adsbygoogle"
          style="display:block"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="5770025949"
          data-ad-format="horizontal"
-         data-full-width-responsive="true"></ins>
+         data-full-width-responsive="false"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>


### PR DESCRIPTION
## Summary

- `data-full-width-responsive="true"` → `false` に変更（コンテナはすでに `max-w-7xl` で幅制約されているため、親コンテナ幅に従わせる）
- `overflow: hidden` をコンテナに追加してはみ出し防止

## 原因

`data-full-width-responsive="true"` が設定されると、AdSense スクリプトがビューポート全幅を基準に `ins` 要素の幅を計算・注入する。これにより `document.body` の計算済み幅がビューポートより広くなり、`max-w-7xl mx-auto` の `auto` マージンがその広い幅を基準に計算されてしまう。結果としてコンテンツが左寄りになり、右側に不自然な余白が生じる（横スクロールは発生しない）。

コンテナはすでに `max-w-7xl mx-auto` で幅制約されているため、`data-full-width-responsive="false"` にしてコンテナ幅に従わせるのが正しい設定。

## Test plan

- [ ] 本番環境または staging でページを開き、AdSenseバナー読み込み後に右側への余白が出ないことを確認
- [ ] モバイル表示（sm未満）では変更なしのため影響なし

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)