### PR TITLE
fix: profileカードへのAdSense Auto Ads自動注入を防ぐ (#838)

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,7 @@
   <style>.page-nav-scroll::-webkit-scrollbar { display: none; }</style>
 <% end %>
 <div class="flex justify-center items-center min-h-screen p-0 md:p-8">
-  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl md:overflow-hidden w-full min-w-0 max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
+  <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl md:overflow-hidden w-full min-w-0 max-w-5xl animate-in slide-in-from-bottom-5 duration-700" data-google-adsense-noads>
     <%= render ProfileHeaderComponent.new(resource: @resource) %>
 
     <nav class="md:hidden sticky top-0 z-20 bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm border-b border-slate-100 dark:border-slate-700 flex items-stretch" aria-label="ページ内ナビゲーション">


### PR DESCRIPTION
## Summary

- `profiles/show.html.erb` のメインカード div に `data-google-adsense-noads` 属性を追加

## 原因

AdSense Auto Ads（自動広告）が有効になっており、スクリプトがプロフィールカード内部に `<div class="google-auto-placed">` を自動注入していた。これが 487×280px のコンテキストパネル（「詳細を見る」等）としてレンダリングされ、ページレイアウトを崩していた。

`data-google-adsense-noads` を指定したコンテナ内部へは Auto Ads を注入しないため、この属性でブロックする。

## Test plan

- [ ] unit/person 詳細ページで AdSense 読み込み後にレイアウトが崩れないことを確認
- [ ] 手動配置の広告（スクエア等）は引き続き表示されることを確認
- [ ] `bin/rails test` が全件パスすること

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)