### PR TITLE
fix: Trendのユニット/人物名はtrends.units/peopleのnameを優先表示

### DIFF
--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -88,10 +88,11 @@
               <% if trend.units %>
                 <% trend.units.each do |unit_data| %>
                   <% unit = @related_units&.dig(unit_data['unit_id']) %>
+                  <% display_name = unit_data['name'].presence || unit&.name %>
                   <% if unit %>
-                    <%= link_to unit.name, profile_path(unit.key), class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors mr-1 border border-indigo-200 dark:border-indigo-700" %>
-                  <% elsif unit_data['name'].present? %>
-                     <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-gray-50 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 mr-1"><%= unit_data['name'] %></span>
+                    <%= link_to display_name, profile_path(unit.key), class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors mr-1 border border-indigo-200 dark:border-indigo-700" %>
+                  <% elsif display_name.present? %>
+                     <span class="inline-block px-2 py-0.5 rounded text-sm font-semibold bg-gray-50 text-gray-700 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 mr-1"><%= display_name %></span>
                   <% end %>
                 <% end %>
               <% end %>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -21,10 +21,11 @@
         <% if @trend.units %>
           <% @trend.units.each do |unit_data| %>
             <% unit = @related_units&.dig(unit_data['unit_id']) %>
+            <% display_name = unit_data['name'].presence || unit&.name %>
             <% if unit %>
-              <%= link_to unit.name, profile_path(unit.key), class: "px-3 py-1 rounded-md text-lg font-bold bg-white/80 text-zinc-900 hover:bg-white/95 transition-colors border border-white/50" %>
-            <% elsif unit_data['name'].present? %>
-              <span class="px-3 py-1 rounded-md text-lg font-bold bg-white/50 text-zinc-900 border border-white/40"><%= unit_data['name'] %></span>
+              <%= link_to display_name, profile_path(unit.key), class: "px-3 py-1 rounded-md text-lg font-bold bg-white/80 text-zinc-900 hover:bg-white/95 transition-colors border border-white/50" %>
+            <% elsif display_name.present? %>
+              <span class="px-3 py-1 rounded-md text-lg font-bold bg-white/50 text-zinc-900 border border-white/40"><%= display_name %></span>
             <% end %>
           <% end %>
         <% end %>
@@ -34,10 +35,11 @@
         <div class="mt-2 flex flex-wrap items-center gap-1">
           <% @trend.people.each do |person_data| %>
             <% person = @related_people&.dig(person_data['person_id']) %>
+            <% display_name = person_data['name'].presence || person&.name %>
             <% if person %>
-              <%= link_to person.name, profile_path(person.key), class: "px-2 py-0.5 rounded text-sm font-medium bg-white/60 text-zinc-800 hover:bg-white/80 transition-colors border border-white/40" %>
-            <% elsif person_data['name'].present? %>
-              <span class="px-2 py-0.5 rounded text-sm font-medium bg-white/40 text-zinc-800 border border-white/30"><%= person_data['name'] %></span>
+              <%= link_to display_name, profile_path(person.key), class: "px-2 py-0.5 rounded text-sm font-medium bg-white/60 text-zinc-800 hover:bg-white/80 transition-colors border border-white/40" %>
+            <% elsif display_name.present? %>
+              <span class="px-2 py-0.5 rounded text-sm font-medium bg-white/40 text-zinc-800 border border-white/30"><%= display_name %></span>
             <% end %>
           <% end %>
         </div>
@@ -85,7 +87,7 @@
             <section>
               <div class="flex items-center gap-2 mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
                 <h2 class="flex items-baseline gap-1.5">
-                  <%= link_to @unit.name, profile_path(@unit.key), class: "text-sm font-bold text-slate-800 dark:text-slate-200 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
+                  <%= link_to (@trend.units.first['name'].presence || @unit.name), profile_path(@unit.key), class: "text-sm font-bold text-slate-800 dark:text-slate-200 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
                   <span class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Members</span>
                 </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>


### PR DESCRIPTION
## Summary
- Trendのshow/一覧ページでUnit/Personの名前を表示する際、常に `unit.name` / `person.name`（現在の正式名称）を優先していたのを、`trends.units[].name` / `trends.people[].name`（Trend作成時に保存された名前）を優先するよう変更
- 該当データが見つからない場合のみ現在の正式名称にフォールバック

## Test plan
- [x] RuboCop / 既存テストがpre-pushフックで全てパス
- [ ] `/trends/2610` など、Unit名がTrend作成時点と異なるレコードで表示が変わることを確認

Fixes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)