### PR TITLE
feat: Official Links の並び替え機能を追加

### DIFF
--- a/app/controllers/admin/links_controller.rb
+++ b/app/controllers/admin/links_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Admin
+  class LinksController < Admin::BaseController
+    before_action :set_linkable
+
+    def reorder
+      params[:ids].each_with_index do |id, index|
+        @linkable.links.find(id).update(sort_order: index + 1)
+      end
+      head :ok
+    end
+
+    private
+
+    def set_linkable
+      type = params[:linkable_type]
+      id   = params[:linkable_id]
+      @linkable = case type
+                  when 'Unit'   then Unit.find(id)
+                  when 'Person' then Person.find(id)
+                  else raise ActionController::BadRequest, 'Invalid linkable_type'
+                  end
+    end
+  end
+end

--- a/app/views/admin/people/_links_form.html.erb
+++ b/app/views/admin/people/_links_form.html.erb
@@ -2,8 +2,37 @@
   <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100 mb-4">Official Links</h3>
   
   <%= form_with(model: [:admin, person], class: "space-y-6") do |form| %>
-    <div class="space-y-3">
-      <%= form.fields_for :links do |link_form| %>
+    <div class="space-y-3"
+         data-controller="sortable"
+         data-sortable-url-value="<%= reorder_admin_links_path(linkable_type: person.class.name, linkable_id: person.id) %>">
+      <%= form.fields_for :links, person.links.select(&:persisted?).sort_by { |l| [l.sort_order || Float::INFINITY, l.id] } do |link_form| %>
+        <div data-id="<%= link_form.object.id %>" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md border border-gray-200 dark:border-gray-700">
+          <div class="w-full flex gap-2 items-center">
+            <span class="drag-handle cursor-move text-gray-400 shrink-0" aria-hidden="true">
+              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </span>
+            <span class="sr-only">並び替え</span>
+            <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :url, placeholder: "URL (https://...)", class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+          </div>
+          <div class="flex items-center gap-4">
+            <div class="flex items-center">
+              <%= link_form.check_box :active, class: "rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600" %>
+              <%= link_form.label :active, class: "ml-2 text-xs text-gray-600 dark:text-gray-400" %>
+            </div>
+            <div class="flex items-center">
+              <%= link_form.check_box :_destroy, class: "rounded border-gray-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 dark:bg-gray-700 dark:border-gray-600" %>
+              <%= link_form.label :_destroy, "Delete", class: "ml-2 text-xs text-red-600 font-medium" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="space-y-3 mt-3">
+      <%= form.fields_for :links, person.links.reject(&:persisted?) do |link_form| %>
         <div class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md border border-gray-200 dark:border-gray-700">
           <div class="w-full flex gap-2">
             <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
@@ -14,12 +43,6 @@
               <%= link_form.check_box :active, class: "rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600" %>
               <%= link_form.label :active, class: "ml-2 text-xs text-gray-600 dark:text-gray-400" %>
             </div>
-            <% if link_form.object.persisted? %>
-              <div class="flex items-center">
-                <%= link_form.check_box :_destroy, class: "rounded border-gray-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 dark:bg-gray-700 dark:border-gray-600" %>
-                <%= link_form.label :_destroy, "Delete", class: "ml-2 text-xs text-red-600 font-medium" %>
-              </div>
-            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/admin/units/_links_form.html.erb
+++ b/app/views/admin/units/_links_form.html.erb
@@ -2,8 +2,37 @@
   <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100 mb-4">Official Links</h3>
   
   <%= form_with(model: [:admin, unit], class: "space-y-6") do |form| %>
