### PR TITLE
リダイレクト元レコードの物理削除機能を追加する(issue #891)

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -2,9 +2,9 @@
 
 module Admin
   class PeopleController < Admin::BaseController # rubocop:disable Metrics/ClassLength
-    before_action :set_person, only: %i[edit update destroy undiscard change_key]
+    before_action :set_person, only: %i[edit update destroy undiscard change_key purge]
     before_action :require_super_operator, only: %i[destroy]
-    before_action :require_admin, only: %i[change_key]
+    before_action :require_admin, only: %i[change_key purge]
 
     def index
       @q = params[:q]
@@ -98,6 +98,30 @@ module Admin
       redirect_to edit_admin_person_path(@person), alert: 'That key is already in use.'
     rescue ActiveRecord::RecordInvalid => e
       redirect_to edit_admin_person_path(@person), alert: e.message
+    end
+
+    def purge
+      unless @person.redirect_source?
+        redirect_to admin_people_path, alert: 'リダイレクト元のレコードのみ物理削除できます。'
+        return
+      end
+
+      if Item.by_artist_key(@person.key).exists?
+        redirect_to admin_people_path, alert: 'このキーはまだ作品から参照されているため物理削除できません。'
+        return
+      end
+
+      key_was = @person.key
+      destination_was = @person.destination_key
+      @person.destroy!
+      UpdateLog.create!(
+        user: current_user,
+        action: 'purge',
+        loggable_type: 'Person',
+        loggable_id: @person.id,
+        diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
+      )
+      redirect_to admin_people_path, notice: 'リダイレクト元レコードを物理削除しました。'
     end
 
     def search

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -102,12 +102,12 @@ module Admin
 
     def purge
       unless @person.redirect_source?
-        redirect_to admin_people_path, alert: 'リダイレクト元のレコードのみ物理削除できます。'
+        redirect_to admin_people_path(redirect_source: 'only'), alert: 'リダイレクト元のレコードのみ物理削除できます。'
         return
       end
 
       if Item.by_artist_key(@person.key).exists?
-        redirect_to admin_people_path, alert: 'このキーはまだ作品から参照されているため物理削除できません。'
+        redirect_to admin_people_path(redirect_source: 'only'), alert: 'このキーはまだ作品から参照されているため物理削除できません。'
         return
       end
 
@@ -121,7 +121,7 @@ module Admin
         loggable_id: @person.id,
         diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
       )
-      redirect_to admin_people_path, notice: 'リダイレクト元レコードを物理削除しました。'
+      redirect_to admin_people_path(redirect_source: 'only'), notice: 'リダイレクト元レコードを物理削除しました。'
     end
 
     def search

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -4,9 +4,9 @@ module Admin
   class UnitsController < Admin::BaseController # rubocop:disable Metrics/ClassLength
     include LoggableLinkChanges
 
-    before_action :set_unit, only: %i[show edit update destroy undiscard change_key]
+    before_action :set_unit, only: %i[show edit update destroy undiscard change_key purge]
     before_action :require_super_operator, only: %i[destroy]
-    before_action :require_admin, only: %i[change_key]
+    before_action :require_admin, only: %i[change_key purge]
 
     def index
       @q = params[:q]
@@ -114,6 +114,30 @@ module Admin
       redirect_to edit_admin_unit_path(@unit), alert: 'That key is already in use.'
     rescue ActiveRecord::RecordInvalid => e
       redirect_to edit_admin_unit_path(@unit), alert: e.message
+    end
+
+    def purge
+      unless @unit.redirect_source?
+        redirect_to admin_units_path, alert: 'リダイレクト元のレコードのみ物理削除できます。'
+        return
+      end
+
+      if Item.by_artist_key(@unit.key).exists?
+        redirect_to admin_units_path, alert: 'このキーはまだ作品から参照されているため物理削除できません。'
+        return
+      end
+
+      key_was = @unit.key
+      destination_was = @unit.destination_key
+      @unit.destroy!
+      UpdateLog.create!(
+        user: current_user,
+        action: 'purge',
+        loggable_type: 'Unit',
+        loggable_id: @unit.id,
+        diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
+      )
+      redirect_to admin_units_path, notice: 'リダイレクト元レコードを物理削除しました。'
     end
 
     def search

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -118,12 +118,12 @@ module Admin
 
     def purge
       unless @unit.redirect_source?
