### PR TITLE
fix: 日付ページ(日/月/年)のヘッダーナビゲーションリンクのサイズ・スタイルを統一し、曜日表示を追加

### DIFF
--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -13,22 +13,22 @@
           <% else %>
             <% prev_year_date = @date - 1.year %>
             <%= link_to "← 前年同日", daily_path(year: prev_year_date.year, month: prev_year_date.month, day: prev_year_date.day),
-                class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+                class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
             <%= link_to "← 前日 (#{prev_date.month}/#{prev_date.day})", daily_path(year: prev_date.year, month: prev_date.month, day: prev_date.day),
                 class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% end %>
         </div>
         <div class="text-center flex-grow">
+          <p class="text-sm text-slate-500 dark:text-slate-400 mb-2">
+            <%= @year_agnostic ? "All Years Summary" : "Daily Summary" %>
+          </p>
           <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
             <% if @year_agnostic %>
               <%= "#{@date.month}月#{@date.day}日" %>
             <% else %>
-              <%= link_to "#{@date.year}年#{@date.month}月", monthly_path(year: @date.year, month: @date.month), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-d日') %>
+              <%= link_to "#{@date.year}年#{@date.month}月", monthly_path(year: @date.year, month: @date.month), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-d日') %><span class="text-xl font-bold text-slate-500 dark:text-slate-400 ml-1">(<%= %w[日 月 火 水 木 金 土][@date.wday] %>)</span>
             <% end %>
           </h1>
-          <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
-            <%= @year_agnostic ? "All Years Summary" : "Daily Summary" %>
-          </p>
           <% if @year_agnostic %>
             <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
               <%= "#{@date.month}月#{@date.day}日" %>が誕生日のアーティストや、動向・リリース情報をまとめて掲載しています。
@@ -46,6 +46,9 @@
                 <% end %>
               </nav>
             <% end %>
+          <% else %>
+            <%= link_to "他の年の#{@date.month}月#{@date.day}日", birthday_date_path(month: @date.month, day: @date.day),
+                class: "inline-block mt-3 text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% end %>
         </div>
         <div class="flex gap-2 flex-shrink-0">
@@ -58,7 +61,7 @@
                 class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
             <% next_year_date = @date + 1.year %>
             <%= link_to "翌年同日 →", daily_path(year: next_year_date.year, month: next_year_date.month, day: next_year_date.day),
-                class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+                class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% end %>
         </div>
       </div>

--- a/app/views/monthly/show.html.erb
+++ b/app/views/monthly/show.html.erb
@@ -8,26 +8,26 @@
         <div class="flex gap-2 flex-shrink-0">
           <% prev_year_date = @date - 1.year %>
           <%= link_to "← 前年同月", monthly_path(year: prev_year_date.year, month: prev_year_date.month),
-              class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+              class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% prev_month = @date - 1.month %>
           <%= link_to "← 前月", monthly_path(year: prev_month.year, month: prev_month.month),
-              class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+              class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
         </div>
         <div class="text-center flex-grow">
+          <p class="text-sm text-slate-500 dark:text-slate-400 mb-2">
+            Monthly Summary
+          </p>
           <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
             <%= link_to "#{@date.year}年", yearly_path(year: @date.year), class: "text-indigo-600 dark:text-indigo-400 underline decoration-2 underline-offset-4 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors" %><%= @date.strftime('%-m月') %>
           </h1>
-          <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
-            Monthly Summary
-          </p>
         </div>
         <div class="flex gap-2 flex-shrink-0">
           <% next_month = @date + 1.month %>
           <%= link_to "翌月 →", monthly_path(year: next_month.year, month: next_month.month),
-              class: "text-xs font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap" %>
+              class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
           <% next_year_date = @date + 1.year %>
           <%= link_to "翌年同月 →", monthly_path(year: next_year_date.year, month: next_year_date.month),
-              class: "text-xs font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 whitespace-nowrap" %>
+              class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
         </div>
       </div>
 

--- a/app/views/yearly/show.html.erb
+++ b/app/views/yearly/show.html.erb
@@ -4,12 +4,12 @@
 
     <!-- Year Header -->
     <header class="mb-8 text-center border-b border-slate-200 dark:border-slate-700 pb-6">
+      <p class="text-sm text-slate-500 dark:text-slate-400 mb-2">
+        Yearly Summary
+      </p>
       <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100">
         <%= @year %>年
       </h1>
-      <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
-        Yearly Summary
-      </p>
     </header>
 
     <!-- Navigation -->
@@ -17,11 +17,11 @@
       <!-- Year Navigation -->
       <div class="flex justify-between items-center">
         <%= link_to "← 前年", yearly_path(year: @year - 1),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
         <%= link_to "年一覧", date_index_path,
-            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" %>
+            class: "text-sm font-bold text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
         <%= link_to "翌年 →", yearly_path(year: @year + 1),
-            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+            class: "text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- 日別/月別/年別ページのヘッダーナビゲーションリンク（前日・翌日・前年同日・翌年同日・前月・翌月・前年同月・翌年同月・前年・翌年）のフォントサイズ・色をindigo系のtext-smスタイルに統一
- 上記全リンクにフォーカス表示（focus-visible）を追加
- Daily/Monthly/Yearly Summary見出しを日付見出しの上に移動
- 日別ページ（/date/:year/:month/:day）の日付見出しに曜日「(火)」等を表示
- 日別ページに「他の年のM月D日」リンクを追加し、年非依存の全年サマリーページへ遷移できるように

## Test plan
- [x] `bin/rails test` が全件パスすること（pre-push hookで確認済み）
- [ ] `/date/2005/7/11`、`/date/2017/12`、`/date/2017` にアクセスし、ヘッダーのリンクサイズ・曜日表示・Summary見出しの位置を目視確認する

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)