### PR TITLE
YouTube埋め込みをOfficial Linksから分離し独立セクションで表示

### DIFF
--- a/app/components/links_component.html.erb
+++ b/app/components/links_component.html.erb
@@ -2,20 +2,12 @@
   <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">Links</h2>
   <ul class="grid gap-3">
     <% @links.each do |link| %>
-      <% if link == embed_target %>
-        <li class="mt-2">
-          <div class="relative pb-[56.25%] h-0 overflow-hidden rounded-2xl shadow-lg ring-1 ring-slate-200 dark:ring-slate-700">
-            <iframe src="https://www.youtube.com/embed/<%= link.youtube_video_id %>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="absolute top-0 left-0 w-full h-full border-0"></iframe>
-          </div>
-        </li>
-      <% else %>
-        <li>
-          <%= link_to link.url, target: "_blank", rel: "noopener", class: "group block p-4 bg-slate-50 dark:bg-slate-900/50 border border-slate-100 dark:border-slate-700 rounded-xl hover:border-unit hover:scale-[1.02] transition-all relative pr-10" do %>
-            <span class="text-sm font-bold text-slate-800 dark:text-slate-200 group-hover:text-unit break-all"><%= link.display_text %></span>
-            <span class="absolute right-4 top-1/2 -translate-y-1/2 opacity-30 group-hover:opacity-100 group-hover:translate-x-1 transition-all text-unit">→</span>
-          <% end %>
-        </li>
-      <% end %>
+      <li>
+        <%= link_to link.url, target: "_blank", rel: "noopener", class: "group block p-4 bg-slate-50 dark:bg-slate-900/50 border border-slate-100 dark:border-slate-700 rounded-xl hover:border-unit hover:scale-[1.02] transition-all relative pr-10" do %>
+          <span class="text-sm font-bold text-slate-800 dark:text-slate-200 group-hover:text-unit break-all"><%= link.display_text %></span>
+          <span class="absolute right-4 top-1/2 -translate-y-1/2 opacity-30 group-hover:opacity-100 group-hover:translate-x-1 transition-all text-unit">→</span>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </section>

--- a/app/components/links_component.rb
+++ b/app/components/links_component.rb
@@ -8,10 +8,4 @@ class LinksComponent < ViewComponent::Base
   def render?
     @links.present?
   end
-
-  private
-
-  def embed_target
-    @embed_target ||= @links.reverse.find { |l| l.youtube_video_id.present? }
-  end
 end

--- a/app/components/youtube_embed_component.html.erb
+++ b/app/components/youtube_embed_component.html.erb
@@ -1,0 +1,5 @@
+<% if render? %>
+  <div class="relative pb-[56.25%] h-0 overflow-hidden rounded-2xl shadow-lg ring-1 ring-slate-200 dark:ring-slate-700">
+    <iframe src="https://www.youtube.com/embed/<%= youtube_video_id %>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="absolute top-0 left-0 w-full h-full border-0"></iframe>
+  </div>
+<% end %>

--- a/app/components/youtube_embed_component.html.erb
+++ b/app/components/youtube_embed_component.html.erb
@@ -1,5 +1,24 @@
 <% if render? %>
-  <div class="relative pb-[56.25%] h-0 overflow-hidden rounded-2xl shadow-lg ring-1 ring-slate-200 dark:ring-slate-700">
-    <iframe src="https://www.youtube.com/embed/<%= youtube_video_id %>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="absolute top-0 left-0 w-full h-full border-0"></iframe>
+  <div data-controller="youtube-carousel">
+    <% @youtube_links.each_with_index do |link, i| %>
+      <div data-youtube-carousel-target="slide" class="<%= "hidden" unless i.zero? %> relative pb-[56.25%] h-0 overflow-hidden rounded-2xl shadow-lg ring-1 ring-slate-200 dark:ring-slate-700">
+        <iframe src="https://www.youtube.com/embed/<%= link.youtube_video_id %>" title="YouTube video <%= i + 1 %>" loading="<%= i.zero? ? "eager" : "lazy" %>" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="absolute top-0 left-0 w-full h-full border-0"></iframe>
+      </div>
+    <% end %>
+
+    <% if @youtube_links.size > 1 %>
+      <div class="flex justify-center gap-2 mt-3" role="group" aria-label="動画を選択">
+        <% @youtube_links.each_with_index do |_, i| %>
+          <button type="button"
+                  data-youtube-carousel-target="dot"
+                  data-action="youtube-carousel#select"
+                  data-youtube-carousel-index-param="<%= i %>"
+                  class="w-2.5 h-2.5 rounded-full cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-unit <%= i.zero? ? "bg-slate-800 dark:bg-slate-200" : "bg-slate-300 dark:bg-slate-600" %>"
+                  aria-label="動画<%= i + 1 %>を表示"
+                  aria-current="<%= i.zero? ? "true" : "false" %>">
+          </button>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/components/youtube_embed_component.rb
+++ b/app/components/youtube_embed_component.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 class YoutubeEmbedComponent < ViewComponent::Base
-  def initialize(link:)
+  def initialize(links:)
     super()
