### PR TITLE
chore: websocket-driver の脆弱性(CVE)に対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Summary
- `actioncable`（Rails本体）が依存する `websocket-driver` を 0.8.0 → 0.8.2 に更新
- 直近公開された以下のCVEに対応（0.8.1以上で修正済み）
  - CVE-2026-54463: プロトコル長ヘッダー悪用によるメモリ枯渇
  - CVE-2026-54464: メッセージ圧縮によるリソース制限バイパス
  - CVE-2026-54465: HTTPヘッダーパーサーのメモリ枯渇
  - GHSA-2x63-gw47-w4mm: 不正なHostヘッダーによるDoS

## 発見経緯
PR #875（issue #866対応）のCI（`scan_ruby` の `bundler-audit`）で検出。develop 自体も同じ脆弱性を含んでいたため、無関係な別対応として切り出した。

## Test plan
- [x] `bin/bundler-audit --update` で脆弱性が検出されないことを確認
- [x] `bin/rails test`（88 tests, 0 failures）