### PR TITLE
fix: Recent TrendsのバンドName優先順位をTrend#unitsのnameに揃える

### DIFF
--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module TrendsHelper
+  # Trend#units / Trend#people の jsonb に保存されたスナップショット時点の名前を優先し、
+  # 無ければ現在の Unit / Person の名前にフォールバックする
+  def trend_unit_display_name(unit_data, unit)
+    unit_data['name'].presence || unit&.name
+  end
+
+  def trend_person_display_name(person_data, person)
+    person_data['name'].presence || person&.name
+  end
+
   def twitter_url?(url)
     return false if url.blank?
 

--- a/app/views/custom_pages/_sidebar.html.erb
+++ b/app/views/custom_pages/_sidebar.html.erb
@@ -15,7 +15,7 @@
                 <% if trend.units.present? %>
                   <% trend.units.each do |u| %>
                     <% unit = @weekly_trend_units[u['unit_id']] %>
-                    <% name = unit&.name || u['name'] %>
+                    <% name = trend_unit_display_name(u, unit) %>
                     <% if name.present? %>
                       <span class="inline-block px-1.5 py-0.5 rounded text-xs font-semibold bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 border border-slate-200 dark:border-slate-600">
                         <%= name %>
@@ -26,7 +26,7 @@
                 <% if trend.people.present? %>
                   <% trend.people.each do |p| %>
                     <% person = @weekly_trend_people[p['person_id']] %>
-                    <% name = person&.name || p['name'] %>
+                    <% name = trend_person_display_name(p, person) %>
                     <% if name.present? %>
                       <span class="inline-block px-1.5 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600">
                         <%= name %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -88,7 +88,7 @@
               <% if trend.units %>
                 <% trend.units.each do |unit_data| %>
                   <% unit = @related_units&.dig(unit_data['unit_id']) %>
-                  <% display_name = unit_data['name'].presence || unit&.name %>
+                  <% display_name = trend_unit_display_name(unit_data, unit) %>
                   <% if unit %>
                     <%= link_to display_name, profile_path(unit.key), class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900 dark:text-indigo-200 dark:hover:bg-indigo-800 transition-colors mr-1 border border-indigo-200 dark:border-indigo-700" %>
                   <% elsif display_name.present? %>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -21,7 +21,7 @@
         <% if @trend.units %>
           <% @trend.units.each do |unit_data| %>
             <% unit = @related_units&.dig(unit_data['unit_id']) %>
-            <% display_name = unit_data['name'].presence || unit&.name %>
+            <% display_name = trend_unit_display_name(unit_data, unit) %>
             <% if unit %>
               <%= link_to display_name, profile_path(unit.key), class: "px-3 py-1 rounded-md text-lg font-bold bg-white/80 text-zinc-900 hover:bg-white/95 transition-colors border border-white/50" %>
             <% elsif display_name.present? %>
@@ -35,7 +35,7 @@
         <div class="mt-2 flex flex-wrap items-center gap-1">
           <% @trend.people.each do |person_data| %>
             <% person = @related_people&.dig(person_data['person_id']) %>
-            <% display_name = person_data['name'].presence || person&.name %>
+            <% display_name = trend_person_display_name(person_data, person) %>
             <% if person %>
               <%= link_to display_name, profile_path(person.key), class: "px-2 py-0.5 rounded text-sm font-medium bg-white/60 text-zinc-800 hover:bg-white/80 transition-colors border border-white/40" %>
             <% elsif display_name.present? %>
@@ -87,7 +87,7 @@
             <section>
               <div class="flex items-center gap-2 mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
                 <h2 class="flex items-baseline gap-1.5">
-                  <%= link_to (@trend.units.first['name'].presence || @unit.name), profile_path(@unit.key), class: "text-sm font-bold text-slate-800 dark:text-slate-200 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
+                  <%= link_to trend_unit_display_name(@trend.units.first, @unit), profile_path(@unit.key), class: "text-sm font-bold text-slate-800 dark:text-slate-200 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors" %>
                   <span class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Members</span>
                 </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>


### PR DESCRIPTION
## Summary
- TOPページの「Recent Trends」セクションで、バンド名/人物名の優先順位が `Trend#show` / `Trend#index` と逆になっており、trend記録時点のスナップショット名（`Trend#units` / `Trend#people` の jsonb name）ではなく常に最新のUnit/Person名が表示されていた問題を修正
- `unit_data['name'].presence || unit&.name` という正しい優先順位のロジックを `TrendsHelper#trend_unit_display_name` / `#trend_person_display_name` として共通化し、`trends/show.html.erb`、`trends/index.html.erb`、`custom_pages/_sidebar.html.erb` の5箇所で再利用するように統一

## Test plan
- [x] `bundle exec rails runner` でヘルパーメソッドの優先順位ロジックを単体確認
- [x] ローカルの開発サーバーで TOPページ（Recent Trendsサイドバー）、`/trends`（一覧）、`/trends/:id`（詳細）の3画面を実際にレンダリングし、バンド名の表示・リンクが崩れていないことを確認
- [x] RuboCop / テストスイート（pre-push フック）が全てパス

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)