### PR TITLE
fix: Old Keyリンク先ドメインをwiki.vkdb.jpに変更し設定可能にする

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -89,7 +89,7 @@ class Person < ApplicationRecord
   def vkdb_url
     return nil if old_key.blank?
 
-    "https://www.vkdb.jp/#{old_key}.html"
+    "#{Rails.application.config.old_key_url_base}/#{old_key}.html"
   end
 
   def birthday_display

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -68,7 +68,7 @@ class Unit < ApplicationRecord
   def vkdb_url
     return nil if old_key.blank?
 
-    "https://www.vkdb.jp/#{old_key}.html"
+    "#{Rails.application.config.old_key_url_base}/#{old_key}.html"
   end
 
   def name_logs

--- a/app/models/wikipage.rb
+++ b/app/models/wikipage.rb
@@ -26,6 +26,6 @@
 class Wikipage < ApplicationRecord
   def vkdb_url
     encoded = URI.encode_www_form_component(name.gsub('/', '%2F').encode('EUC-JP'))
-    "https://www.vkdb.jp/#{encoded}.html"
+    "#{Rails.application.config.old_key_url_base}/#{encoded}.html"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,10 @@ module Vkdby
     # Site name used in page titles
     config.site_name = ENV.fetch('SITE_NAME', 'vkdb.jp')
 
+    # Base URL for old-key links to the legacy site (issue #946).
+    # Only relevant during the migration period; remove once the old site is retired.
+    config.old_key_url_base = ENV.fetch('OLD_KEY_URL_BASE', 'https://wiki.vkdb.jp')
+
     # TagIndex IDs that mark a Person/Unit as unpublished (content hidden, see issue #919).
     # Override per environment in config/environments/*.rb if needed.
     config.unpublished_tag_ids = [2643]


### PR DESCRIPTION
## Summary
- Old Key（Management Information）のリンク先を `www.vkdb.jp` から `wiki.vkdb.jp` に変更
  - 並行期間中は `www.vkdb.jp` が自身を指してしまうため、現行サイトの別ドメインに変更
- リンク先ドメインを `config.old_key_url_base`（`OLD_KEY_URL_BASE` 環境変数で上書き可）として設定化
  - 並行期間の開始/終了間際にドメイン変更の可能性があるため、コード変更なしで切り替え可能に

Closes #946

## Test plan
- [x] `bundle exec rubocop` / テストスイート（pre-push hookで自動実行、全てパス）
- [x] コンソールで `Unit#vkdb_url` / `Person#vkdb_url` / `Wikipage#vkdb_url` が `https://wiki.vkdb.jp/...` を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)