### PR TITLE
fix: モバイル用水平バナースロットを削除し「詳細を見る」注入を防ぐ

### DIFF
--- a/app/views/layouts/_google_adsense_horizontal.html.erb
+++ b/app/views/layouts/_google_adsense_horizontal.html.erb
@@ -1,5 +1,4 @@
 <% if ENV['GOOGLE_ADSENSE_CLIENT_ID'].present? && !(defined?(logged_in?) && logged_in?) %>
-  <%# Desktop: horizontal banner (sm以上) %>
   <div class="hidden sm:block max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 adsense-container adsense-container--horizontal" style="overflow: hidden">
     <ins class="adsbygoogle"
          style="display:block"
@@ -8,22 +7,7 @@
          data-ad-format="horizontal"
          data-full-width-responsive="false"></ins>
     <script>
-      if (window.innerWidth >= 640) {
-        (adsbygoogle = window.adsbygoogle || []).push({});
-      }
-    </script>
-  </div>
-  <%# Mobile: full-width fixed-height banner (sm未満) %>
-  <div class="sm:hidden adsense-container adsense-container--horizontal">
-    <ins class="adsbygoogle"
-         style="display:inline-block;width:100%;height:50px"
-         data-ad-client="<%= ENV['GOOGLE_ADSENSE_CLIENT_ID'] %>"
-         data-ad-slot="2361507820"
-         data-full-width-responsive="false"></ins>
-    <script>
-      if (window.innerWidth < 640) {
-        (adsbygoogle = window.adsbygoogle || []).push({});
-      }
+      (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要

`_google_adsense_horizontal.html.erb` からモバイル専用スロット（`sm:hidden` 側、slot: `2361507820`）を丸ごと削除する。

## 背景

`sm:hidden` の `<ins>` 要素は Tailwind で非表示にしているが、Auto Ads の `reactive_library_fy2021.js` がデスクトップでも DOM をスキャンして発見し独自に push する。広告が埋まらない（`unfill-optimized`）と、フォールバックとして「Related Search（詳細を見る）」ウィジェットを **`position: fixed`** で注入する。`position: fixed` は親の `display: none` や `overflow: hidden` を貫通するため、プロフィールページの右カラムに重なりレイアウトが壊れていた。

## 変更内容

- モバイル専用スロット（`sm:hidden` ブロック全体）を削除
- desktop 側スロットの不要な `if (window.innerWidth >= 640)` ガードも削除（`hidden sm:block` で制御済みのため不要）

## 影響

- モバイルでの水平バナーは非表示になる（もともと unfill-optimized で実質未表示だった）
- デスクトップの水平バナーは引き続き動作する
- 「詳細を見る」フォールバックウィジェットが注入されなくなる

## 関連

- closes #850
- #842 #847 と関連する Auto Ads レイアウト崩れシリーズ