### PR TITLE
ログイン履歴機能を追加（operation_logs）

### DIFF
--- a/app/controllers/admin/operation_logs_controller.rb
+++ b/app/controllers/admin/operation_logs_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class OperationLogsController < Admin::BaseController
+    before_action :require_admin
+
+    def index
+      @pagy, @operation_logs = pagy(OperationLog.includes(:user).order(created_at: :desc), limit: 50)
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,6 +9,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user&.authenticate(params[:password])
       session[:user_id] = user.id
+      OperationLog.create!(user: user, operation_type: 'login')
       redirect_to session.delete(:return_to) || root_path, notice: 'ログインしました'
     else
       flash.now[:alert] = 'メールアドレスまたはパスワードが正しくありません'

--- a/app/models/operation_log.rb
+++ b/app/models/operation_log.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: operation_logs
+#
+#  id             :bigint           not null, primary key
+#  operation_type :string           not null
+#  created_at     :datetime         not null
+#  user_id        :bigint           not null
+#
+# Indexes
+#
+#  index_operation_logs_on_created_at      (created_at)
+#  index_operation_logs_on_operation_type  (operation_type)
+#  index_operation_logs_on_user_id         (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class OperationLog < ApplicationRecord
+  belongs_to :user
+
+  OPERATION_TYPES = %w[login].freeze
+
+  validates :operation_type, inclusion: { in: OPERATION_TYPES }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,8 @@ class User < ApplicationRecord
   has_secure_password
   enum :role, { operator: 0, super_operator: 1, admin: 2 }, default: :operator
 
+  has_many :operation_logs, dependent: :destroy
+
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true
 

--- a/app/views/admin/operation_logs/index.html.erb
+++ b/app/views/admin/operation_logs/index.html.erb
@@ -1,0 +1,37 @@
+<div class="sm:flex sm:items-center">
+  <div class="sm:flex-auto">
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">ログイン履歴</h1>
+    <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">ユーザーのログイン履歴の一覧です。</p>
+  </div>
+</div>
+
+<div class="mt-8 flow-root">
+  <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+    <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+      <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 rounded-lg">
+        <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
+          <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-gray-100 sm:pl-6">日時</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">ユーザー</th>
+              <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">操作</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 dark:divide-gray-800 bg-white dark:bg-gray-900">
+            <% @operation_logs.each do |log| %>
+              <tr>
+                <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-500 dark:text-gray-400 sm:pl-6"><%= log.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900 dark:text-gray-100"><%= log.user.name %>（<%= log.user.email %>）</td>
+                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400"><%= log.operation_type %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mt-4">
+  <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -197,6 +197,14 @@
                       </svg>
                       Users
                     <% end %>
+                    <% if current_user.admin? %>
+                      <%= link_to admin_operation_logs_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-indigo-600 dark:text-zinc-500 dark:group-hover:text-indigo-400">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                        </svg>
+                        Login History
+                      <% end %>
+                    <% end %>
                     <%= link_to edit_password_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-indigo-600 dark:text-zinc-500 dark:group-hover:text-indigo-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 0 1 0 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 0 1 0-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281Z" />
@@ -353,6 +361,11 @@
                       <% end %>
                       <%= link_to admin_users_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Users
+                      <% end %>
+                      <% if current_user.admin? %>
+                        <%= link_to admin_operation_logs_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
+                          Settings: Login History
+                        <% end %>
                       <% end %>
                       <%= link_to edit_password_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Password Settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   namespace :admin do
     root to: 'users#index'
     resources :users
+    resources :operation_logs, only: %i[index]
     resources :external_sites
     resources :units do
       collection do

--- a/db/migrate/20260717151105_create_operation_logs.rb
+++ b/db/migrate/20260717151105_create_operation_logs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateOperationLogs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :operation_logs do |t|
+      t.references :user, null: false, foreign_key: true, index: true
+      t.string :operation_type, null: false
+      t.datetime :created_at, null: false
+    end
+
+    add_index :operation_logs, :operation_type
+    add_index :operation_logs, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_064057) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_17_151105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -128,6 +128,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_064057) do
     t.string "via"
     t.string "via_url"
     t.integer "wikipage_id"
+  end
+
+  create_table "operation_logs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "operation_type", null: false
+    t.bigint "user_id", null: false
+    t.index ["created_at"], name: "index_operation_logs_on_created_at"
+    t.index ["operation_type"], name: "index_operation_logs_on_operation_type"
+    t.index ["user_id"], name: "index_operation_logs_on_user_id"
   end
 
   create_table "people", force: :cascade do |t|
