### PR TITLE
fix: Trend#showページのMembersセクションにバンド名を表示

### DIFF
--- a/app/components/unit_trends_component.html.erb
+++ b/app/components/unit_trends_component.html.erb
@@ -1,4 +1,4 @@
-<section class="mt-8">
+<section class="<%= 'mt-8' if @top_spacing %>">
   <div class="flex items-center justify-between mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
     <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Trends</h2>
   </div>

--- a/app/components/unit_trends_component.rb
+++ b/app/components/unit_trends_component.rb
@@ -4,10 +4,11 @@ class UnitTrendsComponent < ViewComponent::Base
   include WikiLinkHelper
   include Rails.application.routes.url_helpers
 
-  def initialize(trends:, current_trend_id: nil)
+  def initialize(trends:, current_trend_id: nil, top_spacing: true)
     super()
     @trends           = trends
     @current_trend_id = current_trend_id
+    @top_spacing      = top_spacing
   end
 
   def current?(trend)

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -83,9 +83,10 @@
         <div class="mt-10 grid gap-8 grid-cols-1 md:grid-cols-[1fr_360px] items-start">
           <% if @snapshot %>
             <section>
-              <div class="flex items-center gap-2 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
-                <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                  <%= @unit.name %> Members
+              <div class="flex items-center gap-2 mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
+                <h2 class="flex items-baseline gap-1.5">
+                  <span class="text-sm font-bold text-slate-800 dark:text-slate-200"><%= @unit.name %></span>
+                  <span class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Members</span>
                 </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>
                   <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= @snapshot.label %></span>
@@ -102,7 +103,7 @@
             <div></div>
           <% end %>
 
-          <%= render UnitTrendsComponent.new(trends: @unit_trends, current_trend_id: @trend.id) %>
+          <%= render UnitTrendsComponent.new(trends: @unit_trends, current_trend_id: @trend.id, top_spacing: false) %>
         </div>
       <% end %>
 

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -85,7 +85,7 @@
             <section>
               <div class="flex items-center gap-2 mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
                 <h2 class="flex items-baseline gap-1.5">
-                  <span class="text-sm font-bold text-slate-800 dark:text-slate-200"><%= @unit.name %></span>
+                  <%= link_to @unit.name, profile_path(@unit.key), class: "text-sm font-bold text-slate-800 dark:text-slate-200 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
                   <span class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Members</span>
                 </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -85,7 +85,7 @@
             <section>
               <div class="flex items-center gap-2 mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
                 <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                  <% if @trend.units.size > 1 %><%= @unit.name %> <% end %>Members
+                  <%= @unit.name %> Members
                 </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>
                   <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= @snapshot.label %></span>


### PR DESCRIPTION
## Summary
- Trend#show の Members セクション見出しが、紐づくバンドが複数の場合のみバンド名を表示していたのを、常に「◯◯ Members」と表示するように変更

## Test plan
- [x] `bundle exec rails test test/controllers/trends_controller_test.rb` が通ることを確認
- [x] pre-push hook (RuboCop + 全テスト) が通ることを確認

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)