-    @link = link
+    @youtube_links = links
   end
 
   def render?
-    @link&.youtube_video_id.present?
-  end
-
-  def youtube_video_id
-    @link.youtube_video_id
+    @youtube_links.present?
   end
 end

--- a/app/components/youtube_embed_component.rb
+++ b/app/components/youtube_embed_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class YoutubeEmbedComponent < ViewComponent::Base
+  def initialize(link:)
+    super()
+    @link = link
+  end
+
+  def render?
+    @link&.youtube_video_id.present?
+  end
+
+  def youtube_video_id
+    @link.youtube_video_id
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -15,6 +15,8 @@ class ProfilesController < ApplicationController
     raise ActiveRecord::RecordNotFound if @resource.discarded?
 
     @links = @resource.links.where(active: true).order(:sort_order)
+    @youtube_embed_link = @links.reverse.find { |l| l.youtube_video_id.present? }
+    @links_for_list = @links - [@youtube_embed_link].compact
 
     @resource.is_a?(Person) ? load_person_data : load_unit_data
     load_items

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -15,8 +15,8 @@ class ProfilesController < ApplicationController
     raise ActiveRecord::RecordNotFound if @resource.discarded?
 
     @links = @resource.links.where(active: true).order(:sort_order)
-    @youtube_embed_link = @links.reverse.find { |l| l.youtube_video_id.present? }
-    @links_for_list = @links - [@youtube_embed_link].compact
+    @youtube_links = @links.select { |l| l.youtube_video_id.present? }
+    @links_for_list = @links - @youtube_links
 
     @resource.is_a?(Person) ? load_person_data : load_unit_data
     load_items

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -45,3 +45,6 @@ application.register("timeline", TimelineController)
 
 import TimelineSearchController from "controllers/timeline_search_controller"
 application.register("timeline-search", TimelineSearchController)
+
+import YoutubeCarouselController from "controllers/youtube_carousel_controller"
+application.register("youtube-carousel", YoutubeCarouselController)

--- a/app/javascript/controllers/youtube_carousel_controller.js
+++ b/app/javascript/controllers/youtube_carousel_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["slide", "dot"]
+    static values = { index: { type: Number, default: 0 } }
+
+    indexValueChanged() {
+        this.slideTargets.forEach((el, i) => {
+            el.classList.toggle("hidden", i !== this.indexValue)
+        })
+
+        this.dotTargets.forEach((el, i) => {
+            const active = i === this.indexValue
+            el.classList.toggle("bg-slate-800", active)
+            el.classList.toggle("dark:bg-slate-200", active)
+            el.classList.toggle("bg-slate-300", !active)
+            el.classList.toggle("dark:bg-slate-600", !active)
+            el.setAttribute("aria-current", active ? "true" : "false")
+        })
+    }
+
+    select(event) {
+        this.indexValue = Number(event.params.index)
+    }
+}

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -36,7 +36,7 @@
 
     <div class="p-5 md:p-8">
       <div class="md:hidden mb-4">
-        <%= render YoutubeEmbedComponent.new(link: @youtube_embed_link) %>
+        <%= render YoutubeEmbedComponent.new(links: @youtube_links) %>
       </div>
 
       <div class="grid gap-8 grid-cols-1 md:grid-cols-[350px_1fr] items-start">
@@ -55,7 +55,7 @@
         <div class="column-right">
           <% if @resource.is_a?(Unit) %>
             <div class="hidden md:block mb-4">
-              <%= render YoutubeEmbedComponent.new(link: @youtube_embed_link) %>
+              <%= render YoutubeEmbedComponent.new(links: @youtube_links) %>
             </div>
 
             <div id="members">
@@ -135,7 +135,7 @@
 
           <% if @resource.is_a?(Person) %>
             <div class="hidden md:block mt-8">
-              <%= render YoutubeEmbedComponent.new(link: @youtube_embed_link) %>
+              <%= render YoutubeEmbedComponent.new(links: @youtube_links) %>
             </div>
           <% end %>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -35,12 +35,16 @@
     </nav>
 
     <div class="p-5 md:p-8">
+      <div class="md:hidden mb-4">
+        <%= render YoutubeEmbedComponent.new(link: @youtube_embed_link) %>
+      </div>
+
       <div class="grid gap-8 grid-cols-1 md:grid-cols-[350px_1fr] items-start">
         <div>
           <%= render BasicAttributesComponent.new(resource: @resource) %>
           <%= render NameHistoryComponent.new(resource: @resource) %>
           <div class="hidden md:block">
-            <%= render LinksComponent.new(links: @links) %>
+            <%= render LinksComponent.new(links: @links_for_list) %>
             <%= render SpotifyEmbedComponent.new(links: @links) %>
           </div>
           <div class="mt-4">
@@ -50,6 +54,10 @@
 
         <div class="column-right">
           <% if @resource.is_a?(Unit) %>