@@ -410,6 +419,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_064057) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "custom_page_includes", "custom_pages", column: "source_custom_page_id"
   add_foreign_key "custom_page_includes", "custom_pages", column: "target_custom_page_id"
+  add_foreign_key "operation_logs", "users"
   add_foreign_key "snapshot_people", "people"
   add_foreign_key "snapshot_people", "unit_snapshots"
   add_foreign_key "tag_index_items", "tag_indices"

--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -52,6 +52,7 @@
 | **画像アップロード**（Custom Page 編集） | upload_image |
 | Items — 削除 | destroy |
 | Users 管理 | 全アクション |
+| Operation Logs（ログイン履歴） | index（全アクション） |
 | Wiki Page Imports | 全アクション |
 | Units / People — キー変更 | change_key |
 | Units / People — リダイレクト元の物理削除 | purge |
@@ -94,3 +95,5 @@
 - ロール定義: `app/models/user.rb`
 - 権限チェックメソッド: `app/controllers/admin/base_controller.rb`
 - 各コントローラーの `before_action`: `app/controllers/admin/` 以下
+- ログイン履歴（`OperationLog`）の記録: `app/controllers/sessions_controller.rb`（ログイン成功時）
+- ログイン履歴の参照: `app/controllers/admin/operation_logs_controller.rb`（`require_admin`）

