### PR TITLE
release-pr スキルのブランチ名を v0 プレフィックス・同日複数リリース対応にする

### DIFF
--- a/.claude/skills/release-pr/SKILL.md
+++ b/.claude/skills/release-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-pr
-description: developブランチから release/0.yyyy.mmdd ブランチを切ってpushし、PRを作成する
+description: developブランチから release/v0.yyyy.mmdd ブランチを切ってpushし、PRを作成する
 ---
 
 # Release PR 作成
@@ -10,7 +10,7 @@ description: developブランチから release/0.yyyy.mmdd ブランチを切っ
 ## 手順
 
 1. 今日の日付を取得して、ブランチ名を決定する
-   - フォーマット: `release/0.YYYY.MMDD`（例: `release/0.2026.0227`）
+   - フォーマット: `release/v0.YYYY.MMDD`（例: `release/v0.2026.0227`）
    - Bash で `date +%Y.%m%d` を実行して取得する
 
 2. `develop` ブランチに切り替えて最新化する
@@ -26,20 +26,30 @@ description: developブランチから release/0.yyyy.mmdd ブランチを切っ
      ```
    - issue が1件も見つからない場合は「変更内容なし（依存関係更新のみ等）」と記載する
 
-4. リリースブランチを作成する
+4. ブランチ名を確定する
+   - 最新タグを取得する:
+     ```
+     git tag --sort=-creatordate | head -1
+     ```
+   - 最新タグが今日の日付文字列（`<date>`）を含む場合: 末尾のサフィックス番号を +1 する
+     - 例: 最新タグが `v0.2026.0227` → `release/v0.2026.0227.2`
+     - 例: 最新タグが `v0.2026.0227.2` → `release/v0.2026.0227.3`
+   - 最新タグが今日の日付文字列を含まない場合: `release/v0.<date>` をそのまま使う
+
+5. リリースブランチを作成する
    ```
-   git checkout -b release/0.<date>
+   git checkout -b <確定したブランチ名>
    ```
 
-5. リモートにpushする
+6. リモートにpushする
    ```
-   git push origin release/0.<date>
+   git push origin <確定したブランチ名>
    ```
 
-6. PRを作成する（ベースブランチは `main`）
+7. PRを作成する（ベースブランチは `main`）
    収集した issue 一覧を PR の本文に含める。フォーマット:
    ```
-   ## Release 0.<date>
+   ## Release v0.<date>
 
    ### 含まれる変更
 
@@ -48,7 +58,7 @@ description: developブランチから release/0.yyyy.mmdd ブランチを切っ
    ```
 
    ```
-   gh pr create --base main --title "release/0.<date>" --body "<上記フォーマットの本文>"
+   gh pr create --base main --title "<確定したブランチ名>" --body "<上記フォーマットの本文>"
    ```
 
-7. 作成したPRのURLをユーザーに表示する
+8. 作成したPRのURLをユーザーに表示する


### PR DESCRIPTION
## Summary
- リリースタグ形式が `release/0.yyyy.mmdd` から `release/v0.yyyy.mmdd` に変わったため、`.claude/skills/release-pr/SKILL.md` の手順を追従させる
- 同日に複数回リリースする場合に、最新タグを確認してサフィックス番号（`.2`, `.3` ...）を採番するロジックを追加

## Test plan
- [x] `bin/rails test` が全件パスすること（Markdownのみの変更のため影響なし）
- [ ] 次回 `/release-pr` 実行時に、ブランチ名・PRタイトルが `release/v0.<date>` 形式になること
- [ ] 同日に複数回実行した場合、`.2`, `.3` のようにサフィックスが採番されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)