### PR TITLE
fix: 別名のnameが空の場合にプロフィールヘッダーで「/」だけが表示されるのを防ぐ

### DIFF
--- a/app/components/profile_header_component.html.erb
+++ b/app/components/profile_header_component.html.erb
@@ -7,10 +7,10 @@
         <%= name %>
       <% end %>
     </h1>
-    <% if @resource.aliases.any? %>
+    <% if display_aliases.any? %>
       <span class="text-2xl md:text-3xl opacity-40 font-thin">/</span>
       <span class="text-2xl md:text-3xl opacity-75 font-medium">
-        <% @resource.aliases.each_with_index do |a, i| %>
+        <% display_aliases.each_with_index do |a, i| %>
           <%= " / " if i > 0 %><% if a.kana.present? %><ruby><%= a.name %><rt><%= a.kana %></rt></ruby><% else %><%= a.name %><% end %>
         <% end %>
       </span>

--- a/app/components/profile_header_component.rb
+++ b/app/components/profile_header_component.rb
@@ -22,4 +22,8 @@ class ProfileHeaderComponent < ViewComponent::Base
   def name_kana
     @resource.name_kana
   end
+
+  def display_aliases
+    @resource.aliases.reject { |a| a.name.blank? }
+  end
 end


### PR DESCRIPTION
## Summary
- `ProfileHeaderComponent` の `@resource.aliases.any?` は配列が空かどうかしか見ておらず、name が nil のエントリでも区切り記号「/」が表示されてしまっていた
- L'Arc〜en〜Ciel (`/rarukuanshieru`) の `units.aliases` カラムに `{"kana" => "", "name" => nil, "old_key" => "..."}` という、旧wiki移行時の old_key のみ残存したデータがあり、これにより「/」だけが表示される不具合が発生していた
- name が空のエントリを除外する `display_aliases` を追加し、そちらを表示判定・ループに使うよう変更

Fixes #903

## Test plan
- [x] `/rarukuanshieru` で「/」が表示されなくなることを確認
- [x] 実際に別名を持つユニット (`/siva`) で別名表示が壊れていないことを確認
- [x] pre-push フック（RuboCop / テスト）が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)