+            <div class="hidden md:block mb-4">
+              <%= render YoutubeEmbedComponent.new(link: @youtube_embed_link) %>
+            </div>
+
             <div id="members">
               <%= render UnitSnapshotsComponent.new(snapshots: @snapshots, unit: @resource, admin: defined?(logged_in?) && logged_in?) %>
             </div>
@@ -125,6 +133,12 @@
             </section>
           <% end %>
 
+          <% if @resource.is_a?(Person) %>
+            <div class="hidden md:block mt-8">
+              <%= render YoutubeEmbedComponent.new(link: @youtube_embed_link) %>
+            </div>
+          <% end %>
+
           <% if @resource.is_a?(Person) && @trends.present? %>
             <div id="trends">
               <%= render UnitTrendsComponent.new(trends: @trends) %>
@@ -175,7 +189,7 @@
       <%= render SameKanaSuggestionComponent.new(resource: @resource, same_kana_resources: @same_kana_resources, same_kana_total: @same_kana_total) %>
 
       <div id="links" class="md:hidden">
-        <%= render LinksComponent.new(links: @links) %>
+        <%= render LinksComponent.new(links: @links_for_list) %>
         <%= render SpotifyEmbedComponent.new(links: @links) %>
       </div>
 

--- a/test/components/previews/links_component_preview.rb
+++ b/test/components/previews/links_component_preview.rb
@@ -12,15 +12,6 @@ class LinksComponentPreview < ViewComponent::Preview
     render(LinksComponent.new(links: links))
   end
 
-  def with_youtube_embed
-    links = [
-      mock_link('Official Site', 'https://example.com'),
-      mock_link('YouTube Music Video', 'https://youtube.com/watch?v=dQw4w9WgXcQ'),
-      mock_link('Twitter', 'https://twitter.com/example')
-    ]
-    render(LinksComponent.new(links: links))
-  end
-
   def no_links
     render(LinksComponent.new(links: []))
   end

--- a/test/components/previews/youtube_embed_component_preview.rb
+++ b/test/components/previews/youtube_embed_component_preview.rb
@@ -3,12 +3,21 @@
 class YoutubeEmbedComponentPreview < ViewComponent::Preview
   layout 'component_preview'
   def default
-    link = mock_link('https://youtube.com/watch?v=dQw4w9WgXcQ')
-    render(YoutubeEmbedComponent.new(link: link))
+    links = [mock_link('https://youtube.com/watch?v=dQw4w9WgXcQ')]
+    render(YoutubeEmbedComponent.new(links: links))
   end
 
-  def no_link
-    render(YoutubeEmbedComponent.new(link: nil))
+  def multiple_videos
+    links = [
+      mock_link('https://youtube.com/watch?v=dQw4w9WgXcQ'),
+      mock_link('https://youtu.be/XjFviZsK9Yk'),
+      mock_link('https://youtu.be/ze-cHnIJohY')
+    ]
+    render(YoutubeEmbedComponent.new(links: links))
+  end
+
+  def no_links
+    render(YoutubeEmbedComponent.new(links: []))
   end
 
   private

--- a/test/components/previews/youtube_embed_component_preview.rb
+++ b/test/components/previews/youtube_embed_component_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class YoutubeEmbedComponentPreview < ViewComponent::Preview
+  layout 'component_preview'
+  def default
+    link = mock_link('https://youtube.com/watch?v=dQw4w9WgXcQ')
+    render(YoutubeEmbedComponent.new(link: link))
+  end
+
+  def no_link
+    render(YoutubeEmbedComponent.new(link: nil))
+  end
+
+  private
+
+  def mock_link(url)
+    Link.new(
+      url: url,
+      linkable: Person.new
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- `LinksComponent` からYouTube動画のiframe埋め込みロジックを削除し、通常のリンク一覧のみを表示するように変更
- YouTube埋め込み専用の `YoutubeEmbedComponent` を新規作成（`SpotifyEmbedComponent` を参考に、見出しなしで実装）
- 埋め込み対象のYouTubeリンクは全てOfficial Linksの一覧からは除外
- 複数のYouTubeリンクがある場合は、下部のドットインジケーター（Stimulusコントローラ `youtube-carousel`）でカルーゼル切り替え表示できるようにした
- 表示位置:
  - モバイル: Basic Information の上（見出しなし）
  - PC・Unit: Members セクションの上（見出しなし）
  - PC・Person: History セクションの下（見出しなし）

## Test plan
- [x] `bundle exec rails test test/controllers/profiles_controller_test.rb` が通ることを確認
- [x] MIYAVI（`miyavi-0914`）等、YouTubeリンクを持つPersonページで、モバイル/PC表示ともに新セクションが意図した位置に表示され、Official Linksの一覧からは対象URLが除外されていることをブラウザで確認
- [x] 複数のYouTubeリンクを持つUnit（`el-ethnic-legist-` / Ethnic Legist）で、ドットインジケーターによる動画切り替えが正しく動作することをブラウザで確認
- [x] Unitページでのモバイル/PC表示も確認
- [x] pre-push フック（RuboCop・テスト86件）通過

closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)