### PR TITLE
feat: Unit Edit画面に論理削除ボタンを追加する(issue #895)

### DIFF
--- a/app/views/admin/shared/_change_key_form.html.erb
+++ b/app/views/admin/shared/_change_key_form.html.erb
@@ -1,6 +1,6 @@
 <%# locals: change_key_path, form_id %>
 <%# フォームの入れ子はできないため、外枠だけをここに置き、可視部品(_change_key_trigger)は
-    key フィールドの隣から form="<%= form_id %>" で参照する %>
+    key フィールドの隣から form 属性で form_id を参照する %>
 <% if current_user&.admin? %>
   <%= form_with url: change_key_path, method: :patch, id: form_id do end %>
 <% end %>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -4,18 +4,26 @@
       <h1 class="text-2xl font-bold">Edit Unit: <%= @unit.name %></h1>
       <%= link_to "Back to Public Page", profile_path(@unit.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
-    <div class="md:grid md:grid-cols-3 md:gap-8">
-      <div class="md:col-span-1">
+    <div class="md:grid md:grid-cols-5 md:gap-8">
+      <div class="md:col-span-2">
         <div class="bg-white shadow rounded-lg p-6 mb-6">
           <%= render "form", unit: @unit %>
         </div>
         <%= render "admin/shared/change_key_form", change_key_path: change_key_admin_unit_path(@unit), form_id: "change_key_form" %>
       </div>
-      
-      <div class="md:col-span-2">
+
+      <div class="md:col-span-3">
         <%= render "snapshots_list", unit: @unit, unit_snapshots: @unit_snapshots %>
         <%= render "links_form", unit: @unit %>
         <%= render "admin/sections/list", sectionable: @unit, sections: @unit.sections.with_discarded.order(:sort_order) %>
+        <% if current_user.super_operator_or_above? && !@unit.discarded? %>
+          <div class="mt-4 mb-4 flex justify-end">
+            <%= button_to "論理削除", admin_unit_path(@unit), method: :delete,
+                form_class: "inline",
+                onclick: "return confirm('#{@unit.name} を論理削除しますか？')",
+                class: "px-3 py-1.5 text-sm text-white bg-red-600 hover:bg-red-700 rounded cursor-pointer border-0" %>
+          </div>
+        <% end %>
         <%= render "admin/wiki_page_imports/import_target_panel", wiki_page_imports: @wiki_page_imports, import_target: @unit %>
       </div>
     </div>

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -136,11 +136,41 @@ module Admin
       assert_not_includes response.body, 'キー変更'
     end
 
+    test 'edit shows the discard button for super_operator or above' do
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      assert_includes response.body, '論理削除'
+    end
+
+    test 'edit does not show the discard button for operator' do
+      login_as_operator
+
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      assert_not_includes response.body, '論理削除'
+    end
+
+    test 'edit does not show the discard button for an already discarded unit' do
+      @unit.discard
+
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      assert_not_includes response.body, '論理削除'
+    end
+
     private
 
     def login_as_admin
       admin = User.create!(email: 'admin-key-change-test@example.com', name: 'Admin', password: 'password', role: :admin)
       post login_path, params: { email: admin.email, password: 'password' }
+    end
+
+    def login_as_operator
+      operator = User.create!(email: 'operator-discard-test@example.com', name: 'Operator', password: 'password', role: :operator)
+      post login_path, params: { email: operator.email, password: 'password' }
     end
   end
 end


### PR DESCRIPTION
## Summary
- Person Edit画面と同様に、Unit Edit画面にも論理削除ボタンを追加(super_operator以上のロールで、未削除のUnitにのみ表示)
- 検証中に見つかった `_change_key_form.html.erb` のERBコメント閉じ忘れ(2026-07-09混入)による文字列漏れを修正
- 左右カラム比率を `1:2` から `2:3`(左を少し広く)に調整

Closes #895

## Test plan
- [x] `test/controllers/admin/units_controller_test.rb` にボタン表示/非表示のテストを追加し、全15テスト成功
- [x] `bin/rails tailwindcss:build` 後、ブラウザで論理削除ボタンの表示・非表示(operator/super_operator/discarded済み)を確認
- [x] 論理削除ボタン押下 → discard実行 → 一覧へリダイレクト → DBのdiscarded_atが更新されることを確認
- [x] `_change_key_form.html.erb` 修正後、不審な文字列が表示されなくなったことを確認
- [x] push時のpre-pushフック(RuboCop 291ファイル、テスト133件)が全て成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)