### PR TITLE
fix: Unit の key を通常の編集フォームから変更できないようにする

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -74,7 +74,7 @@ module Admin
     def update
       pre_link_ids = @unit.links.pluck(:id)
 
-      if @unit.update(unit_params)
+      if @unit.update(unit_update_params)
         record_update_log(@unit, action: 'update')
         record_link_changes(@unit, pre_link_ids)
         redirect_to edit_admin_unit_path(@unit), notice: 'Unit updated successfully.'
@@ -127,6 +127,11 @@ module Admin
                                    name_logs_attributes: %i[name name_kana],
                                    aliases_attributes: %i[name kana old_key],
                                    activity_periods_attributes: %i[from to label])
+    end
+
+    # key はキー変更専用の操作でのみ変更可能(issue #57)。通常の update では受け付けない。
+    def unit_update_params
+      unit_params.except(:key)
     end
   end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -45,6 +45,7 @@ class Unit < ApplicationRecord
   enum :status, { pre: 0, active: 1, freeze: 2, disbanded: 3, unknown: 99 }
 
   validates :status, presence: true
+  validate :key_immutable, on: :update
 
   STATUS_TRANSLATIONS = {
     'pre' => '準備中',
@@ -105,6 +106,12 @@ class Unit < ApplicationRecord
   end
 
   private
+
+  def key_immutable
+    return unless key_changed? && key_was.present?
+
+    errors.add(:key, 'cannot be changed once set')
+  end
 
   after_commit :expire_timeline_cache
   after_commit :expire_sidebar_cache

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -22,7 +22,14 @@
 
   <div>
     <%= form.label :key, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-    <%= form.text_field :key, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+    <% if unit.new_record? %>
+      <%= form.text_field :key, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+    <% else %>
+      <div class="mt-1 block w-full rounded-md bg-gray-100 border-gray-300 px-3 py-2 text-base text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+        <%= unit.key || "(not set)" %>
+      </div>
+      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Key cannot be changed</p>
+    <% end %>
   </div>
 
   <div>

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class UnitsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+      @unit = Unit.create!(name: 'Existing Unit', key: 'existing-unit-controller-test', status: :active)
+    end
+
+    test 'update does not change key even when key param is submitted' do
+      patch admin_unit_path(@unit), params: {
+        unit: { name: 'Renamed Unit', key: 'attempted-new-key' }
+      }
+
+      assert_redirected_to edit_admin_unit_path(@unit)
+      @unit.reload
+      assert_equal 'existing-unit-controller-test', @unit.key
+      assert_equal 'Renamed Unit', @unit.name
+    end
+
+    test 'create allows setting key' do
+      assert_difference('Unit.count') do
+        post admin_units_path, params: {
+          unit: { name: 'Brand New Unit', key: 'brand-new-unit-key', status: 'active' }
+        }
+      end
+
+      assert_equal 'brand-new-unit-key', Unit.last.key
+    end
+  end
+end

--- a/test/models/unit_test.rb
+++ b/test/models/unit_test.rb
@@ -28,7 +28,25 @@
 require 'test_helper'
 
 class UnitTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'key can be set on create' do
+    unit = Unit.create!(name: 'New Unit', key: 'new-unit-key-test', status: :active)
+
+    assert_equal 'new-unit-key-test', unit.key
+  end
+
+  test 'key cannot be changed once set' do
+    unit = Unit.create!(name: 'Existing Unit', key: 'existing-unit-key-test', status: :active)
+
+    unit.key = 'changed-unit-key-test'
+
+    assert_not unit.valid?
+    assert_includes unit.errors[:key], 'cannot be changed once set'
+  end
+
+  test 'other attributes can still be updated when key is unchanged' do
+    unit = Unit.create!(name: 'Existing Unit', key: 'unchanged-unit-key-test', status: :active)
+
+    assert unit.update(name: 'Renamed Unit')
+    assert_equal 'Renamed Unit', unit.reload.name
+  end
 end


### PR DESCRIPTION
## Summary
- `docs/admin/key_change.md`（実装ステップ Step 2）対応
- `Unit` に `key_immutable` バリデーション（`validate :key_immutable, on: :update`）を追加し、Person と同様に一度設定した `key` を通常の `update` では変更できないようにする
- `Admin::UnitsController#update` は `key` を除いた `unit_update_params` を使用（`new`/`create` は引き続き `key` を設定可能）
- 編集画面（`units/_form.html.erb`）の `key` 表示を readonly に変更（新規作成時は引き続き入力可能）

Closes #867

## Test plan
- [x] `bundle exec rubocop`（オフェンスなし）
- [x] `bin/rails test`（100 tests, 0 failures）
- [x] フォームの直接レンダリングで、既存Unitはreadonly表示・新規Unitは入力欄になることを確認