-        redirect_to admin_units_path, alert: 'リダイレクト元のレコードのみ物理削除できます。'
+        redirect_to admin_units_path(redirect_source: 'only'), alert: 'リダイレクト元のレコードのみ物理削除できます。'
         return
       end
 
       if Item.by_artist_key(@unit.key).exists?
-        redirect_to admin_units_path, alert: 'このキーはまだ作品から参照されているため物理削除できません。'
+        redirect_to admin_units_path(redirect_source: 'only'), alert: 'このキーはまだ作品から参照されているため物理削除できません。'
         return
       end
 
@@ -137,7 +137,7 @@ module Admin
         loggable_id: @unit.id,
         diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
       )
-      redirect_to admin_units_path, notice: 'リダイレクト元レコードを物理削除しました。'
+      redirect_to admin_units_path(redirect_source: 'only'), notice: 'リダイレクト元レコードを物理削除しました。'
     end
 
     def search

--- a/app/models/concerns/key_changeable.rb
+++ b/app/models/concerns/key_changeable.rb
@@ -31,6 +31,12 @@ module KeyChangeable
     end
   end
 
+  # discard 済み・destination_key ありのリダイレクト元レコードかどうか(issue #891)。
+  # 物理削除できる対象をこの条件に厳密に限定する。
+  def redirect_source?
+    discarded? && destination_key.present?
+  end
+
   private
 
   # サブクラスで、key を参照している独自テーブルのカスケード更新に使う

--- a/app/models/update_log.rb
+++ b/app/models/update_log.rb
@@ -15,7 +15,7 @@ class UpdateLog < ApplicationRecord
     end
   end
 
-  validates :action, inclusion: { in: %w[create update discard undiscard change_key] }
+  validates :action, inclusion: { in: %w[create update discard undiscard change_key purge] }
 
   def self.for_unit(unit)
     snapshot_ids = unit.unit_snapshot_ids

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -82,6 +82,12 @@
                       form: { class: "inline-block" },
                       class: "text-green-600 hover:text-green-900 bg-transparent border-0 cursor-pointer p-0" %>
                 <% end %>
+                <% if person.redirect_source? && current_user.admin? %>
+                  <%= button_to "物理削除", purge_admin_person_path(person), method: :delete,
+                      form: { class: "inline-block ml-4" },
+                      onclick: "return confirm('「#{person.key}」を物理削除します。この操作は元に戻せません。よろしいですか？')",
+                      class: "text-white bg-red-800 hover:bg-red-900 rounded px-2 py-1 cursor-pointer" %>
+                <% end %>
               <% else %>
                 <%= link_to "Edit", edit_admin_person_path(person), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
                 <% if current_user.super_operator_or_above? %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -81,6 +81,12 @@
                       form: { class: "inline-block" },
                       class: "text-green-600 hover:text-green-900 bg-transparent border-0 cursor-pointer p-0" %>
                 <% end %>
+                <% if unit.redirect_source? && current_user.admin? %>
+                  <%= button_to "物理削除", purge_admin_unit_path(unit), method: :delete,
+                      form: { class: "inline-block ml-4" },
+                      onclick: "return confirm('「#{unit.key}」を物理削除します。この操作は元に戻せません。よろしいですか？')",
+                      class: "text-white bg-red-800 hover:bg-red-900 rounded px-2 py-1 cursor-pointer" %>
+                <% end %>
               <% else %>
                 <%= link_to "Logs", admin_unit_unit_logs_path(unit), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
                 <%= link_to "Edit", edit_admin_unit_path(unit), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       member do
         patch :undiscard
         patch :change_key