-    <div class="space-y-3">
-      <%= form.fields_for :links do |link_form| %>
+    <div class="space-y-3"
+         data-controller="sortable"
+         data-sortable-url-value="<%= reorder_admin_links_path(linkable_type: unit.class.name, linkable_id: unit.id) %>">
+      <%= form.fields_for :links, unit.links.select(&:persisted?).sort_by { |l| [l.sort_order || Float::INFINITY, l.id] } do |link_form| %>
+        <div data-id="<%= link_form.object.id %>" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
+          <div class="w-full flex gap-2 items-center">
+            <span class="drag-handle cursor-move text-gray-400 shrink-0" aria-hidden="true">
+              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </span>
+            <span class="sr-only">並び替え</span>
+            <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :url, placeholder: "URL (https://...)", class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+          </div>
+          <div class="flex items-center gap-4 mt-2 sm:mt-0">
+            <div class="flex items-center">
+              <%= link_form.check_box :active, class: "rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600" %>
+              <%= link_form.label :active, class: "ml-2 text-xs text-gray-600 dark:text-gray-400" %>
+            </div>
+            <div class="flex items-center">
+              <%= link_form.check_box :_destroy, class: "rounded border-gray-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 dark:bg-gray-700 dark:border-gray-600" %>
+              <%= link_form.label :_destroy, "Delete", class: "ml-2 text-xs text-red-600 font-medium" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="space-y-3 mt-3">
+      <%= form.fields_for :links, unit.links.reject(&:persisted?) do |link_form| %>
         <div class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
           <div class="w-full flex gap-2">
             <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
@@ -14,12 +43,6 @@
               <%= link_form.check_box :active, class: "rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600" %>
               <%= link_form.label :active, class: "ml-2 text-xs text-gray-600 dark:text-gray-400" %>
             </div>
-            <% if link_form.object.persisted? %>
-              <div class="flex items-center">
-                <%= link_form.check_box :_destroy, class: "rounded border-gray-300 text-red-600 shadow-sm focus:border-red-500 focus:ring-red-500 dark:bg-gray-700 dark:border-gray-600" %>
-                <%= link_form.label :_destroy, "Delete", class: "ml-2 text-xs text-red-600 font-medium" %>
-              </div>
-            <% end %>
           </div>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
       end
     end
 
+    resources(:links, only: []) { collection { patch :reorder } }
     resources :images, only: %i[index show destroy]
 
     resources :update_logs, only: [] do

--- a/test/controllers/admin/links_controller_test.rb
+++ b/test/controllers/admin/links_controller_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class LinksControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+      @unit = units(:one)
+      @link_one = @unit.links.create!(url: 'https://example.com/a', sort_order: 1)
+      @link_two = @unit.links.create!(url: 'https://example.com/b', sort_order: 2)
+    end
+
+    test 'should reorder links' do
+      patch reorder_admin_links_path, params: {
+        linkable_type: 'Unit',
+        linkable_id: @unit.id,
+        ids: [@link_two.id, @link_one.id]
+      }, as: :json
+
+      assert_response :success
+      assert_equal 1, @link_two.reload.sort_order
+      assert_equal 2, @link_one.reload.sort_order
+    end
+
+    test 'should reject invalid linkable_type' do
+      patch reorder_admin_links_path, params: {
+        linkable_type: 'Wikipage',
+        linkable_id: @unit.id,
+        ids: [@link_one.id]
+      }, as: :json
+
+      assert_response :bad_request
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Unit / Person の管理画面で Official Links をドラッグ&ドロップで並び替えできるようにする
- 既存の Sections / SnapshotPeople と同じ sortable パターン（`sortable_controller.js` + polymorphic reorder エンドポイント）を踏襲
- 並び順は公開プロフィール画面（`profiles_controller.rb`）が既に参照している `sort_order` カラムに保存

## 変更内容
- `Admin::LinksController#reorder` を新規追加（`linkable_type`/`linkable_id` で Unit/Person を解決）
- ルート追加: `PATCH /admin/links/reorder`
- `admin/units/_links_form.html.erb` / `admin/people/_links_form.html.erb`
  - 既存リンクをドラッグハンドル付きのソート可能リストに変更（`sort_order` 順、null は末尾）
  - 新規追加用の空フィールドはソート対象外の別セクションに分離

## Test plan
- [x] `bundle exec rails test test/controllers/admin/links_controller_test.rb`
- [x] `bundle exec rubocop`
- [x] Unit / Person の編集画面で Official Links のドラッグ&ドロップ並び替えをブラウザで動作確認済み

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)