### PR TITLE
feat: 管理画面にキー変更UIを追加する

### DIFF
--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -94,6 +94,10 @@
         </div>
       </div>
 
+      <% unless person.new_record? %>
+        <%= render "admin/shared/change_key_trigger", resource: person, form_id: "change_key_form" %>
+      <% end %>
+
       <div>
         <%= form.label :destination_key, "転送先キー (destination_key)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
         <%= form.text_field :destination_key, placeholder: "統合先 Person の key（旧URL転送用）", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-2 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -8,6 +8,7 @@
     <div class="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-8 items-start">
       <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
         <%= render "form", person: @person %>
+        <%= render "admin/shared/change_key_form", resource: @person, change_key_path: change_key_admin_person_path(@person) %>
       </div>
 
       <div>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -8,8 +8,8 @@
     <div class="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-8 items-start">
       <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
         <%= render "form", person: @person %>
-        <%= render "admin/shared/change_key_form", resource: @person, change_key_path: change_key_admin_person_path(@person) %>
       </div>
+      <%= render "admin/shared/change_key_form", change_key_path: change_key_admin_person_path(@person), form_id: "change_key_form" %>
 
       <div>
         <%= render "links_form", person: @person %>

--- a/app/views/admin/shared/_change_key_form.html.erb
+++ b/app/views/admin/shared/_change_key_form.html.erb
@@ -1,0 +1,21 @@
+<%# locals: resource (Person or Unit), change_key_path %>
+<% if current_user&.admin? %>
+  <div class="mt-4" data-controller="toggle" data-toggle-open-value="false">
+    <button type="button" data-action="toggle#toggle" class="text-xs font-medium text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">
+      キー変更
+    </button>
+    <div data-toggle-target="content" class="mt-2 p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-md">
+      <p class="text-xs text-gray-600 dark:text-gray-400 mb-2">
+        現在のキー: <code class="font-mono"><%= resource.key %></code><br>
+        キーを変更すると、旧キーへのアクセスは新しいキーへ自動的にリダイレクトされます。
+      </p>
+      <%= form_with url: change_key_path, method: :patch, class: "flex gap-2 items-center" do |ck_form| %>
+        <%= ck_form.text_field :new_key, placeholder: "新しいキー", required: true,
+              class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+        <%= ck_form.submit "変更",
+              onclick: "return confirm('新しいキー「' + this.form.new_key.value + '」に変更しますか？この操作は元に戻せません。');",
+              class: "px-3 py-1.5 text-sm text-white bg-indigo-600 hover:bg-indigo-700 rounded cursor-pointer border-0 whitespace-nowrap" %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/shared/_change_key_form.html.erb
+++ b/app/views/admin/shared/_change_key_form.html.erb
@@ -1,21 +1,6 @@
-<%# locals: resource (Person or Unit), change_key_path %>
+<%# locals: change_key_path, form_id %>
+<%# フォームの入れ子はできないため、外枠だけをここに置き、可視部品(_change_key_trigger)は
+    key フィールドの隣から form="<%= form_id %>" で参照する %>
 <% if current_user&.admin? %>
-  <div class="mt-4" data-controller="toggle" data-toggle-open-value="false">
-    <button type="button" data-action="toggle#toggle" class="text-xs font-medium text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">
-      キー変更
-    </button>
-    <div data-toggle-target="content" class="mt-2 p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-md">
-      <p class="text-xs text-gray-600 dark:text-gray-400 mb-2">
-        現在のキー: <code class="font-mono"><%= resource.key %></code><br>
-        キーを変更すると、旧キーへのアクセスは新しいキーへ自動的にリダイレクトされます。
-      </p>
-      <%= form_with url: change_key_path, method: :patch, class: "flex gap-2 items-center" do |ck_form| %>
-        <%= ck_form.text_field :new_key, placeholder: "新しいキー", required: true,
-              class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
-        <%= ck_form.submit "変更",
-              onclick: "return confirm('新しいキー「' + this.form.new_key.value + '」に変更しますか？この操作は元に戻せません。');",
-              class: "px-3 py-1.5 text-sm text-white bg-indigo-600 hover:bg-indigo-700 rounded cursor-pointer border-0 whitespace-nowrap" %>
-      <% end %>
-    </div>
-  </div>
+  <%= form_with url: change_key_path, method: :patch, id: form_id do end %>
 <% end %>

