### PR TITLE
fix: ログイン画面の不要なグレー枠を解消

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "Sign in" %>
-<div class="flex items-center justify-center min-h-screen bg-gray-100 px-4">
+<div class="flex items-center justify-center py-12 px-4">
   <div class="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-lg">
     <h2 class="text-3xl font-bold text-center text-gray-900">Sign in</h2>
 


### PR DESCRIPTION
## Summary
- `sessions/new.html.erb` の `min-h-screen bg-gray-100` ラッパーが、`layouts/application.html.erb` の `main`（既に余白を持つ）とネストし、body の背景色（`bg-zinc-50`）とは異なる色のグレー枠として表示されていた問題を修正
- issue #898（PR #909）で他ページに行った対応と同様の考え方で、不要な背景色ラッパーを解消
- 縦方向の余白は `min-h-screen` の代わりに `py-12` の固定パディングに変更し、上下バランスを調整

## Test plan
- [x] `bin/rails test` が全件パスすること
- [ ] `/login` にアクセスし、グレーの枠が表示されないこと・カードの上下余白のバランスが取れていることを目視確認

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)