### PR TITLE
fix: スクエア広告を300×250固定サイズに変更してグリッド崩れを防ぐ

### DIFF
--- a/app/views/layouts/_google_adsense_square.html.erb
+++ b/app/views/layouts/_google_adsense_square.html.erb
@@ -1,11 +1,9 @@
 <% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
   <div class="adsense-container">
     <ins class="adsbygoogle"
-         style="display:block"
+         style="display:inline-block;width:300px;height:250px"
          data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
-         data-ad-slot="490467213"
-         data-ad-format="auto"
-         data-full-width-responsive="false"></ins>
+         data-ad-slot="490467213"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>


### PR DESCRIPTION
## 概要

`_google_adsense_square.html.erb`（slot: 490467213）を `data-ad-format="auto"` から 300×250px の固定サイズに変更する。

## 背景

- プロフィールページの左カラムは `grid-cols-[350px_1fr]` の固定350px
- `data-ad-format="auto"` では Google が 350px を超える広告を割り当てる場合があり、カラムが溢れてグリッドレイアウト全体が崩れる
- 300×250（Medium Rectangle）は最も在庫が多く、350px カラムに確実に収まる標準サイズ

## 変更内容

- `style="display:block"` → `style="display:inline-block;width:300px;height:250px"`
- `data-ad-format="auto"` を削除
- `data-full-width-responsive="false"` を削除（固定サイズのため不要）

## 関連

- closes #847
- #842（Auto Ads注入問題）は引き続き別途対応