--- a/docs/plans/issue_928_operation_logs.md
+++ b/docs/plans/issue_928_operation_logs.md
@@ -1,0 +1,192 @@
+# Issue #928: ログインのログ機能 実装プラン
+
+## Issue概要
+- `operation_logs` テーブルを新設し、重要なユーザーオペレーションを記録する。
+- まずは `operation_type = "login"` を記録する。
+- admin ユーザーのみが参照可能な、ユーザーのログイン履歴機能を追加する。
+
+## 未確定事項（着手前に確認したい点）
+- ログイン**失敗**時も記録するか（issue文面からは成功ログインのみと解釈）。
+  → 今回は成功ログインのみを対象とする前提でプランを作成。失敗も記録する場合は `user_id` を optional にする必要あり。
+- IPアドレス・User-Agent も記録するか（一般的な「ログイン履歴」機能では有用だが issue に明記なし）。
+  → 今回は含めない前提。必要なら追加カラムとして後日拡張可能な設計にする。
+
+---
+
+## 1. マイグレーション
+
+新規ファイル: `db/migrate/YYYYMMDDHHMMSS_create_operation_logs.rb`
+
+```ruby
+class CreateOperationLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :operation_logs do |t|
+      t.references :user, null: false, foreign_key: true, index: true
+      t.string :operation_type, null: false
+      t.datetime :created_at, null: false
+    end
+
+    add_index :operation_logs, :operation_type
+    add_index :operation_logs, :created_at
+  end
+end
+```
+
+- `update_logs` テーブルの構造（`created_at` のみで `updated_at` なし、`user_id` に FK・インデックス）に倣う。
+- `t.references :user` に `index: true` を明示し、`user_id` にもインデックスを張る（`update_logs` の `index_update_logs_on_user_id` と同じ構成）。
+- `updated_at` は不要（ログは追記のみで更新しないため）。
+
+---
+
+## 2. モデル
+
+新規ファイル: `app/models/operation_log.rb`
+
+```ruby
+class OperationLog < ApplicationRecord
+  belongs_to :user
+
+  OPERATION_TYPES = %w[login].freeze
+
+  validates :operation_type, inclusion: { in: OPERATION_TYPES }
+end
+```
+
+- `UpdateLog#action` の `validates :action, inclusion: { in: %w[...] }` パターンを踏襲。
+- 将来オペレーション種別を増やす際は `OPERATION_TYPES` に追記するだけで済む設計。
+
+`app/models/user.rb` に関連を追加:
+```ruby
+has_many :operation_logs, dependent: :destroy
+```
+
+---
+
+## 3. ログイン時の記録
+
+`app/controllers/sessions_controller.rb` の `create` アクションを修正:
+
+```ruby
+def create
+  user = User.find_by(email: params[:email])
+  if user&.authenticate(params[:password])
+    session[:user_id] = user.id
+    OperationLog.create!(user: user, operation_type: 'login')
+    redirect_to session.delete(:return_to) || root_path, notice: 'ログインしました'
+  else
+    flash.now[:alert] = 'メールアドレスまたはパスワードが正しくありません'
+    render :new, status: :unprocessable_entity
+  end
+end
+```
+
+- 認証成功後、セッション確立と同じタイミングで記録する。
+- 記録処理の失敗でログイン自体を失敗させたくないため、`create!` の例外はそのまま気にしない（DB制約違反以外は基本発生しない想定）。過剰な防御的 rescue は追加しない。
+
+---
+
+## 4. 管理画面: 参照機能（admin専用）
+
+### ルーティング
+`config/routes.rb` の `namespace :admin do ... end` 内、`resources :users` の近くに追加:
+
+```ruby
+resources :operation_logs, only: %i[index]
+```
+
+### コントローラー
+新規ファイル: `app/controllers/admin/operation_logs_controller.rb`
+
+```ruby
+module Admin
+  class OperationLogsController < Admin::BaseController
+    before_action :require_admin
+
+    def index
+      @operation_logs = OperationLog.includes(:user).order(created_at: :desc)
+    end
+  end
+end
+```
+
+- `Admin::BaseController` の `require_login` は既に効いているため、`require_admin` の `before_action` を追加するだけでよい（`Admin::UsersController` と同じパターン）。
+- 一覧のみで十分（作成・編集・削除は不要 = ログは改ざん不可であるべき）。
+
+### ビュー
+新規ファイル: `app/views/admin/operation_logs/index.html.erb`
+
+- `app/views/admin/unit_logs/index.html.erb` / `_list.html.erb` のテーブル形式を踏襲。
+- 表示カラム: 発生日時（`created_at`）／ユーザー名・メールアドレス／操作種別（`operation_type`）。
+- 件数が多くなる想定のため、`kaminari` 等既存のページネーション手段があれば流用（他の index で使用しているものを確認して合わせる）。
+- アクセシビリティ: テーブルは `<th scope="col">` を使用し、他の管理画面一覧と同じコントラスト・フォーカス指針に従う。
+
+---
+
+## 5. ナビゲーション
+
+`app/views/layouts/application.html.erb` の admin ドロップダウン内、デスクトップ版（`admin_users_path` の直前、約194行目）とモバイル版（約354行目）の2箇所に、`current_user.admin?` の場合のみ表示するリンクを追加する。
+
+```erb
+<% if current_user.admin? %>
+  <%= link_to admin_operation_logs_path, class: "..." do %>
+    ...
+  <% end %>
+<% end %>
+```
+
+- 既存の「Images」リンクが `admin?` 限定で条件分岐しているので、そのパターンに倣う。
+
+---
+
+## 6. ドキュメント更新（CLAUDE.md指示に基づく必須対応）
+
+`docs/admin/permissions.md` の「admin のみ」セクションの表に追記:
+
+| 機能 | アクション |
+|---|---|
+| Operation Logs（ログイン履歴） | index（全アクション） |
+
+「実装箇所」セクションにも `OperationLog` 関連の記述を追加する。
+
+---
+
+## 7. テスト
+
+- モデルスペック: `OperationLog` の validation（`operation_type` の inclusion）。
+- リクエスト/コントローラースペック:
+  - ログイン成功時に `OperationLog` が1件作成されること。
+  - ログイン失敗時には作成されないこと。
+  - `Admin::OperationLogsController#index` が admin 以外（未ログイン／operator／super_operator）からのアクセスで拒否されること。
+  - admin からのアクセスでは一覧が表示されること。
+- 既存のテストフレームワーク（RSpec想定、`spec/` 配下の既存パターンに合わせる）を確認して同じ書式で追加する。
+
+---
+
+## 実装順序（チェックリスト）
+
+1. [ ] マイグレーション作成・実行（`bundle exec rails db:migrate`）
+2. [ ] `OperationLog` モデル作成 + `User#operation_logs` 関連追加
+3. [ ] `SessionsController#create` に記録処理を追加
+4. [ ] `Admin::OperationLogsController` 追加 + ルーティング追加
+5. [ ] `admin/operation_logs/index.html.erb` ビュー作成
+6. [ ] ナビゲーションに admin 限定リンク追加（デスクトップ・モバイル両方）
+7. [ ] `docs/admin/permissions.md` 更新
+8. [ ] テスト追加（モデル・コントローラー）
+9. [ ] ブランチ `feat/issue-928-operation-logs-login` を `develop` から作成し PR 作成
+
+---
+
+## 影響範囲まとめ
+
+| ファイル | 変更内容 |
+|---|---|
+| `db/migrate/xxx_create_operation_logs.rb` | 新規 |
+| `app/models/operation_log.rb` | 新規 |
+| `app/models/user.rb` | `has_many :operation_logs` 追加 |
+| `app/controllers/sessions_controller.rb` | ログイン成功時に記録処理追加 |
+| `app/controllers/admin/operation_logs_controller.rb` | 新規 |
+| `app/views/admin/operation_logs/index.html.erb` | 新規 |
+| `config/routes.rb` | `resources :operation_logs, only: %i[index]` 追加 |
+| `app/views/layouts/application.html.erb` | admin限定ナビリンク追加（2箇所） |
+| `docs/admin/permissions.md` | admin専用機能として追記 |
+| `spec/...` | モデル・コントローラーのテスト追加 |