--- a/app/views/admin/shared/_change_key_trigger.html.erb
+++ b/app/views/admin/shared/_change_key_trigger.html.erb
@@ -1,0 +1,24 @@
+<%# locals: resource (Person or Unit), form_id %>
+<% if current_user&.admin? %>
+  <div class="mt-2" data-controller="toggle" data-toggle-open-value="false">
+    <button type="button" data-action="toggle#toggle"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-md">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
+      </svg>
+      キー変更
+    </button>
+    <div data-toggle-target="content" class="mt-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-md">
+      <p class="text-xs text-gray-600 dark:text-gray-400 mb-2">
+        キーを変更すると、旧キー（<code class="font-mono"><%= resource.key %></code>）へのアクセスは新しいキーへ自動的にリダイレクトされます。
+      </p>
+      <div class="flex gap-2 items-center">
+        <%= text_field_tag :new_key, nil, form: form_id, placeholder: "新しいキー", required: true,
+              class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+        <%= submit_tag "変更", form: form_id,
+              onclick: "return confirm('新しいキー「' + document.getElementById('new_key').value + '」に変更しますか？この操作は元に戻せません。');",
+              class: "px-3 py-1.5 text-sm text-white bg-amber-600 hover:bg-amber-700 rounded cursor-pointer border-0 whitespace-nowrap" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -29,6 +29,7 @@
         <%= unit.key || "(not set)" %>
       </div>
       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Key cannot be changed</p>
+      <%= render "admin/shared/change_key_trigger", resource: unit, form_id: "change_key_form" %>
     <% end %>
   </div>
 

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -8,8 +8,8 @@
       <div class="md:col-span-1">
         <div class="bg-white shadow rounded-lg p-6 mb-6">
           <%= render "form", unit: @unit %>
-          <%= render "admin/shared/change_key_form", resource: @unit, change_key_path: change_key_admin_unit_path(@unit) %>
         </div>
+        <%= render "admin/shared/change_key_form", change_key_path: change_key_admin_unit_path(@unit), form_id: "change_key_form" %>
       </div>
       
       <div class="md:col-span-2">

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -8,6 +8,7 @@
       <div class="md:col-span-1">
         <div class="bg-white shadow rounded-lg p-6 mb-6">
           <%= render "form", unit: @unit %>
+          <%= render "admin/shared/change_key_form", resource: @unit, change_key_path: change_key_admin_unit_path(@unit) %>
         </div>
       </div>
       

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -62,6 +62,22 @@ module Admin
       assert_equal 'existing-person-controller-test', @person.reload.key
     end
 
+    test 'edit shows the change key form for admin' do
+      login_as_admin
+
+      get edit_admin_person_path(@person)
+
+      assert_response :success
+      assert_includes response.body, 'キー変更'
+    end
+
+    test 'edit does not show the change key form for non-admin' do
+      get edit_admin_person_path(@person)
+
+      assert_response :success
+      assert_not_includes response.body, 'キー変更'
+    end
+
     private
 
     def login_as_admin

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -62,6 +62,22 @@ module Admin
       assert_equal 'existing-unit-controller-test', @unit.reload.key
     end
 
+    test 'edit shows the change key form for admin' do
+      login_as_admin
+
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      assert_includes response.body, 'キー変更'
+    end
+
+    test 'edit does not show the change key form for non-admin' do
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      assert_not_includes response.body, 'キー変更'
+    end
+
     private
 
     def login_as_admin


### PR DESCRIPTION
## Summary
- `docs/admin/key_change.md`（実装ステップ Step 5）対応
- People/Units 編集画面の readonly な key フィールドのすぐ下に「キー変更」ボタンを配置
  - `<form>` は入れ子にできないため、可視部品（ボタン・入力欄）は key フィールド近く（主フォームの内側）に置きつつ、HTML の `form=` 属性で主フォームの外側にある空のフォーム（`admin/shared/_change_key_form.html.erb`）へ送信する構成にした
  - ボタンはアンバー色・アイコン付きで目立つスタイルに（`admin/shared/_change_key_trigger.html.erb`）
  - 既存の `toggle_controller`（Stimulus）で押下時に入力欄を展開
  - 送信ボタンに `onclick: "return confirm(...)"` で確認ダイアログ（入力された新キーの値を動的に埋め込み）
  - `current_user.admin?` の場合のみ表示
- Step 4（#869）の `change_key` エンドポイントへ `PATCH` 送信

## 動作確認
ローカルで確認用の一時管理者アカウントを作成し、実際にレンダリングされたHTML・フォームを curl で操作して一連の流れを確認（確認後、一時アカウントは削除済み）:
- People/Units 編集画面で「キー変更」ボタンが key フィールドのすぐ下に配置されていることを確認
- 主フォームと change_key フォームが正しく分離されており（入れ子になっていない）、`form=` 属性経由で意図通り送信されることを確認
- 実際のフォーム送信で 302 リダイレクト・キー変更・discard済みスタブ作成・旧キーからの301リダイレクトを確認

Closes #870

## Test plan
- [x] `bundle exec rubocop`（オフェンスなし）
- [x] `bin/rails test`（117 tests, 0 failures）
- [x] admin/非admin での表示切り替えをコントローラースペックで確認
- [x] ローカルで実際のHTML・フォーム構造・送信・リダイレクトを手動確認（上記参照）