### PR TITLE
feat: Person/Unit に change_key! を実装する

### DIFF
--- a/app/models/concerns/key_changeable.rb
+++ b/app/models/concerns/key_changeable.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Person/Unit の key を管理者操作専用に変更するための共通処理(issue #57)。
+# 通常の update では key_immutable バリデーションが変更をブロックするため、
+# change_key! はそのバリデーションを一時的に迂回する専用パスとして提供する。
+module KeyChangeable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :key_change_in_progress
+  end
+
+  # key を new_key に変更し、旧キーからのリダイレクト用スタブレコードを作成、
+  # 旧キーを参照している他テーブルのレコードを一括で追従させる。
+  def change_key!(new_key)
+    return update!(key: new_key) if key.blank?
+
+    prev_key = key
+
+    transaction do
+      begin
+        self.key_change_in_progress = true
+        update!(key: new_key)
+      ensure
+        self.key_change_in_progress = false
+      end
+
+      create_key_change_stub!(prev_key, new_key)
+      rewrite_item_artist_keys(prev_key, new_key)
+      after_key_change(prev_key, new_key)
+    end
+  end
+
+  private
+
+  # サブクラスで、key を参照している独自テーブルのカスケード更新に使う
+  def after_key_change(prev_key, new_key); end
+
+  def create_key_change_stub!(prev_key, new_key)
+    stub = dup
+    stub.key = prev_key
+    stub.destination_key = new_key
+    stub.old_key = nil
+    stub.created_at = nil
+    stub.updated_at = nil
+    stub.save!
+    stub.discard
+  end
+
+  def rewrite_item_artist_keys(prev_key, new_key)
+    Item.by_artist_key(prev_key).find_each do |item|
+      updated_artists = item.artists.map { |a| a['key'] == prev_key ? a.merge('key' => new_key) : a }
+      item.update_column(:artists, updated_artists)
+    end
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -36,6 +36,7 @@ require 'discard'
 class Person < ApplicationRecord
   include Discard::Model
   include WikiParser
+  include KeyChangeable
   has_many :links, as: :linkable, dependent: :destroy
   has_many :wiki_page_imports, as: :import_target
   has_many :unit_people
@@ -157,9 +158,15 @@ class Person < ApplicationRecord
   end
 
   def key_immutable
+    return if key_change_in_progress
     return unless key_changed? && key_was.present?
 
     errors.add(:key, 'cannot be changed once set')
+  end
+
+  def after_key_change(prev_key, new_key)
+    SnapshotPerson.where(person_key: prev_key).update_all(person_key: new_key)
+    UnitPerson.where(person_key: prev_key).update_all(person_key: new_key)
   end
 
   def auto_link_snapshot_people

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -31,6 +31,7 @@ require 'discard'
 
 class Unit < ApplicationRecord
   include Discard::Model
+  include KeyChangeable
   has_many :links, as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: proc { |attrs| attrs['url'].blank? }
   has_many :wiki_page_imports, as: :import_target
@@ -108,6 +109,7 @@ class Unit < ApplicationRecord
   private
 
   def key_immutable
+    return if key_change_in_progress
     return unless key_changed? && key_was.present?
 
     errors.add(:key, 'cannot be changed once set')

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -32,7 +32,7 @@
 #
 require 'test_helper'
 
-class PersonTest < ActiveSupport::TestCase
+class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
   test 'parse_old_history parses simple history' do
     person = Person.new(old_history: 'BandA → BandB')
     history = person.parse_old_history
@@ -190,5 +190,42 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal "Develop One's Faculties", item[:unit_name]
     # '(0x27)は%2527に二重エンコード
     assert_equal '%44%65%76%65%6C%6F%70+%4F%6E%65%2527%73+%46%61%63%75%6C%74%69%65%73', item[:old_key]
+  end
+
+  test 'change_key! updates the key and creates a discarded redirect stub' do
+    person = Person.create!(name: 'Rename Target Person', key: 'person-key-change-before', status: :active)
+
+    person.change_key!('person-key-change-after')
+
+    assert_equal 'person-key-change-after', person.reload.key
+
+    stub = Person.discarded.find_by(key: 'person-key-change-before')
+    assert stub.present?
+    assert stub.discarded?
+    assert_equal 'person-key-change-after', stub.destination_key
+    assert_nil stub.old_key
+  end
+
+  test 'change_key! rewrites snapshot_people.person_key and unit_people.person_key' do
+    person = Person.create!(name: 'Referenced Person', key: 'person-ref-key-before', status: :active)
+    unit = Unit.create!(name: 'Host Unit', key: 'person-ref-host-unit', status: :active)
+    snapshot = unit.unit_snapshots.create!(snapshot_date: Date.current, current: true)
+    snapshot_person = snapshot.snapshot_people.create!(person_key: 'person-ref-key-before', person_name: 'x', sort_order: 1)
+    unit_person = UnitPerson.create!(unit: unit, person_key: 'person-ref-key-before')
+
+    person.change_key!('person-ref-key-after')
+
+    assert_equal 'person-ref-key-after', snapshot_person.reload.person_key
+    assert_equal 'person-ref-key-after', unit_person.reload.person_key
+  end
+
+  test 'change_key! rewrites items.artists referencing the previous key' do
+    person = Person.create!(name: 'Artist Person', key: 'person-artist-key-before', status: :active)
+    item = Item.create!(title: 'Artist Item', release_date: Date.current, link_url: 'https://example.com/person-artist-item',
+                        artists: [{ 'name' => 'Artist Person', 'key' => 'person-artist-key-before' }])
+
+    person.change_key!('person-artist-key-after')
+
+    assert_equal 'person-artist-key-after', item.reload.artists.first['key']
   end
 end

--- a/test/models/unit_test.rb
+++ b/test/models/unit_test.rb
@@ -49,4 +49,28 @@ class UnitTest < ActiveSupport::TestCase
     assert unit.update(name: 'Renamed Unit')
     assert_equal 'Renamed Unit', unit.reload.name
   end
+
+  test 'change_key! updates the key and creates a discarded redirect stub' do
+    unit = Unit.create!(name: 'Rename Target Unit', key: 'unit-key-change-before', status: :active)
+
+    unit.change_key!('unit-key-change-after')
+
+    assert_equal 'unit-key-change-after', unit.reload.key
+
+    stub = Unit.discarded.find_by(key: 'unit-key-change-before')
+    assert stub.present?
+    assert stub.discarded?
+    assert_equal 'unit-key-change-after', stub.destination_key
+    assert_nil stub.old_key
+  end
+
+  test 'change_key! rewrites items.artists referencing the previous key' do
+    unit = Unit.create!(name: 'Artist Unit', key: 'unit-artist-key-before', status: :active)
+    item = Item.create!(title: 'Artist Item', release_date: Date.current, link_url: 'https://example.com/unit-artist-item',
+                        artists: [{ 'name' => 'Artist Unit', 'key' => 'unit-artist-key-before' }])
+
+    unit.change_key!('unit-artist-key-after')
+
+    assert_equal 'unit-artist-key-after', item.reload.artists.first['key']
+  end
 end


### PR DESCRIPTION
## Summary
- `docs/admin/key_change.md`（実装ステップ Step 3）対応
- `KeyChangeable` concern（`app/models/concerns/key_changeable.rb`）を新規作成し、`Person` / `Unit` に共通の `change_key!(new_key)` を実装
  - `key_immutable` バリデーションを迂回する専用フラグ（`key_change_in_progress`）を使ってキーを更新
  - `key: 旧キー` / `destination_key: 新キー` を持つ discard 済みのリダイレクト用スタブレコードを作成（既存の `destination_key` リダイレクト機構をそのまま利用、`ProfilesController` 側の変更は不要）
  - `Person` / `Unit` 共通で `items.artists`（jsonb）内の該当 `key` を新キーに書き換え
  - `Person` はさらに `snapshot_people.person_key` / `unit_people.person_key` を一括置換（`after_key_change` フックで実装）
- Step 1・2 の完了を前提とする実装

Closes #868

## Test plan
- [x] `bundle exec rubocop`（オフェンスなし）
- [x] `bin/rails test`（107 tests, 0 failures）
- [x] スタブレコードの discard 状態・`destination_key`・`old_key` が `nil` であることをモデルスペックで確認
- [x] `snapshot_people` / `unit_people` / `items.artists` の一括置換をモデルスペックで確認