+        delete :purge
       end
       resources :unit_logs
       resources :unit_snapshots, except: %i[show] do
@@ -41,6 +42,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       member do
         patch :undiscard
         patch :change_key
+        delete :purge
       end
     end
 

--- a/docs/admin/key_change.md
+++ b/docs/admin/key_change.md
@@ -66,6 +66,7 @@ end
 - Person / Unit で discard ベースの実装を共通化する（Unit には統合用の確立済みパターンとして `unit_type: moved`（discard せず `kept` のまま運用、`lib/tasks/import_moved.rake:57-68`）が既に存在するが、Person には `unit_type` に相当するカラムがなく同じパターンを使えないため、今回は Person/Unit 対称に discard ベースで統一する。`unit_type: moved` は既存の統合用途のまま温存し、本機能では使わない）
 - discard により admin 側のデフォルト一覧・検索（`Person.kept` / `Unit.kept` 起点、[`admin/people_controller.rb`](../../app/controllers/admin/people_controller.rb#L8-L21), [`admin/units_controller.rb`](../../app/controllers/admin/units_controller.rb#L16-L27)）や公開側の一覧・検索・自動補完（`.kept` 起点）からは自動的に除外される
 - 複数回リネームされた場合（A→B→C）、A へのアクセスは B を経由して C まで2ホップでリダイレクトされる（destination_key チェーンは既存の統合パターンでも起こり得る挙動であり、本機能固有の問題ではないため許容する）
+- スタブレコードが残っている間は `prev_key` が unique index 上「使用中」のままになるため、キーを元に戻す（revert）操作はできない。これを解消するため、リダイレクト元レコードを物理削除できる機能を別途 [issue #891](https://github.com/kuwavkdb/vkdby/issues/891) で追加した（`purge` アクション、admin 限定）
 
 ### 2. `change_key!` によるキー更新とカスケード
 

--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -54,6 +54,7 @@
 | Users 管理 | 全アクション |
 | Wiki Page Imports | 全アクション |
 | Units / People — キー変更 | change_key |
+| Units / People — リダイレクト元の物理削除 | purge |
 
 ---
 
@@ -84,6 +85,7 @@
 | `admin?` でない | Section / Custom Page 編集画面のアップロードボタン |
 | `admin?` でない | ナビの Images リンク |
 | `admin?` でない | Units / People 編集画面の「キー変更」ボタン |
+| `admin?` でない | Units / People 一覧のリダイレクト元「物理削除」ボタン |
 
 ---
 

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -62,6 +62,64 @@ module Admin
       assert_equal 'existing-person-controller-test', @person.reload.key
     end
 
+    test 'purge requires admin role' do
+      @person.change_key!('new-key-for-purge-auth-test')
+      stub = Person.discarded.find_by(key: 'existing-person-controller-test')
+
+      delete purge_admin_person_path(stub)
+
+      assert_redirected_to root_path
+      assert Person.exists?(id: stub.id)
+    end
+
+    test 'purge is rejected for a non redirect-source record' do
+      login_as_admin
+
+      delete purge_admin_person_path(@person)
+
+      assert_redirected_to admin_people_path
+      assert_equal 'リダイレクト元のレコードのみ物理削除できます。', flash[:alert]
+      assert Person.exists?(id: @person.id)
+    end
+
+    test 'purge deletes the redirect-source stub and logs the action' do
+      login_as_admin
+      @person.change_key!('new-key-for-purge-test')
+      stub = Person.discarded.find_by(key: 'existing-person-controller-test')
+
+      delete purge_admin_person_path(stub)
+
+      assert_redirected_to admin_people_path
+      assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
+      assert_not Person.exists?(id: stub.id)
+      assert UpdateLog.exists?(loggable_type: 'Person', loggable_id: stub.id, action: 'purge')
+    end
+
+    test 'purge is rejected when the key is still referenced by an item' do
+      login_as_admin
+      @person.change_key!('new-key-for-purge-item-test')
+      stub = Person.discarded.find_by(key: 'existing-person-controller-test')
+      Item.create!(title: 'Some Album', release_date: Date.current, link_url: 'https://example.com/item',
+                   artists: [{ 'key' => stub.key, 'name' => 'Existing Person' }])
+
+      delete purge_admin_person_path(stub)
+
+      assert_redirected_to admin_people_path
+      assert_equal 'このキーはまだ作品から参照されているため物理削除できません。', flash[:alert]
+      assert Person.exists?(id: stub.id)
+    end
+
+    test 'purging a redirect-source stub allows reverting the key' do
+      login_as_admin
+      @person.change_key!('new-key-for-purge-revert-test')
+      stub = Person.discarded.find_by(key: 'existing-person-controller-test')
+
+      delete purge_admin_person_path(stub)
+      @person.reload.change_key!('existing-person-controller-test')
+
+      assert_equal 'existing-person-controller-test', @person.reload.key
+    end
+
     test 'edit shows the change key form for admin' do
       login_as_admin
 

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module Admin
-  class PeopleControllerTest < ActionDispatch::IntegrationTest
+  class PeopleControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
     setup do
       post login_path, params: { email: users(:one).email, password: 'password' }
       @person = Person.create!(name: 'Existing Person', key: 'existing-person-controller-test', status: :active)

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -77,7 +77,7 @@ module Admin
 
       delete purge_admin_person_path(@person)
 
-      assert_redirected_to admin_people_path
+      assert_redirected_to admin_people_path(redirect_source: 'only')
       assert_equal 'リダイレクト元のレコードのみ物理削除できます。', flash[:alert]
       assert Person.exists?(id: @person.id)
     end
@@ -89,7 +89,7 @@ module Admin
 
       delete purge_admin_person_path(stub)
 
-      assert_redirected_to admin_people_path
+      assert_redirected_to admin_people_path(redirect_source: 'only')
       assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
       assert_not Person.exists?(id: stub.id)
       assert UpdateLog.exists?(loggable_type: 'Person', loggable_id: stub.id, action: 'purge')
@@ -104,7 +104,7 @@ module Admin
 
       delete purge_admin_person_path(stub)
 
-      assert_redirected_to admin_people_path
+      assert_redirected_to admin_people_path(redirect_source: 'only')
       assert_equal 'このキーはまだ作品から参照されているため物理削除できません。', flash[:alert]
       assert Person.exists?(id: stub.id)
     end

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -77,7 +77,7 @@ module Admin
 
       delete purge_admin_unit_path(@unit)
 
-      assert_redirected_to admin_units_path
+      assert_redirected_to admin_units_path(redirect_source: 'only')
       assert_equal 'リダイレクト元のレコードのみ物理削除できます。', flash[:alert]
       assert Unit.exists?(id: @unit.id)
     end
@@ -89,7 +89,7 @@ module Admin
 
       delete purge_admin_unit_path(stub)
 
-      assert_redirected_to admin_units_path
+      assert_redirected_to admin_units_path(redirect_source: 'only')
       assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
       assert_not Unit.exists?(id: stub.id)
       assert UpdateLog.exists?(loggable_type: 'Unit', loggable_id: stub.id, action: 'purge')
@@ -104,7 +104,7 @@ module Admin
 
       delete purge_admin_unit_path(stub)
 
-      assert_redirected_to admin_units_path
+      assert_redirected_to admin_units_path(redirect_source: 'only')
       assert_equal 'このキーはまだ作品から参照されているため物理削除できません。', flash[:alert]
       assert Unit.exists?(id: stub.id)
     end

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -62,6 +62,64 @@ module Admin
       assert_equal 'existing-unit-controller-test', @unit.reload.key
     end
 
+    test 'purge requires admin role' do
+      @unit.change_key!('new-key-for-purge-auth-test')
+      stub = Unit.discarded.find_by(key: 'existing-unit-controller-test')
+
+      delete purge_admin_unit_path(stub)
+
+      assert_redirected_to root_path
+      assert Unit.exists?(id: stub.id)
+    end
+
+    test 'purge is rejected for a non redirect-source record' do
+      login_as_admin
+
+      delete purge_admin_unit_path(@unit)
+
+      assert_redirected_to admin_units_path
+      assert_equal 'リダイレクト元のレコードのみ物理削除できます。', flash[:alert]
+      assert Unit.exists?(id: @unit.id)
+    end
+
+    test 'purge deletes the redirect-source stub and logs the action' do
+      login_as_admin
+      @unit.change_key!('new-key-for-purge-test')
+      stub = Unit.discarded.find_by(key: 'existing-unit-controller-test')
+
+      delete purge_admin_unit_path(stub)
+
+      assert_redirected_to admin_units_path
+      assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
+      assert_not Unit.exists?(id: stub.id)
+      assert UpdateLog.exists?(loggable_type: 'Unit', loggable_id: stub.id, action: 'purge')
+    end
+
+    test 'purge is rejected when the key is still referenced by an item' do
+      login_as_admin
+      @unit.change_key!('new-key-for-purge-item-test')
+      stub = Unit.discarded.find_by(key: 'existing-unit-controller-test')
+      Item.create!(title: 'Some Album', release_date: Date.current, link_url: 'https://example.com/item',
+                   artists: [{ 'key' => stub.key, 'name' => 'Existing Unit' }])
+
+      delete purge_admin_unit_path(stub)
+
+      assert_redirected_to admin_units_path
+      assert_equal 'このキーはまだ作品から参照されているため物理削除できません。', flash[:alert]
+      assert Unit.exists?(id: stub.id)
+    end
+
+    test 'purging a redirect-source stub allows reverting the key' do
+      login_as_admin
+      @unit.change_key!('new-key-for-purge-revert-test')
+      stub = Unit.discarded.find_by(key: 'existing-unit-controller-test')
+
+      delete purge_admin_unit_path(stub)
+      @unit.reload.change_key!('existing-unit-controller-test')
+
+      assert_equal 'existing-unit-controller-test', @unit.reload.key
+    end
+
     test 'edit shows the change key form for admin' do
       login_as_admin
 

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module Admin
-  class UnitsControllerTest < ActionDispatch::IntegrationTest
+  class UnitsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
     setup do
       post login_path, params: { email: users(:one).email, password: 'password' }
       @unit = Unit.create!(name: 'Existing Unit', key: 'existing-unit-controller-test', status: :active)


### PR DESCRIPTION
## Summary
- キー変更（issue #57）で作成されるリダイレクト元スタブは discard 済みのまま key の unique index を占有し続けるため、後でキーを元に戻す（revert）変更ができなくなる問題があった (#891)
- admin 限定の `purge` アクションを Person/Unit に追加し、discard済み・`destination_key`ありのレコード（リダイレクト元）のみ物理削除できるようにした
- 削除前に `Item.by_artist_key` でまだ作品から参照されているキーでないことを確認し、リンク切れを防止
- `UpdateLog` に `purge` アクションを記録

## Test plan
- [x] `bundle exec rails test test/controllers/admin/people_controller_test.rb test/controllers/admin/units_controller_test.rb test/models/person_test.rb test/models/unit_test.rb` — 全件パス
- [x] `bundle exec rubocop` 対象ファイルでオフェンスなし
- [x] ローカル dev サーバーで実際にログイン→リダイレクト元一覧→物理削除ボタンの動作をcurlで実行し、スタブレコードが削除され `UpdateLog(action: 'purge')` が記録されることを確認
- [x] **本題の確認**: 物理削除後にキーを元に戻す `change_key!` が成功し、`/{元のキー}` が 200 で解決することを確認
- [x] `docs/admin/permissions.md` / `docs/admin/key_change.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)