### PR TITLE
test: change_key! によるリダイレクト経路を検証する

### DIFF
--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -14,4 +14,50 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     get profile_path(person.key)
     assert_response :success
   end
+
+  test 'accessing a unit by its previous key redirects to the current key after change_key!' do
+    unit = Unit.create!(name: 'Renamed Unit', key: 'unit-redirect-before', status: :active)
+    unit.change_key!('unit-redirect-after')
+
+    get profile_path('unit-redirect-before')
+
+    assert_response :moved_permanently
+    assert_redirected_to profile_path('unit-redirect-after')
+
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, 'Renamed Unit'
+  end
+
+  test 'accessing a person by its previous key redirects to the current key after change_key!' do
+    person = Person.create!(name: 'Renamed Person', key: 'person-redirect-before', status: :active)
+    person.change_key!('person-redirect-after')
+
+    get profile_path('person-redirect-before')
+
+    assert_response :moved_permanently
+    assert_redirected_to profile_path('person-redirect-after')
+
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, 'Renamed Person'
+  end
+
+  test 'accessing a key renamed twice requires two redirect hops to reach the final key' do
+    unit = Unit.create!(name: 'Twice Renamed Unit', key: 'unit-chain-a', status: :active)
+    unit.change_key!('unit-chain-b')
+    unit.change_key!('unit-chain-c')
+
+    get profile_path('unit-chain-a')
+    assert_response :moved_permanently
+    assert_redirected_to profile_path('unit-chain-b')
+
+    follow_redirect!
+    assert_response :moved_permanently
+    assert_redirected_to profile_path('unit-chain-c')
+
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, 'Twice Renamed Unit'
+  end
 end


### PR DESCRIPTION
## Summary
- `docs/admin/key_change.md`（実装ステップ Step 6）対応
- `ProfilesController#show` はコード変更不要（既存の `destination_key` リダイレクトロジックをそのまま利用するため）
- `change_key!` によるリダイレクトを検証するテストを追加
  - Unit / Person それぞれ、旧キーへのアクセスが新キーへ301リダイレクトされること
  - 複数回リネーム（A→B→C）した場合、`/A` へのアクセスが `/B` を経由して2ホップで `/C` に到達すること（実際に `change_key!` を2回実行して確認）

Closes #871

## Test plan
- [x] `bundle exec rubocop`（オフェンスなし）
- [x] `bin/rails test`（120 tests, 0 failures）