### PR TITLE
fix: 日別ページのページ内リンクが狭い画面幅で折り返される問題を解消

### DIFF
--- a/app/views/daily/show.html.erb
+++ b/app/views/daily/show.html.erb
@@ -4,7 +4,7 @@
 
     <!-- Date Header -->
     <header class="mb-8 border-b border-slate-200 dark:border-slate-700 pb-6">
-      <div class="flex justify-between items-center gap-4">
+      <div class="flex justify-between items-center gap-4 mb-6">
         <div class="flex gap-2 flex-shrink-0">
           <% prev_date = @date - 1.day %>
           <% if @year_agnostic %>
@@ -33,19 +33,6 @@
             <p class="text-sm text-slate-500 dark:text-slate-400 mt-2">
               <%= "#{@date.month}月#{@date.day}日" %>が誕生日のアーティストや、動向・リリース情報をまとめて掲載しています。
             </p>
-            <% if @birthdays.present? || @trends.present? || @releases.present? %>
-              <nav class="flex flex-wrap justify-center gap-2 mt-4" aria-label="ページ内リンク">
-                <% if @birthdays.present? %>
-                  <%= link_to '#birthdays', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>誕生日<% end %>
-                <% end %>
-                <% if @trends.present? %>
-                  <%= link_to '#trends', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>動向<% end %>
-                <% end %>
-                <% if @releases.present? %>
-                  <%= link_to '#releases', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>リリース<% end %>
-                <% end %>
-              </nav>
-            <% end %>
           <% else %>
             <%= link_to "他の年の#{@date.month}月#{@date.day}日", birthday_date_path(month: @date.month, day: @date.day),
                 class: "inline-block mt-3 text-sm font-bold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 whitespace-nowrap focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" %>
@@ -65,6 +52,21 @@
           <% end %>
         </div>
       </div>
+
+      <!-- Page-internal Links -->
+      <% if @year_agnostic && (@birthdays.present? || @trends.present? || @releases.present?) %>
+        <nav class="flex flex-wrap justify-center gap-2" aria-label="ページ内リンク">
+          <% if @birthdays.present? %>
+            <%= link_to '#birthdays', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>誕生日<% end %>
+          <% end %>
+          <% if @trends.present? %>
+            <%= link_to '#trends', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>動向<% end %>
+          <% end %>
+          <% if @releases.present? %>
+            <%= link_to '#releases', class: "px-3 py-1.5 rounded-full text-xs font-bold bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400" do %>リリース<% end %>
+          <% end %>
+        </nav>
+      <% end %>
     </header>
 
     <!-- Birthdays Section (year-agnostic: shown first) -->


### PR DESCRIPTION
## Summary
- `/date/-/M/D` のような日別ページで、幅400px程度の狭い画面では「誕生日/動向/リリース」のページ内リンク(pill)が不格好に折り返されてしまう問題を修正
- 原因: ヘッダーの中央カラムが前日/翌日リンクに挟まれて実効幅が狭くなり、その中にページ内リンクnavも入っていたため
- monthlyページの「12ヶ月ナビゲーション」と同様に、ページ内リンクnavをヘッダー行の外に出しフル幅で配置するよう変更

## Test plan
- [x] `bundle exec rubocop` / テスト（pre-push hookで実行、全て成功）
- [x] ローカルでブラウザの幅を400px程度に狭めて `/date/-/7/11` を表示し、ページ内リンクが1行に収まることを確認