### PR TITLE
fix: プロフィールページのメインカラム幅がサイドカラムより狭くなる問題を修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
     <%= render 'layouts/google_adsense' %>
   </head>
 
-  <body class="bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
+  <body class="bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 min-w-[375px]">
     <nav class="bg-white/95 dark:bg-zinc-950/95 border-b border-zinc-200 dark:border-zinc-800 relative z-50 backdrop-blur-sm">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -39,7 +39,7 @@
         <%= render YoutubeEmbedComponent.new(links: @youtube_links) %>
       </div>
 
-      <div class="grid gap-8 grid-cols-1 md:grid-cols-[350px_1fr] items-start">
+      <div class="grid gap-8 grid-cols-1 md:grid-cols-[minmax(220px,350px)_minmax(350px,1fr)] items-start">
         <div>
           <%= render BasicAttributesComponent.new(resource: @resource) %>
           <%= render NameHistoryComponent.new(resource: @resource) %>


### PR DESCRIPTION
## Summary
- issue #904 対応。プロフィールページ（Person/Unit共通）で、画面幅が768〜850px付近のとき、メインカラム(`.column-right`)がサイドカラム(BASIC INFORMATION等)より狭くなってしまう問題を修正
- グリッド定義を `md:grid-cols-[350px_1fr]` から `md:grid-cols-[minmax(220px,350px)_minmax(350px,1fr)]` に変更し、メインカラムに常時350px以上の最小幅を保証
- あわせて、サイト全体（`body`）に `min-width: 375px` を設定し、極端に狭い画面幅でもレイアウトが崩れず横スクロールで収まるようにした

## Test plan
- [x] Playwright で 700px〜1280px の各幅で Person/Unit 双方のプロフィールページを検証し、修正前は768〜850px帯で再現、修正後は全幅で解消することを確認
- [x] 320px/360px/375px/400px でサイト全体の min-width 375px の挙動を確認（375px未満で横スクロール、崩れなし）
- [x] `bundle exec rails test` 実行済み（135 runs, 0 failures）
- [x] RuboCop 実行済み（no offenses detected）

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)