### PR TITLE
docs: キー変更機能の権限をpermissions.mdに追記する

### DIFF
--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -53,6 +53,7 @@
 | Items — 削除 | destroy |
 | Users 管理 | 全アクション |
 | Wiki Page Imports | 全アクション |
+| Units / People — キー変更 | change_key |
 
 ---
 
@@ -82,6 +83,7 @@
 | `super_operator_or_above?` でない | 画像管理の削除ボタン |
 | `admin?` でない | Section / Custom Page 編集画面のアップロードボタン |
 | `admin?` でない | ナビの Images リンク |
+| `admin?` でない | Units / People 編集画面の「キー変更」ボタン |
 
 ---
 


### PR DESCRIPTION
## Summary
- `docs/admin/key_change.md`（実装ステップ Step 7）対応
- `docs/admin/permissions.md` に、Step 4（#869）で追加した `change_key` アクションが `admin` ロールのみに制限されていることを追記
  - 「admin のみ」テーブルに `Units / People — キー変更 | change_key` を追加
  - 「ビュー側の表示制御」テーブルに、`admin?` でない場合は「キー変更」ボタンが非表示になることを追加

Closes #872

これで issue #57「[admin] キー変更機能」の Step 1〜7 が全て完了します。