### PR TITLE
feat: snapshot_people編集画面からPersonレコードを新規作成して紐付ける機能を追加

### DIFF
--- a/app/controllers/admin/snapshot_people_controller.rb
+++ b/app/controllers/admin/snapshot_people_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class SnapshotPeopleController < Admin::BaseController
     before_action :set_unit
     before_action :set_unit_snapshot
-    before_action :set_snapshot_person, only: %i[edit update destroy]
+    before_action :set_snapshot_person, only: %i[edit update destroy create_person]
 
     def create
       @snapshot_person = @unit_snapshot.snapshot_people.build(snapshot_person_params)
@@ -36,6 +36,40 @@ module Admin
       record_update_log(@snapshot_person, action: 'discard')
       redirect_to edit_admin_unit_unit_snapshot_path(@unit, @unit_snapshot),
                   notice: 'Member was successfully removed.'
+    end
+
+    def create_person
+      if @snapshot_person.person_key.blank?
+        redirect_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @unit_snapshot, @snapshot_person),
+                    alert: 'Person Key を設定してから実行してください。'
+        return
+      end
+
+      if @snapshot_person.person_id.present?
+        redirect_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @unit_snapshot, @snapshot_person),
+                    alert: 'すでにPersonと紐付けられています。'
+        return
+      end
+
+      person = Person.new(
+        name: @snapshot_person.person_name,
+        key: @snapshot_person.person_key,
+        parts: @snapshot_person.part == 'unknown' ? [] : [@snapshot_person.part]
+      )
+
+      if person.save
+        @snapshot_person.update(person_id: person.id)
+        record_update_log(person, action: 'create')
+        record_update_log(@snapshot_person, action: 'update')
+        redirect_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @unit_snapshot, @snapshot_person),
+                    notice: 'Personを新規作成して紐付けました。'
+      else
+        redirect_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @unit_snapshot, @snapshot_person),
+                    alert: "Personの作成に失敗しました: #{person.errors.full_messages.join(', ')}"
+      end
+    rescue ActiveRecord::RecordNotUnique
+      redirect_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @unit_snapshot, @snapshot_person),
+                  alert: 'そのPerson Keyはすでに使用されています。既存のPersonへの紐付けをご確認ください。'
     end
 
     def reorder

--- a/app/views/admin/snapshot_people/edit.html.erb
+++ b/app/views/admin/snapshot_people/edit.html.erb
@@ -14,6 +14,29 @@
       </div>
       <h1 class="text-2xl font-bold dark:text-white">Edit Member: <%= @snapshot_person.name %></h1>
     </div>
+    <% if @snapshot_person.person_id.nil? && @snapshot_person.person_name.present? %>
+      <div class="mb-6 rounded-md border border-indigo-200 bg-indigo-50 p-4 dark:border-indigo-800 dark:bg-indigo-900/30">
+        <p class="text-sm font-medium text-indigo-800 dark:text-indigo-200">Personレコードが未作成です</p>
+        <p class="mt-1 text-sm text-indigo-700 dark:text-indigo-300">
+          以下の内容でPersonを新規作成し、このメンバーに紐付けます:
+          名前「<%= @snapshot_person.person_name %>」/
+          Key「<%= @snapshot_person.person_key.presence || "未設定" %>」/
+          Part「<%= @snapshot_person.part.humanize %>」
+        </p>
+        <% if @snapshot_person.person_key.blank? %>
+          <p class="mt-2 text-sm text-red-600 dark:text-red-400">Person Key を設定してから実行してください。</p>
+        <% end %>
+        <div class="mt-3">
+          <%= button_to "Personを新規作成して紐付ける",
+                create_person_admin_unit_unit_snapshot_snapshot_person_path(@unit, @unit_snapshot, @snapshot_person),
+                method: :post,
+                disabled: @snapshot_person.person_key.blank?,
+                class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
+                form_class: "inline" %>
+        </div>
+      </div>
+    <% end %>
+
     <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
       <%= render "form", unit: @unit, unit_snapshot: @unit_snapshot, snapshot_person: @snapshot_person %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
           collection do
             patch :reorder
           end
+          member do
+            post :create_person
+          end
         end
       end
     end

--- a/test/controllers/admin/snapshot_people_controller_test.rb
+++ b/test/controllers/admin/snapshot_people_controller_test.rb
@@ -44,5 +44,56 @@ module Admin
       end
       assert_redirected_to edit_admin_unit_unit_snapshot_path(@unit, @snapshot)
     end
+
+    test 'should create person and link when person_key is new' do
+      sp = @snapshot.snapshot_people.create!(person_name: 'New Guy', part: 'vocal', person_key: 'new_test_key')
+
+      assert_difference('Person.count', 1) do
+        post create_person_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+      end
+
+      sp.reload
+      assert_equal 'new_test_key', sp.person.key
+      assert_equal 'New Guy', sp.person.name
+      assert_redirected_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+    end
+
+    test 'should not create person when person_key is blank' do
+      sp = @snapshot.snapshot_people.create!(person_name: 'No Key Guy', part: 'vocal')
+
+      assert_no_difference('Person.count') do
+        post create_person_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+      end
+
+      sp.reload
+      assert_nil sp.person_id
+      assert_redirected_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+    end
+
+    test 'should not create person when already linked' do
+      sp = @snapshot.snapshot_people.create!(
+        person_name: 'Linked Guy', part: 'vocal', person_id: people(:one).id, person_key: 'linked_key'
+      )
+
+      assert_no_difference('Person.count') do
+        post create_person_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+      end
+
+      assert_redirected_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+    end
+
+    test 'should link to existing person when person_key is already in use' do
+      Person.create!(name: 'Existing', key: 'dup_key')
+      sp = @snapshot.snapshot_people.create!(person_name: 'Dup Guy', part: 'vocal')
+      sp.update_column(:person_key, 'dup_key')
+
+      assert_no_difference('Person.count') do
+        post create_person_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+      end
+
+      sp.reload
+      assert_nil sp.person_id
+      assert_redirected_to edit_admin_unit_unit_snapshot_snapshot_person_path(@unit, @snapshot, sp)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `snapshot_people` 編集画面（`/admin/units/:unit_id/unit_snapshots/:unit_snapshot_id/snapshot_people/:id/edit`）に、未紐付けのスナップショットメンバー情報から `people` テーブルのレコードを新規作成し、自動的に紐付けるボタンを追加
- `person_key` が未設定の場合はボタンを非活性化、既に紐付け済みの場合や `person_key` が既存Personと重複する場合は alert でエラー内容を案内
- ルート追加（`create_person` メンバーアクション）、コントローラーアクション追加、ビューにプレビュー・ボタンを追加

## Test plan
- [x] `bin/rails test test/controllers/admin/snapshot_people_controller_test.rb` が全件パスすること（新規4件含む）
- [x] `bin/rails test` フルスイート（139件）がパスすること
- [x] RuboCop クリーン
- [x] 実際の管理画面で、person_key未入力→ボタン非活性→保存後にボタン活性化→Person作成・紐付け、の一連の流れを確認

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)