### PR TITLE
カスタムページ top_message をグローバルヘッダ下部に表示する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,11 +12,16 @@ class ApplicationController < ActionController::Base
   include Pagy::Method
 
   before_action :load_footer_page
+  before_action :load_top_message_page
 
   private
 
   def load_footer_page
     @footer_page = CustomPage.published.find_by(key: 'footer')
+  end
+
+  def load_top_message_page
+    @top_message_page = CustomPage.published.find_by(key: 'top_message')
   end
 
   def current_user

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -378,6 +378,15 @@
         </div>
       </div>
     </nav>
+    <% if @top_message_page %>
+      <div class="bg-amber-100 dark:bg-amber-900 border-b border-amber-200 dark:border-amber-800" role="note">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="markdown-content text-sm text-amber-800 dark:text-amber-200 [&>p]:my-0">
+            <%= markdown(@top_message_page.body, sectionable: @top_message_page) %>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <%= render 'layouts/google_adsense_horizontal' %>
     <main class="<%= content_for?(:main_max_w) ? content_for(:main_max_w) : 'max-w-7xl' %> mx-auto py-6 <%= content_for?(:main_px) ? content_for(:main_px) : 'sm:px-6 lg:px-8' %>">
       <% if notice %>


### PR DESCRIPTION
## Summary
- カスタムページ `top_message`（key指定）が存在し公開されている場合、グローバルヘッダ直下に表示する機能を追加
- `ApplicationController` に既存の `load_footer_page` と同じパターンで `load_top_message_page` を追加
- レイアウトの `</nav>` 直後に、`@top_message_page` が存在する場合のみ amber 系の背景で markdown を描画するブロックを追加

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] 開発環境で `custom_pages` の `top_message` レコードを `active: true` にし、トップページ・`/units` 双方でヘッダ直下にメッセージが表示されることを確認
- [x] `active: false` またはレコード無しの場合は何も表示されないことを確認

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)