### PR TITLE
fix: 公開側の discard 済みレコード除外漏れを修正

### DIFF
--- a/app/controllers/custom_pages_controller.rb
+++ b/app/controllers/custom_pages_controller.rb
@@ -45,7 +45,7 @@ class CustomPagesController < ApplicationController
 
     unit_ids   = @weekly_trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
     person_ids = @weekly_trends.flat_map { |t| t.people&.map { |p| p['person_id'] } }.compact.uniq
-    @weekly_trend_units  = Unit.where(id: unit_ids).index_by(&:id)
-    @weekly_trend_people = Person.where(id: person_ids).index_by(&:id)
+    @weekly_trend_units  = Unit.kept.where(id: unit_ids).index_by(&:id)
+    @weekly_trend_people = Person.kept.where(id: person_ids).index_by(&:id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,12 +43,12 @@ class ItemsController < ApplicationController
 
   def filter_by_artist(scope)
     if params[:old_key].present?
-      @artist = Unit.find_by(old_key: params[:old_key]) || Person.find_by(old_key: params[:old_key])
+      @artist = Unit.kept.find_by(old_key: params[:old_key]) || Person.kept.find_by(old_key: params[:old_key])
       scopes = [Item.by_artist_old_key(params[:old_key])]
       scopes << Item.by_artist_key(@artist.key) if @artist&.key.present?
       scope.merge(scopes.reduce(:or))
     elsif params[:key].present?
-      @artist = Unit.find_by(key: params[:key]) || Person.find_by(key: params[:key])
+      @artist = Unit.kept.find_by(key: params[:key]) || Person.kept.find_by(key: params[:key])
       scopes = [Item.by_artist_key(params[:key])]
       scopes << Item.by_artist_old_key(@artist.old_key) if @artist&.old_key.present?
       scope.merge(scopes.reduce(:or))

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -26,7 +26,7 @@ class TrendsController < ApplicationController
     @pagy, @trends = pagy(scope, limit: 20)
 
     all_unit_ids = @trends.flat_map { |t| t.units&.map { |u| u['unit_id'] } }.compact.uniq
-    @related_units = Unit.where(id: all_unit_ids).index_by(&:id)
+    @related_units = Unit.kept.where(id: all_unit_ids).index_by(&:id)
   end
 
   def show
@@ -34,10 +34,10 @@ class TrendsController < ApplicationController
     return unless @trend.units.present?
 
     unit_ids = @trend.units.map { |u| u['unit_id'] }
-    @related_units = Unit.where(id: unit_ids).index_by(&:id)
+    @related_units = Unit.kept.where(id: unit_ids).index_by(&:id)
 
     person_ids = (@trend.people || []).map { |p| p['person_id'] }.compact
-    @related_people = Person.where(id: person_ids).index_by(&:id) if person_ids.any?
+    @related_people = Person.kept.where(id: person_ids).index_by(&:id) if person_ids.any?
 
     first_unit_id = @trend.units.first&.dig('unit_id')
     @unit = @related_units[first_unit_id]

--- a/app/services/unit_graph_builder.rb
+++ b/app/services/unit_graph_builder.rb
@@ -189,7 +189,7 @@ class UnitGraphBuilder # rubocop:disable Metrics/ClassLength
   def build_graph(unit_ids_by_person, current_edge_pairs, relevant_unit_ids, hop1_unit_ids_set = Set.new, base_unit_ids = nil)
     # ノード描画には id/name/key のみ必要なため、Unit を AR オブジェクトとして
     # 全件ロードせず必要な列のみ取得する
-    related_units = Unit.where(id: relevant_unit_ids)
+    related_units = Unit.kept.where(id: relevant_unit_ids)
                         .pluck(:id, :name, :key)
                         .to_h { |id, name, key| [id, GraphUnit.new(id:, name:, key:)] }
 

--- a/app/views/custom_pages/_sidebar.html.erb
+++ b/app/views/custom_pages/_sidebar.html.erb
@@ -15,17 +15,23 @@
                 <% if trend.units.present? %>
                   <% trend.units.each do |u| %>
                     <% unit = @weekly_trend_units[u['unit_id']] %>
-                    <span class="inline-block px-1.5 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 border border-slate-200 dark:border-slate-600">
-                      <%= unit&.name || u['name'] %>
-                    </span>
+                    <% name = unit&.name || u['name'] %>
+                    <% if name.present? %>
+                      <span class="inline-block px-1.5 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 border border-slate-200 dark:border-slate-600">
+                        <%= name %>
+                      </span>
+                    <% end %>
                   <% end %>
                 <% end %>
                 <% if trend.people.present? %>
                   <% trend.people.each do |p| %>
                     <% person = @weekly_trend_people[p['person_id']] %>
-                    <span class="inline-block px-1.5 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600">
-                      <%= person&.name || p['name'] %>
-                    </span>
+                    <% name = person&.name || p['name'] %>
+                    <% if name.present? %>
+                      <span class="inline-block px-1.5 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600">
+                        <%= name %>
+                      </span>
+                    <% end %>
                   <% end %>
                 <% end %>
               </div>

--- a/test/controllers/custom_pages_controller_test.rb
+++ b/test/controllers/custom_pages_controller_test.rb
@@ -23,5 +23,6 @@ class CustomPagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_not_includes response.body, 'Discarded Sidebar Unit'
     assert_not_includes response.body, 'Discarded Sidebar Person'
+    assert_no_match(%r{<span class="inline-block[^"]*">\s*</span>}, response.body)
   end
 end

--- a/test/controllers/custom_pages_controller_test.rb
+++ b/test/controllers/custom_pages_controller_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CustomPagesControllerTest < ActionDispatch::IntegrationTest
+  test 'sidebar does not render a discarded unit or person referenced by a weekly trend' do
+    # key未設定の既存フィクスチャが "最近の更新" 欄に混ざると別バグ(issue #874)で
+    # profile_path がルート生成エラーになるため、この検証の対象外にしておく
+    Unit.kept.where(key: nil).find_each(&:discard)
+    Person.kept.where(key: nil).find_each(&:discard)
+
+    unit = Unit.create!(name: 'Discarded Sidebar Unit', key: 'discarded-unit-sidebar-test', status: :active)
+    person = Person.create!(name: 'Discarded Sidebar Person', key: 'discarded-person-sidebar-test', status: :active)
+    unit.discard
+    person.discard
+    Trend.create!(title: 'Sidebar trend with discarded refs', date: Date.current, publish_start_at: Time.current,
+                  unit_phenomenon: :other,
+                  units: [{ 'unit_id' => unit.id }], people: [{ 'person_id' => person.id }])
+    page = CustomPage.create!(key: 'sidebar-test-page', title: 'Sidebar Test Page', active: true, body: 'body')
+
+    get custom_page_path(key: page.key)
+
+    assert_response :success
+    assert_not_includes response.body, 'Discarded Sidebar Unit'
+    assert_not_includes response.body, 'Discarded Sidebar Person'
+  end
+end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ItemsControllerTest < ActionDispatch::IntegrationTest
+  test 'index does not resolve artist info for a discarded unit key' do
+    unit = Unit.create!(name: 'Discarded Unit', key: 'discarded-unit-items-test', status: :active)
+    unit.discard
+
+    get items_path(key: unit.key)
+
+    assert_response :success
+    assert_not_includes response.body, 'Discarded Unit'
+  end
+
+  test 'index does not resolve artist info for a discarded person key' do
+    person = Person.create!(name: 'Discarded Person', key: 'discarded-person-items-test', status: :active)
+    person.discard
+
+    get items_path(key: person.key)
+
+    assert_response :success
+    assert_not_includes response.body, 'Discarded Person'
+  end
+
+  test 'index resolves artist info for a kept unit key' do
+    unit = Unit.create!(name: 'Kept Unit', key: 'kept-unit-items-test', status: :active)
+
+    get items_path(key: unit.key)
+
+    assert_response :success
+    assert_includes response.body, 'Kept Unit'
+  end
+end

--- a/test/controllers/trends_controller_test.rb
+++ b/test/controllers/trends_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TrendsControllerTest < ActionDispatch::IntegrationTest
+  test 'index does not render a discarded unit referenced by a trend' do
+    unit = Unit.create!(name: 'Discarded Trend Unit', key: 'discarded-unit-trends-test', status: :active)
+    unit.discard
+    Trend.create!(title: 'Trend with discarded unit', date: Date.current, publish_start_at: Time.current,
+                  unit_phenomenon: :other, units: [{ 'unit_id' => unit.id }])
+
+    get trends_path
+
+    assert_response :success
+    assert_not_includes response.body, 'Discarded Trend Unit'
+  end
+
+  test 'show does not render a discarded unit or person referenced by a trend' do
+    unit = Unit.create!(name: 'Discarded Show Unit', key: 'discarded-unit-trends-show-test', status: :active)
+    person = Person.create!(name: 'Discarded Show Person', key: 'discarded-person-trends-show-test', status: :active)
+    unit.discard
+    person.discard
+    trend = Trend.create!(title: 'Trend with discarded refs', date: Date.current, publish_start_at: Time.current,
+                          unit_phenomenon: :other,
+                          units: [{ 'unit_id' => unit.id }], people: [{ 'person_id' => person.id }])
+
+    get trend_path(trend)
+
+    assert_response :success
+    assert_not_includes response.body, 'Discarded Show Unit'
+    assert_not_includes response.body, 'Discarded Show Person'
+  end
+end

--- a/test/services/unit_graph_builder_test.rb
+++ b/test/services/unit_graph_builder_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UnitGraphBuilderTest < ActiveSupport::TestCase
+  test 'excludes a discarded unit sharing a current member from the graph nodes' do
+    person = Person.create!(name: 'Shared Member', status: :active)
+    unit_a = Unit.create!(name: 'Center Unit', key: 'graph-center-unit', status: :active)
+    unit_b = Unit.create!(name: 'Discarded Related Unit', key: 'graph-discarded-unit', status: :active)
+
+    snapshot_a = unit_a.unit_snapshots.create!(snapshot_date: Date.new(2026, 1, 1), current: true)
+    snapshot_a.snapshot_people.create!(person:, sort_order: 1)
+
+    snapshot_b = unit_b.unit_snapshots.create!(snapshot_date: Date.new(2026, 1, 1), current: true)
+    snapshot_b.snapshot_people.create!(person:, sort_order: 1)
+
+    unit_b.discard
+
+    result = UnitGraphBuilder.new(unit_a).call
+    node_ids = result[:nodes].map { |node| node[:data][:id] }
+
+    assert_not_includes node_ids, "unit_#{unit_b.id}"
+  end
+end


### PR DESCRIPTION
## Summary
- `docs/admin/key_change.md`（実装ステップ Step 1）対応
- `.kept` スコープを経由せず Person/Unit を検索・参照していた公開側4箇所を修正
  - `items_controller.rb`（`filter_by_artist`）
  - `trends_controller.rb`（`index`, `show`）
  - `custom_pages_controller.rb`（`load_recent_trends`）
  - `unit_graph_builder.rb`（`build_graph`）
- issue #57 のキー変更機能で discard 済みのスタブレコードを新たに作成するようになるため、公開ページへの漏れを事前に防ぐ
- 各修正箇所に discard 済みレコードが除外されることを確認するテストを追加

## 別issue化した副産物
- テスト作成中に、`custom_pages` サイドバーの「最近の更新」で `key` 未設定の Unit/Person があると 500 エラーになる既存バグを発見（本PRの変更とは無関係）。#874 として別issue化済み

Closes #866

## Test plan
- [x] `bundle exec rubocop`（オフェンスなし）
- [x] `bin/rails test`（95 tests, 0 failures）