### PR TITLE
「掲載停止」タグが付いたページの本文コンテンツを非表示にする

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,13 +14,17 @@ class ProfilesController < ApplicationController
 
     raise ActiveRecord::RecordNotFound if @resource.discarded?
 
-    @links = @resource.links.where(active: true).order(:sort_order)
-    @youtube_links = @links.select { |l| l.youtube_video_id.present? }
-    @links_for_list = @links - @youtube_links
+    @unpublished = @resource.unpublished?
 
-    @resource.is_a?(Person) ? load_person_data : load_unit_data
-    load_items
-    load_same_kana_resources
+    unless @unpublished
+      @links = @resource.links.where(active: true).order(:sort_order)
+      @youtube_links = @links.select { |l| l.youtube_video_id.present? }
+      @links_for_list = @links - @youtube_links
+
+      @resource.is_a?(Person) ? load_person_data : load_unit_data
+      load_items
+      load_same_kana_resources
+    end
 
     respond_to do |format|
       format.html

--- a/app/models/concerns/unpublishable.rb
+++ b/app/models/concerns/unpublishable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Marks a resource as unpublished when tagged with one of the configured
+# unpublished tag IDs (see config.unpublished_tag_ids, issue #919).
+module Unpublishable
+  extend ActiveSupport::Concern
+
+  def unpublished?
+    tag_indices.where(id: Rails.application.config.unpublished_tag_ids).exists?
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -37,6 +37,7 @@ class Person < ApplicationRecord
   include Discard::Model
   include WikiParser
   include KeyChangeable
+  include Unpublishable
   has_many :links, as: :linkable, dependent: :destroy
   has_many :wiki_page_imports, as: :import_target
   has_many :unit_people

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -32,6 +32,7 @@ require 'discard'
 class Unit < ApplicationRecord
   include Discard::Model
   include KeyChangeable
+  include Unpublishable
   has_many :links, as: :linkable, dependent: :destroy
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: proc { |attrs| attrs['url'].blank? }
   has_many :wiki_page_imports, as: :import_target

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,6 +6,14 @@
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl md:overflow-hidden w-full min-w-0 max-w-5xl animate-in slide-in-from-bottom-5 duration-700" data-google-adsense-noads>
     <%= render ProfileHeaderComponent.new(resource: @resource) %>
 
+    <% if @unpublished %>
+      <div class="p-8 md:p-12 text-center text-slate-600 dark:text-slate-300">
+        <p class="text-sm md:text-base">諸事情により掲載を停止しております。</p>
+        <div class="mt-6 flex justify-center">
+          <%= render 'layouts/google_adsense_square' %>
+        </div>
+      </div>
+    <% else %>
     <nav class="md:hidden sticky top-0 z-20 bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm border-b border-slate-100 dark:border-slate-700 flex items-stretch" aria-label="ページ内ナビゲーション">
       <a href="#" class="shrink-0 flex items-center px-3 py-3 text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 border-r border-slate-200 dark:border-slate-700 transition-colors" aria-label="ページ先頭へ戻る">↑ Top</a>
       <div class="page-nav-scroll flex items-stretch gap-x-3 overflow-x-auto px-4 min-w-0" style="scrollbar-width:none;">
@@ -223,5 +231,6 @@
         </p>
       </footer>
     </div>
+    <% end %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,10 @@ module Vkdby
     # Site name used in page titles
     config.site_name = ENV.fetch('SITE_NAME', 'vkdb.jp')
 
+    # TagIndex IDs that mark a Person/Unit as unpublished (content hidden, see issue #919).
+    # Override per environment in config/environments/*.rb if needed.
+    config.unpublished_tag_ids = [2643]
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -60,4 +60,28 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'Twice Renamed Unit'
   end
+
+  test 'shows an unpublished message instead of content for a person tagged as unpublished' do
+    person = Person.create!(name: 'Unpublished Person', key: 'person-unpublished-page', status: :active)
+    tag_index = TagIndex.create!(id: Rails.application.config.unpublished_tag_ids.first, name: '掲載停止')
+    TagIndexItem.create!(tag_index: tag_index, indexable: person)
+
+    get profile_path(person.key)
+
+    assert_response :success
+    assert_includes response.body, 'Unpublished Person'
+    assert_includes response.body, '諸事情により掲載を停止しております。'
+  end
+
+  test 'shows an unpublished message instead of content for a unit tagged as unpublished' do
+    unit = Unit.create!(name: 'Unpublished Unit', key: 'unit-unpublished-page', status: :active)
+    tag_index = TagIndex.create!(id: Rails.application.config.unpublished_tag_ids.first, name: '掲載停止')
+    TagIndexItem.create!(tag_index: tag_index, indexable: unit)
+
+    get profile_path(unit.key)
+
+    assert_response :success
+    assert_includes response.body, 'Unpublished Unit'
+    assert_includes response.body, '諸事情により掲載を停止しております。'
+  end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -228,4 +228,18 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
 
     assert_equal 'person-artist-key-after', item.reload.artists.first['key']
   end
+
+  test 'unpublished? is false without an unpublished tag' do
+    person = Person.create!(name: 'Untagged Person', key: 'person-untagged', status: :active)
+
+    assert_not person.unpublished?
+  end
+
+  test 'unpublished? is true when tagged with a configured unpublished tag id' do
+    person = Person.create!(name: 'Unpublished Person', key: 'person-unpublished', status: :active)
+    tag_index = TagIndex.create!(id: Rails.application.config.unpublished_tag_ids.first, name: '掲載停止')
+    TagIndexItem.create!(tag_index: tag_index, indexable: person)
+
+    assert person.unpublished?
+  end
 end

--- a/test/models/unit_test.rb
+++ b/test/models/unit_test.rb
@@ -73,4 +73,18 @@ class UnitTest < ActiveSupport::TestCase
 
     assert_equal 'unit-artist-key-after', item.reload.artists.first['key']
   end
+
+  test 'unpublished? is false without an unpublished tag' do
+    unit = Unit.create!(name: 'Untagged Unit', key: 'unit-untagged', status: :active)
+
+    assert_not unit.unpublished?
+  end
+
+  test 'unpublished? is true when tagged with a configured unpublished tag id' do
+    unit = Unit.create!(name: 'Unpublished Unit', key: 'unit-unpublished', status: :active)
+    tag_index = TagIndex.create!(id: Rails.application.config.unpublished_tag_ids.first, name: '掲載停止')
+    TagIndexItem.create!(tag_index: tag_index, indexable: unit)
+
+    assert unit.unpublished?
+  end
 end


### PR DESCRIPTION
## Summary
- 「掲載停止」タグ（`TagIndex`）が付いた Person/Unit のプロフィールページで、404 を返す代わりにヘッダーのみ表示し、本文を「諸事情により掲載を停止しております。」に差し替える
- 対象タグIDは `config.unpublished_tag_ids`（デフォルト `[2643]`）で管理し、環境ごとに `config/environments/*.rb` で上書き可能
- 非公開時はレクタングル広告を表示

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] 実際に「掲載停止」タグを付与した Person/Unit のプロフィールページで、本文が非表示になりヘッダーは表示されることを確認する

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)