### PR TITLE
fix: 各画面共通の min-h-screen ラッパーによる二重枠を解消

### DIFF
--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @year_agnostic ? @date.strftime('%-m/%-d') : @date.strftime('%Y/%-m/%-d') %>
-<div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 
     <!-- Date Header -->

--- a/app/views/indices/groups.html.erb
+++ b/app/views/indices/groups.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Index Groups" %>
-<div class="flex justify-center items-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8">
       <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center gap-3">

--- a/app/views/indices/index.html.erb
+++ b/app/views/indices/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @group_name %>
-<div class="flex justify-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <div class="mb-6">
       <%= link_to indices_groups_path,

--- a/app/views/indices/show.html.erb
+++ b/app/views/indices/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @index.name %>
-<div class="flex justify-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <div class="mb-6">
       <% index_group = @index.index_group %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @artist ? "#{@artist.name} - アイテム一覧" : "アイテム一覧" %>
-<div class="flex justify-center items-start min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-amber-500 px-5 py-6 md:px-8 text-center">
       <h1 class="text-3xl font-black text-zinc-900 flex items-center justify-center gap-3">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, [@item.title, @item.artists.map { |a| a['alias'].presence || a['name'] }.join(' / ')].reject(&:blank?).join(' / ') %>
-<div class="flex justify-center items-start min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <!-- ヘッダー（タイトル） -->
     <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30">

--- a/app/views/monthly/show.html.erb
+++ b/app/views/monthly/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @date.strftime('%Y/%m') %>
-<div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 
     <!-- Month Header -->

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "個人一覧" %>
-<div class="flex justify-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8 text-center flex flex-col items-center">
       <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :head do %>
   <style>.page-nav-scroll::-webkit-scrollbar { display: none; }</style>
 <% end %>
-<div class="flex flex-col justify-center items-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl md:overflow-hidden w-full min-w-0 max-w-5xl animate-in slide-in-from-bottom-5 duration-700" data-google-adsense-noads>
     <%= render ProfileHeaderComponent.new(resource: @resource) %>
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Search" %>
-<div class="flex justify-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8 text-center flex flex-col items-center">
       <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "動向一覧" %>
-<div class="flex justify-center items-start min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-amber-500 px-5 py-6 md:px-8 text-center">
       <h1 class="text-3xl font-black text-zinc-900 flex items-center justify-center gap-3">

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @trend.title %>
-<div class="flex justify-center items-start min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30 relative">
       <% if defined?(logged_in?) && logged_in? %>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "バンド索引" %>
-<div class="flex justify-center min-h-screen p-0 md:p-8">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
     <header class="mb-8 text-center flex flex-col items-center">
       <h1 class="text-3xl font-black text-slate-800 dark:text-slate-100 flex items-center justify-center gap-3">

--- a/app/views/yearly/index.html.erb
+++ b/app/views/yearly/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "年別" %>
-<div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 
     <!-- Header -->

--- a/app/views/yearly/show.html.erb
+++ b/app/views/yearly/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, @year.to_s %>
-<div class="flex justify-center min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900">
+<div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700 p-5 md:p-8">
 
     <!-- Year Header -->


### PR DESCRIPTION
## Summary
- `layouts/application.html.erb` の `<main>` が既に余白・背景を持っているのに、対象ページ側でも `min-h-screen p-0 md:p-8 bg-gray-100 dark:bg-gray-900` の全画面ラッパーを重ねていたため、二重の枠・余白が見える問題を修正
- 対象15ファイルとも、外側ラッパーの `min-h-screen` / `p-0 md:p-8` / `bg-gray-100 dark:bg-gray-900` / `items-center` / `items-start` を削除し、`flex justify-center` のみ残してカードを `main` の余白内に自然に配置する形に統一
- `sessions/new.html.erb`, `passwords/edit.html.erb`（ログイン・パスワード変更フォーム）は同じ min-h-screen パターンを使っているが dark mode 未対応など別デザインのため、今回は対象外（別issueで対応予定）
- `indices/groups.html.erb`, `profiles/show.html.erb` にあった `items-center` による縦中央寄せ効果は、外側ラッパー削除に伴い無くなる（コンテンツが短い場合に画面下部が余るが、二重枠解消を優先）

Closes #898

## Test plan
- [x] RuboCop / テストスイート（pre-push hook）通過
- [x] 変更15ページすべてサーバーレンダリングで200 OK・クラス変更反映を確認（daily/monthly/yearly/indices/search/units/trends/people/items/profiles）
- [x] ユーザーによるブラウザ目視確認（light/dark, mobile/desktop）OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)