### PR TITLE
fix: admin/people/new で key を設定できるようにする

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -61,7 +61,8 @@ module Admin
     end
 
     def update
-      if @person.update(person_params)
+      # key はキー変更専用の操作でのみ変更可能(issue #57)。通常の update では受け付けない。
+      if @person.update(person_params.except(:key))
         record_update_log(@person, action: 'update')
         redirect_to edit_admin_person_path(@person), notice: 'Person updated successfully.'
       else
@@ -107,7 +108,8 @@ module Admin
 
     def person_params
       params.require(:person).permit(
-        :name, :name_kana, :birthday, :birth_year, :blood, :hometown, :status, :old_history, :destination_key, :note,
+        :name, :key, :name_kana, :birthday, :birth_year, :blood, :hometown, :status, :old_history, :destination_key,
+        :note,
         parts: [],
         tag_index_ids: [],
         links_attributes: %i[id text url active _destroy],

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -76,10 +76,14 @@
       <div class="grid grid-cols-2 gap-4">
         <div>
           <%= form.label :key, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-          <div class="mt-1 block w-full rounded-md bg-gray-100 border-gray-300 px-3 py-2 text-base text-gray-600 dark:bg-gray-900 dark:text-gray-400">
-            <%= person.key || "(not set)" %>
-          </div>
-          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Key cannot be changed</p>
+          <% if person.new_record? %>
+            <%= form.text_field :key, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-2 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+          <% else %>
+            <div class="mt-1 block w-full rounded-md bg-gray-100 border-gray-300 px-3 py-2 text-base text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+              <%= person.key || "(not set)" %>
+            </div>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Key cannot be changed</p>
+          <% end %>
         </div>
         <div>
           <%= form.label :old_key, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -4,8 +4,30 @@ require 'test_helper'
 
 module Admin
   class PeopleControllerTest < ActionDispatch::IntegrationTest
-    # test "the truth" do
-    #   assert true
-    # end
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+      @person = Person.create!(name: 'Existing Person', key: 'existing-person-controller-test', status: :active)
+    end
+
+    test 'create allows setting key' do
+      assert_difference('Person.count') do
+        post admin_people_path, params: {
+          person: { name: 'Brand New Person', key: 'brand-new-person-key', status: 'active' }
+        }
+      end
+
+      assert_equal 'brand-new-person-key', Person.last.key
+    end
+
+    test 'update does not change key even when key param is submitted' do
+      patch admin_person_path(@person), params: {
+        person: { name: 'Renamed Person', key: 'attempted-new-key' }
+      }
+
+      assert_redirected_to edit_admin_person_path(@person)
+      @person.reload
+      assert_equal 'existing-person-controller-test', @person.key
+      assert_equal 'Renamed Person', @person.name
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `person_params` に `:key` を追加（従来は `create` でも欠落しており、`/admin/people/new` から key を持つ Person を作成する手段が存在しなかった）
- フォーム（`people/_form.html.erb`）は `person.new_record?` の場合のみ key を編集可能なテキストフィールドにし、保存済みレコードは従来通り readonly 表示のまま
- `update` アクションは `person_params.except(:key)` を使用し、key の変更を受け付けない（既存の `key_immutable` バリデーションと二重に保護）

## 発見経緯
issue #867（Unitのkey保護）対応中に、Unitで「新規作成時のみ編集可・保存後はreadonly」というパターンを実装した際、Person側の現状を確認して発覚。Person は key_immutable バリデーションと readonly 表示は既にあったが、新規作成時にも key 入力欄自体が存在せず、`/admin/people/new` から key を持つ Person を作成できない状態だった。

Closes #878

## Test plan
- [x] `bundle exec rubocop`（オフェンスなし）
- [x] `bin/rails test`（97 tests, 0 failures）
- [x] 修正前にテストが失敗すること（`create allows setting key` が `nil` を返すこと）を確認してから修正・再確認