### PR TITLE
ログイン/ログアウト後に元のページへ自動遷移する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   def require_login
     return if logged_in?
 
-    store_return_to(request.fullpath) if request.get?
+    store_return_to(request.fullpath) if request.get? || request.head?
     redirect_to login_path, alert: 'ログインしてください'
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,33 @@ class ApplicationController < ActionController::Base
   def require_login
     return if logged_in?
 
+    store_return_to(request.fullpath) if request.get?
     redirect_to login_path, alert: 'ログインしてください'
+  end
+
+  def store_return_to(path)
+    safe_path = safe_return_to(path)
+    session[:return_to] = safe_path if safe_path
+  end
+
+  RETURN_TO_MAX_LENGTH = 512
+
+  # 外部から渡された値をそのまま使うとオープンリダイレクトの脆弱性になるため、
+  # host/scheme を持たないサイト内の相対パスのみ許可する。
+  # 単純な文字列プレフィックスチェック（"//"や"/\"始まりを弾くだけ）だと、
+  # ブラウザがLocationヘッダー中のタブ/改行/復帰文字をどこにあっても除去してから
+  # URLを解釈するため、"/\t/evil.com" のような値が "//evil.com" に変化して
+  # プロトコル相対の外部リダイレクトを許してしまう。URI.parse で厳密に検証する。
+  #
+  # 長さも制限する。session はデフォルトで cookie に保存されるため、長すぎる
+  # 値をそのまま入れると ActionDispatch::Cookies::CookieOverflow で 500 になる。
+  def safe_return_to(path)
+    return unless path.is_a?(String) && path.start_with?('/') && path.length <= RETURN_TO_MAX_LENGTH
+
+    uri = URI.parse(path)
+    path if uri.host.nil? && uri.scheme.nil?
+  rescue URI::InvalidURIError
+    nil
   end
 
   def valid_year?(year)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  def new; end
+  def new
+    store_return_to(params[:return_to])
+  end
 
   def create
     user = User.find_by(email: params[:email])
     if user&.authenticate(params[:password])
       session[:user_id] = user.id
-      redirect_to root_path, notice: 'ログインしました'
+      redirect_to session.delete(:return_to) || root_path, notice: 'ログインしました'
     else
       flash.now[:alert] = 'メールアドレスまたはパスワードが正しくありません'
       render :new, status: :unprocessable_entity
@@ -15,7 +17,8 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    return_to = safe_return_to(params[:return_to])
     reset_session
-    redirect_to root_path, notice: 'ログアウトしました'
+    redirect_to return_to || root_path, notice: 'ログアウトしました'
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -204,7 +204,7 @@
                       </svg>
                       Settings
                     <% end %>
-                    <%= button_to logout_path, method: :delete, class: "group flex w-full items-center px-4 py-2 text-sm text-red-600 hover:bg-zinc-50 dark:text-red-400 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                    <%= button_to logout_path(return_to: request.fullpath), method: :delete, class: "group flex w-full items-center px-4 py-2 text-sm text-red-600 hover:bg-zinc-50 dark:text-red-400 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-red-500 group-hover:text-red-600 dark:text-red-400 dark:group-hover:text-red-300">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75" />
                       </svg>
@@ -214,7 +214,7 @@
                 </div>
               </div>
             <% else %>
-              <%= link_to "Login", login_path, class: "text-indigo-600 hover:text-indigo-800 text-sm font-medium dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors" %>
+              <%= link_to "Login", login_path(return_to: request.fullpath), class: "text-indigo-600 hover:text-indigo-800 text-sm font-medium dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors" %>
             <% end %>
           </div>
           
@@ -357,7 +357,7 @@
                       <%= link_to edit_password_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Password Settings
                       <% end %>
-                      <%= button_to logout_path, method: :delete, class: "block w-full text-left px-4 py-2 text-base font-medium text-red-600 hover:text-red-800 hover:bg-zinc-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-zinc-900 transition-colors" do %>
+                      <%= button_to logout_path(return_to: request.fullpath), method: :delete, class: "block w-full text-left px-4 py-2 text-base font-medium text-red-600 hover:text-red-800 hover:bg-zinc-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-zinc-900 transition-colors" do %>
                         Logout
                       <% end %>
                     </div>
@@ -365,7 +365,7 @@
                 <% else %>
                   <div class="pt-4 pb-3">
                     <div class="space-y-1">
-                      <%= link_to "Login", login_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" %>
+                      <%= link_to "Login", login_path(return_to: request.fullpath), class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" %>
                     </div>
                   </div>
                 <% end %>

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -13,8 +13,55 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
+  test 'should redirect back to the page that required login' do
+    get admin_root_url
+    assert_redirected_to login_url
+
+    post login_url, params: { email: 'one@example.com', password: 'password' }
+    assert_redirected_to admin_root_url
+  end
+
+  test 'should redirect back to return_to param passed to the login page' do
+    get login_url, params: { return_to: '/password/edit' }
+    post login_url, params: { email: 'one@example.com', password: 'password' }
+    assert_redirected_to edit_password_url
+  end
+
+  test 'should ignore an external return_to to avoid open redirect' do
+    get login_url, params: { return_to: '//evil.example.com' }
+    post login_url, params: { email: 'one@example.com', password: 'password' }
+    assert_redirected_to root_url
+  end
+
+  test 'should ignore a return_to that hides a protocol-relative host behind a tab character' do
+    get login_url, params: { return_to: "/\t/evil.example.com" }
+    post login_url, params: { email: 'one@example.com', password: 'password' }
+    assert_redirected_to root_url
+  end
+
+  test 'should ignore an overly long return_to to avoid session cookie overflow' do
+    get login_url, params: { return_to: "/#{'a' * 5000}" }
+    post login_url, params: { email: 'one@example.com', password: 'password' }
+    assert_redirected_to root_url
+  end
+
   test 'should get destroy' do
     delete logout_url
+    assert_redirected_to root_url
+  end
+
+  test 'should redirect back to the page that had the logout button' do
+    delete logout_url, params: { return_to: '/password/edit' }
+    assert_redirected_to edit_password_url
+  end
+
+  test 'should ignore an external return_to on logout to avoid open redirect' do
+    delete logout_url, params: { return_to: '//evil.example.com' }
+    assert_redirected_to root_url
+  end
+
+  test 'should ignore a logout return_to that hides a protocol-relative host behind a tab character' do
+    delete logout_url, params: { return_to: "/\t/evil.example.com" }
     assert_redirected_to root_url
   end
 end


### PR DESCRIPTION
## Summary
- `require_login` によるリダイレクトやヘッダーのログイン/ログアウトリンクから遷移元パスを session に保存し、ログイン・ログアウト完了後にそこへ戻すようにした
- オープンリダイレクト対策として `URI.parse` で host/scheme を持つ値を拒否
- ブラウザのURL正規化（タブ/改行文字除去）によるプロトコル相対URLへのバイパスを防止
- 長すぎる `return_to` によるセッションCookieオーバーフロー（500エラー）を防止する長さ制限を追加

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] RuboCop に違反がないこと
- [ ] 実ブラウザでログイン前のページ → ログイン → 元のページに戻ることを確認（動作確認済み）
- [ ] ログアウトについても同様に確認

Closes #857

🤖 Generated with [Claude Code](https://claude.com/claude-code)