--- a/test/controllers/admin/operation_logs_controller_test.rb
+++ b/test/controllers/admin/operation_logs_controller_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class OperationLogsControllerTest < ActionDispatch::IntegrationTest
+    test 'should get index as admin' do
+      post login_path, params: { email: users(:admin).email, password: 'password' }
+      get admin_operation_logs_path
+      assert_response :success
+    end
+
+    test 'should deny index for super_operator' do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+      get admin_operation_logs_path
+      assert_redirected_to root_path
+    end
+
+    test 'should redirect to login when not logged in' do
+      get admin_operation_logs_path
+      assert_redirected_to login_path
+    end
+  end
+end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -13,6 +13,21 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
+  test 'should record an operation log on successful login' do
+    assert_difference('OperationLog.count', 1) do
+      post login_url, params: { email: 'one@example.com', password: 'password' }
+    end
+    log = OperationLog.last
+    assert_equal users(:one), log.user
+    assert_equal 'login', log.operation_type
+  end
+
+  test 'should not record an operation log on failed login' do
+    assert_no_difference('OperationLog.count') do
+      post login_url, params: { email: 'one@example.com', password: 'wrong' }
+    end
+  end
+
   test 'should redirect back to the page that required login' do
     get admin_root_url
     assert_redirected_to login_url

--- a/test/fixtures/operation_logs.yml
+++ b/test/fixtures/operation_logs.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  operation_type: login
+  created_at: <%= 1.day.ago %>
+
+two:
+  user: admin
+  operation_type: login
+  created_at: <%= 1.hour.ago %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -27,3 +27,9 @@ two:
   name: User Two
   role: 1
   password_digest: <%= BCrypt::Password.create('password') %>
+
+admin:
+  email: admin@example.com
+  name: Admin User
+  role: 2
+  password_digest: <%= BCrypt::Password.create('password') %>

--- a/test/models/operation_log_test.rb
+++ b/test/models/operation_log_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: operation_logs
+#
+#  id             :bigint           not null, primary key
+#  operation_type :string           not null
+#  created_at     :datetime         not null
+#  user_id        :bigint           not null
+#
+# Indexes
+#
+#  index_operation_logs_on_created_at      (created_at)
+#  index_operation_logs_on_operation_type  (operation_type)
+#  index_operation_logs_on_user_id         (user_id)
+#
+require 'test_helper'
+
+class OperationLogTest < ActiveSupport::TestCase
+  test 'valid with operation_type login' do
+    log = OperationLog.new(user: users(:one), operation_type: 'login')
+    assert log.valid?
+  end
+
+  test 'invalid with an unknown operation_type' do
+    log = OperationLog.new(user: users(:one), operation_type: 'unknown')
+    assert_not log.valid?
+  end
+
+  test 'invalid without a user' do
+    log = OperationLog.new(operation_type: 'login')
+    assert_not log.valid?
+  end
+end


### PR DESCRIPTION
## Summary
- `operation_logs` テーブルを新設し、重要なユーザーオペレーションを記録できるようにした
- ログイン成功時に `operation_type: "login"` を記録する（`SessionsController#create`）
- admin ユーザーのみが `/admin/operation_logs` でログイン履歴を参照できる画面を追加
- 管理画面ナビ（デスクトップ・モバイル）に admin 限定の「Login History」リンクを追加
- `docs/admin/permissions.md` に新機能の権限を追記

## Test plan
- [x] `bin/rails test` が全件パスすること（161 runs, 0 failures）
- [x] RuboCop でオフェンスがないこと
- [ ] ログインして `/admin/operation_logs` に admin ユーザーでアクセスし、履歴が表示されることを確認
- [ ] admin 以外のロールで `/admin/operation_logs` にアクセスすると拒否されることを確認

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)