### PR TITLE
旧サイト重要ページURLのリダイレクトを追加

### DIFF
--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -7,10 +7,20 @@ class LegacyRedirectsController < ApplicationController
     '個人索引' => '/people'
   }.freeze
   YEARLY_TREND_PATTERN = %r{\A動向/(\d{4})\z}
+  DAILY_CALENDAR_PATTERN = %r{\Aカレンダー/(\d{4})-(\d{1,2})-(\d{1,2})\z}
 
   def show
     old_key = params[:old_key]
     encoded_old_key = URI.encode_www_form_component(old_key.gsub('+', ' '))
+    decoded_name = decode_euc_jp(old_key)
+
+    # 固定の旧サイトページ（索引・年表・年別動向）はUnit/Personの検索より優先する。
+    # 旧サイトの索引・一覧ページがUnitとして誤って取り込まれ、old_keyがこれらの
+    # 名前と衝突しているデータが存在するため。
+    if decoded_name && (special_redirect_path = special_legacy_redirect_path(decoded_name))
+      redirect_to special_redirect_path, status: :moved_permanently
+      return
+    end
 
     # Try to find Unit by old_key
     if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key) ||
@@ -29,14 +39,6 @@ class LegacyRedirectsController < ApplicationController
       new_url = profile_url(person.key)
       response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
       redirect_to new_url, status: :moved_permanently
-      return
-    end
-
-    decoded_name = decode_euc_jp(old_key)
-
-    # Fallback: Try to match fixed legacy pages (index/timeline/yearly trend pages)
-    if decoded_name && (special_redirect_path = special_legacy_redirect_path(decoded_name))
-      redirect_to special_redirect_path, status: :moved_permanently
       return
     end
 
@@ -78,6 +80,10 @@ class LegacyRedirectsController < ApplicationController
   def special_legacy_redirect_path(decoded_name)
     return SPECIAL_LEGACY_PAGES[decoded_name] if SPECIAL_LEGACY_PAGES.key?(decoded_name)
     return '/timeline' if decoded_name.start_with?('年表')
+
+    if (match = decoded_name.match(DAILY_CALENDAR_PATTERN))
+      return "/date/#{match[1]}/#{match[2]}/#{match[3]}"
+    end
 
     (match = decoded_name.match(YEARLY_TREND_PATTERN)) && "/date/#{match[1]}"
   end

--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class LegacyRedirectsController < ApplicationController
+  # Fixed legacy pages keyed by their EUC-JP decoded name (issue #925)
+  SPECIAL_LEGACY_PAGES = {
+    '索引' => '/units',
+    '個人索引' => '/people'
+  }.freeze
+  YEARLY_TREND_PATTERN = %r{\A動向/(\d{4})\z}
+
   def show
     old_key = params[:old_key]
     encoded_old_key = URI.encode_www_form_component(old_key.gsub('+', ' '))
@@ -25,16 +32,17 @@ class LegacyRedirectsController < ApplicationController
       return
     end
 
+    decoded_name = decode_euc_jp(old_key)
+
+    # Fallback: Try to match fixed legacy pages (index/timeline/yearly trend pages)
+    if decoded_name && (special_redirect_path = special_legacy_redirect_path(decoded_name))
+      redirect_to special_redirect_path, status: :moved_permanently
+      return
+    end
+
     # If neither found, prepare data for 404 page with creation link
     @old_key = old_key
-    begin
-      # Try to decode old_key (EUC-JP) to UTF-8 unit_name
-      # Unescape first, then force encoding to EUC-JP and transcode to UTF-8
-      decoded_bytes = URI.decode_www_form_component(old_key)
-      @unit_name = decoded_bytes.force_encoding('EUC-JP').encode('UTF-8')
-    rescue StandardError
-      @unit_name = nil
-    end
+    @unit_name = decoded_name
 
     render 'not_found', status: :not_found, layout: false
   end
@@ -55,5 +63,22 @@ class LegacyRedirectsController < ApplicationController
     else
       render 'not_found', status: :not_found, layout: false
     end
