### PR TITLE
トップページに「今日はなんの日？」導線を追加する

### DIFF
--- a/app/views/custom_pages/_today_teaser.html.erb
+++ b/app/views/custom_pages/_today_teaser.html.erb
@@ -1,0 +1,22 @@
+<% today = Date.current %>
+<div class="bg-white dark:bg-slate-800 shadow rounded-2xl overflow-hidden">
+  <%= link_to birthday_date_path(month: today.month, day: today.day),
+      class: "flex items-center gap-4 px-4 py-4 sm:px-6 sm:py-5 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+         class="w-8 h-8 shrink-0 text-indigo-500 dark:text-indigo-400" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+    </svg>
+    <div class="flex-1 min-w-0">
+      <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+        What Happened Today<br><span class="text-xs font-normal">今日はなんの日？</span>
+      </h2>
+      <p class="mt-1 text-sm font-bold text-slate-700 dark:text-slate-200">
+        <%= "#{today.month}月#{today.day}日" %>が誕生日のアーティストや、動向・リリース情報をまとめてチェック
+      </p>
+    </div>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+         class="w-5 h-5 shrink-0 text-slate-400 dark:text-slate-500" aria-hidden="true">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+    </svg>
+  <% end %>
+</div>

--- a/app/views/custom_pages/show.html.erb
+++ b/app/views/custom_pages/show.html.erb
@@ -4,25 +4,32 @@
   <div class="w-full max-w-7xl">
     <div class="lg:grid lg:grid-cols-[1fr_280px] lg:gap-6 lg:items-start">
 
-      <%# メインコンテンツ %>
-      <div class="bg-white dark:bg-slate-800 shadow md:shadow-2xl rounded-none md:rounded-3xl overflow-hidden animate-in slide-in-from-bottom-5 duration-700">
-        <div class="bg-slate-50 dark:bg-slate-900/30 p-6 md:p-8 border-b border-slate-100 dark:border-slate-700 flex justify-between items-start">
-          <h1 class="text-2xl md:text-3xl font-bold text-slate-800 dark:text-slate-100"><%= @page.title %></h1>
-          <% if logged_in? %>
-            <%= link_to edit_admin_custom_page_path(@page),
-                class: "ml-4 flex-shrink-0 flex items-center gap-1 px-3 py-1.5 text-sm text-indigo-600 border border-indigo-300 rounded-md hover:bg-indigo-50 dark:text-indigo-400 dark:border-indigo-700 dark:hover:bg-indigo-900/30" do %>
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
-              </svg>
-              編集
+      <%# メインカラム: メインコンテンツ＋今日はなんの日？（トップページのみ） %>
+      <div class="space-y-6">
+        <div class="bg-white dark:bg-slate-800 shadow md:shadow-2xl rounded-none md:rounded-3xl overflow-hidden animate-in slide-in-from-bottom-5 duration-700">
+          <div class="bg-slate-50 dark:bg-slate-900/30 p-6 md:p-8 border-b border-slate-100 dark:border-slate-700 flex justify-between items-start">
+            <h1 class="text-2xl md:text-3xl font-bold text-slate-800 dark:text-slate-100"><%= @page.title %></h1>
+            <% if logged_in? %>
+              <%= link_to edit_admin_custom_page_path(@page),
+                  class: "ml-4 flex-shrink-0 flex items-center gap-1 px-3 py-1.5 text-sm text-indigo-600 border border-indigo-300 rounded-md hover:bg-indigo-50 dark:text-indigo-400 dark:border-indigo-700 dark:hover:bg-indigo-900/30" do %>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
+                </svg>
+                編集
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
-        <div class="p-5 md:p-8">
-          <div class="markdown-content max-w-none">
-            <%= markdown(@page.body, sectionable: @page) %>
+          </div>
+          <div class="p-5 md:p-8">
+            <div class="markdown-content max-w-none">
+              <%= markdown(@page.body, sectionable: @page) %>
+            </div>
           </div>
         </div>
+
+        <%# 今日はなんの日？ (トップページのみ、メインコンテンツの下に表示) %>
+        <% if @page.key == 'index' %>
+          <%= render 'today_teaser' %>
+        <% end %>
       </div>
 
       <%# PC: サイドバーを右カラムに表示 %>

--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -8,14 +8,14 @@
         <div class="flex gap-2 flex-shrink-0">
           <% prev_date = @date - 1.day %>
           <% if @year_agnostic %>
-            <%= link_to "← 前日", birthday_date_path(month: prev_date.month, day: prev_date.day),
-                class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+            <%= link_to "← 前日 (#{prev_date.month}/#{prev_date.day})", birthday_date_path(month: prev_date.month, day: prev_date.day),
+                class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% else %>
             <% prev_year_date = @date - 1.year %>
             <%= link_to "← 前年同日", daily_path(year: prev_year_date.year, month: prev_year_date.month, day: prev_year_date.day),
                 class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
-            <%= link_to "← 前日", daily_path(year: prev_date.year, month: prev_date.month, day: prev_date.day),
-                class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+            <%= link_to "← 前日 (#{prev_date.month}/#{prev_date.day})", daily_path(year: prev_date.year, month: prev_date.month, day: prev_date.day),
+                class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% end %>
         </div>
         <div class="text-center flex-grow">
@@ -29,15 +29,33 @@
           <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
             <%= @year_agnostic ? "All Years Summary" : "Daily Summary" %>
           </p>
