### PR TITLE
fix: 水平バナーのpush({})をビューポート幅で条件分岐 (#843)

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -8,7 +8,9 @@
          data-ad-format="horizontal"
          data-full-width-responsive="false"></ins>
     <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
+      if (window.innerWidth >= 640) {
+        (adsbygoogle = window.adsbygoogle || []).push({});
+      }
     </script>
   </div>
   <%# Mobile: full-width fixed-height banner (sm未満) %>
@@ -19,7 +21,9 @@
          data-ad-slot="2361507820"
          data-full-width-responsive="false"></ins>
     <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
+      if (window.innerWidth < 640) {
+        (adsbygoogle = window.adsbygoogle || []).push({});
+      }
     </script>
   </div>
 <% end %>


### PR DESCRIPTION
## Summary

- デスクトップ用 `push({})` を `window.innerWidth >= 640` の場合のみ実行
- モバイル用 `push({})` を `window.innerWidth < 640` の場合のみ実行

## 原因

両方の `push({})` が常に実行されており、デスクトップでも AdSense がモバイル用 `ins`（`display:inline-block;width:100%;height:50px`、max-width 制約なし）を処理していた。AdSense がコンテナの表示状態を操作することでページ幅が崩れ、右側に不自然な余白が発生。

## Test plan

- [ ] デスクトップで右側余白が発生しないことを確認
- [ ] デスクトップでバナー広告が正常に表示されることを確認
- [ ] モバイルでバナー広告が正常に表示されることを確認
- [ ] `bin/rails test` が全件パスすること

Closes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)