+  end
+
+  private
+
+  # Try to decode old_key (EUC-JP) to UTF-8
+  # Unescape first, then force encoding to EUC-JP and transcode to UTF-8
+  def decode_euc_jp(old_key)
+    URI.decode_www_form_component(old_key).force_encoding('EUC-JP').encode('UTF-8')
+  rescue StandardError
+    nil
+  end
+
+  def special_legacy_redirect_path(decoded_name)
+    return SPECIAL_LEGACY_PAGES[decoded_name] if SPECIAL_LEGACY_PAGES.key?(decoded_name)
+    return '/timeline' if decoded_name.start_with?('年表')
+
+    (match = decoded_name.match(YEARLY_TREND_PATTERN)) && "/date/#{match[1]}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,6 +172,10 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   # Cross-search
   get 'search', to: 'search#index'
 
+  # Legacy redirects for fixed important pages (issue #925)
+  get '/NEWS.html', to: redirect('/trends')
+  get '/release_recent.htm', to: redirect('/items')
+
   # Legacy redirects for .html extensions
   get '/:old_key.html', to: 'legacy_redirects#show', constraints: { old_key: %r{[^/]+} }
 

--- a/test/controllers/legacy_redirects_controller_test.rb
+++ b/test/controllers/legacy_redirects_controller_test.rb
@@ -97,4 +97,10 @@ class LegacyRedirectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :moved_permanently
     assert_redirected_to '/date/2024'
   end
+
+  test 'should redirect double-percent-encoded calendar page to /date/:year/:month/:day' do
+    get '/%A5%AB%A5%EC%A5%F3%A5%C0%A1%BC%252F2026%2D4%2D15.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/date/2026/4/15'
+  end
 end

--- a/test/controllers/legacy_redirects_controller_test.rb
+++ b/test/controllers/legacy_redirects_controller_test.rb
@@ -55,4 +55,46 @@ class LegacyRedirectsControllerTest < ActionDispatch::IntegrationTest
     get '/non_existent_key.html'
     assert_response :not_found
   end
+
+  test 'should redirect /NEWS.html to /trends' do
+    get '/NEWS.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/trends'
+  end
+
+  test 'should redirect /release_recent.htm to /items' do
+    get '/release_recent.htm'
+    assert_response :moved_permanently
+    assert_redirected_to '/items'
+  end
+
+  test 'should redirect EUC-JP encoded index page to /units' do
+    get '/%BA%F7%B0%FA.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/units'
+  end
+
+  test 'should redirect EUC-JP encoded person index page to /people' do
+    get '/%B8%C4%BF%CD%BA%F7%B0%FA.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/people'
+  end
+
+  test 'should redirect EUC-JP encoded timeline page to /timeline' do
+    get '/%C7%AF%C9%BD.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/timeline'
+  end
+
+  test 'should redirect EUC-JP encoded timeline page with suffix to /timeline' do
+    get '/%C7%AF%C9%BD2008.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/timeline'
+  end
+
+  test 'should redirect double-percent-encoded yearly trend page to /date/:year' do
+    get '/%C6%B0%B8%FE%252F2024.html'
+    assert_response :moved_permanently
+    assert_redirected_to '/date/2024'
+  end
 end


### PR DESCRIPTION
## Summary
- issue #925 対応: 旧サイトの重要ページURLを新サイトの対応ページへ301リダイレクトする
  - `/NEWS.html` → `/trends`
  - `/release_recent.htm` → `/items`
  - `/索引.html`（EUC-JP: `%BA%F7%B0%FA`） → `/units`
  - `/個人索引.html`（EUC-JP: `%B8%C4%BF%CD%BA%F7%B0%FA`） → `/people`
  - `/年表*.html`（EUC-JP、前方一致） → `/timeline`
  - `/動向%252F{year}.html`（二重%エンコード） → `/date/{year}`
  - `/カレンダー%252F{year}-{month}-{day}.html`（二重%エンコード） → `/date/{year}/{month}/{day}`
- 固定レガシーページの判定を Unit/Person の `old_key` 検索より先に行うよう順序を修正
  - 旧サイトの索引・年表・年別動向ページが過去のインポートで誤って `Unit` レコードとして取り込まれ、これらの固定URLの `old_key` と衝突していたため（DB調査で5件の該当レコードを確認、いずれも実データではなくジャンクな索引/一覧ページ）

## Test plan
- [x] `bin/rails test` が全件パスすること（153 runs, 480 assertions, 0 failures）
- [x] RuboCop で offense がないこと
- [x] ローカルの `bin/rails server` に対して実際に各URLへ `curl` し、期待通りのリダイレクト先になることを確認

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)