+          <% if @year_agnostic %>
+            <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
+              <%= "#{@date.month}月#{@date.day}日" %>が誕生日のアーティストや、動向・リリース情報をまとめて掲載しています。
+            </p>
+            <% if @birthdays.present? || @trends.present? || @releases.present? %>
+              <nav class="flex flex-wrap justify-center gap-2 mt-4" aria-label="ページ内リンク">
+                <% if @birthdays.present? %>
+                  <%= link_to '#birthdays', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>誕生日<% end %>
+                <% end %>
+                <% if @trends.present? %>
+                  <%= link_to '#trends', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>動向<% end %>
+                <% end %>
+                <% if @releases.present? %>
+                  <%= link_to '#releases', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>リリース<% end %>
+                <% end %>
+              </nav>
+            <% end %>
+          <% end %>
         </div>
         <div class="flex gap-2 flex-shrink-0">
           <% next_date = @date + 1.day %>
           <% if @year_agnostic %>
-            <%= link_to "翌日 →", birthday_date_path(month: next_date.month, day: next_date.day),
-                class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+            <%= link_to "翌日 (#{next_date.month}/#{next_date.day}) →", birthday_date_path(month: next_date.month, day: next_date.day),
+                class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% else %>
-            <%= link_to "翌日 →", daily_path(year: next_date.year, month: next_date.month, day: next_date.day),
-                class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+            <%= link_to "翌日 (#{next_date.month}/#{next_date.day}) →", daily_path(year: next_date.year, month: next_date.month, day: next_date.day),
+                class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
             <% next_year_date = @date + 1.year %>
             <%= link_to "翌年同日 →", daily_path(year: next_year_date.year, month: next_year_date.month, day: next_year_date.day),
                 class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
@@ -51,7 +69,7 @@
 
     <!-- Trends Section -->
     <% if @trends.present? %>
-      <section class="mb-12">
+      <section id="trends" class="mb-12">
         <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4 flex items-center gap-2">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
@@ -88,7 +106,7 @@
 
     <!-- Releases Section -->
     <% if @releases.present? %>
-      <section class="mb-12">
+      <section id="releases" class="mb-12">
         <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700 pb-2 mb-4 flex items-center gap-2">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>

--- a/test/controllers/custom_pages_controller_test.rb
+++ b/test/controllers/custom_pages_controller_test.rb
@@ -3,12 +3,14 @@
 require 'test_helper'
 
 class CustomPagesControllerTest < ActionDispatch::IntegrationTest
-  test 'sidebar does not render a discarded unit or person referenced by a weekly trend' do
+  setup do
     # key未設定の既存フィクスチャが "最近の更新" 欄に混ざると別バグ(issue #874)で
     # profile_path がルート生成エラーになるため、この検証の対象外にしておく
     Unit.kept.where(key: nil).find_each(&:discard)
     Person.kept.where(key: nil).find_each(&:discard)
+  end
 
+  test 'sidebar does not render a discarded unit or person referenced by a weekly trend' do
     unit = Unit.create!(name: 'Discarded Sidebar Unit', key: 'discarded-unit-sidebar-test', status: :active)
     person = Person.create!(name: 'Discarded Sidebar Person', key: 'discarded-person-sidebar-test', status: :active)
     unit.discard

--- a/test/controllers/custom_pages_controller_test.rb
+++ b/test/controllers/custom_pages_controller_test.rb
@@ -25,4 +25,26 @@ class CustomPagesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, 'Discarded Sidebar Person'
     assert_no_match(%r{<span class="inline-block[^"]*">\s*</span>}, response.body)
   end
+
+  test 'index page shows the today teaser link with correct href and bilingual text' do
+    CustomPage.create!(key: 'index', title: 'トップページ', active: true, body: 'body')
+    today = Date.current
+
+    get root_path
+
+    assert_response :success
+    assert_includes response.body, birthday_date_path(month: today.month, day: today.day)
+    assert_includes response.body, '今日はなんの日？'
+    assert_includes response.body, 'What Happened Today'
+  end
+
+  test 'non-index custom page does not show the today teaser link' do
+    page = CustomPage.create!(key: 'other-page-for-teaser-test', title: 'Other Page', active: true, body: 'body')
+
+    get custom_page_path(key: page.key)
+
+    assert_response :success
+    assert_not_includes response.body, '今日はなんの日？'
+    assert_not_includes response.body, 'What Happened Today'
+  end
 end


### PR DESCRIPTION
## Summary
- トップページのメインコンテンツ下に、今日の月日に対応する年をまたいだ「今日はなんの日？」ページ（`/date/-/MM/DD`）への導線（`_today_teaser.html.erb`）を追加
- 導線はトップページ（`CustomPage#key == 'index'`）のみに表示し、他の静的ページには表示されないようガード
- リンク先の年をまたいだ日付ページ（`daily/show.html.erb`、`@year_agnostic`）にも、同様の説明文と、誕生日／動向／リリースへのページ内ジャンプリンクを追加
- 同ページの前日・翌日リンクに日付を括弧書きで併記し、視認性を向上

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bin/rubocop` でオフェンスがないこと
- [ ] トップページのメインコンテンツ下に「今日はなんの日？」セクションが表示され、クリックで年をまたいだ日付ページに遷移すること
- [ ] トップページ以外の静的ページでは当該セクションが表示されないこと
- [ ] 日付ページの「誕生日／動向／リリース」ジャンプリンクが該当セクションにスクロールすること
- [ ] 前日・翌日リンクに日付が表示されること

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)