### PR TITLE
fix: プロフィールページの外側flexに flex-col を追加してAuto Ads注入によるカード圧縮を防ぐ

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :head do %>
   <style>.page-nav-scroll::-webkit-scrollbar { display: none; }</style>
 <% end %>
-<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
+<div class="flex flex-col justify-center items-center min-h-screen p-0 md:p-8">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl md:overflow-hidden w-full min-w-0 max-w-5xl animate-in slide-in-from-bottom-5 duration-700" data-google-adsense-noads>
     <%= render ProfileHeaderComponent.new(resource: @resource) %>
 


### PR DESCRIPTION
## 概要

[profiles/show.html.erb](app/views/profiles/show.html.erb) の外側 flex コンテナに `flex-col` を追加する。

## 原因

```html
<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
  <div ...>プロフィールカード</div>
  <!-- Auto Ads が div.google-aiuf をここに注入 -->
</div>
```

`flex`（デフォルト横並び）の状態でこの div 直下に `div.google-aiuf` が注入されると、プロフィールカードと横並びに配置される。その結果カードの横幅が圧縮されグリッドレイアウトが崩れる。

## 修正

`flex-col` を追加して縦方向にする。注入された要素はカードの**下**に表示され、カードの横幅に影響しなくなる。

## 関連

- #847