### PR TITLE
fix: スクエアAdSenseによるグリッドレイアウト崩れを修正 (#834)

### DIFF
--- a/app/views/layouts/_google_adsense_square.html.erb
+++ b/app/views/layouts/_google_adsense_square.html.erb
@@ -5,7 +5,7 @@
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="490467213"
          data-ad-format="auto"
-         data-full-width-responsive="true"></ins>
+         data-full-width-responsive="false"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>

--- a/app/views/layouts/_google_adsense_square2.html.erb
+++ b/app/views/layouts/_google_adsense_square2.html.erb
@@ -5,7 +5,7 @@
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
          data-ad-slot="7915453923"
          data-ad-format="auto"
-         data-full-width-responsive="true"></ins>
+         data-full-width-responsive="false"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,9 @@
       .admin-dropdown:hover .admin-dropdown-menu {
         display: block;
       }
+      .adsense-container {
+        overflow: hidden;
+      }
       .adsense-container:has(ins[data-ad-status^="unfill"]) {
         display: none;
       }


### PR DESCRIPTION
## Summary

- `_google_adsense_square.html.erb` / `_google_adsense_square2.html.erb` の `data-full-width-responsive` を `true` → `false` に変更
- `application.html.erb` の `.adsense-container` に `overflow: hidden` を追加（全広告ユニットの安全網）

## 原因

スクエア広告は `grid-cols-[350px_1fr]` の左カラム（350px固定）内に配置されているが、`data-full-width-responsive="true"` のため AdSense スクリプトがビューポート全幅でadを描画しようとしてカラムからはみ出す。これによりグリッドの幅計算が崩れ、右側に不自然な余白が発生する（横スクロールは出ない）。

## Test plan

- [ ] unit/person 詳細ページで AdSense 読み込み後に右側余白が出ないことを確認

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)