### PR TITLE
スナップショット一覧にID表示 (issue #954)

### DIFF
--- a/app/views/admin/unit_snapshots/index.html.erb
+++ b/app/views/admin/unit_snapshots/index.html.erb
@@ -17,6 +17,7 @@
           <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
             <thead class="bg-gray-50 dark:bg-gray-800">
               <tr>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">ID</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">日付</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">ラベル</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">メンバー</th>
@@ -30,6 +31,9 @@
             <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700">
               <% @unit_snapshots.each do |snapshot| %>
                 <tr>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    <%= snapshot.id %>
+                  </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 dark:text-gray-200">
                     <%= snapshot.snapshot_date&.strftime("%Y/%m/%d") %>
                   </td>

--- a/app/views/admin/units/_snapshots_list.html.erb
+++ b/app/views/admin/units/_snapshots_list.html.erb
@@ -16,6 +16,7 @@
             <th scope="col" class="relative py-2 pl-4 pr-3 sm:pl-6 w-10">
               <span class="sr-only">Sort</span>
             </th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">ID</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Date</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Label</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Members</th>
@@ -32,6 +33,9 @@
                 <svg class="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400">
+                <%= snapshot.id %>
               </td>
               <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-900 dark:text-gray-200">
                 <%= snapshot.snapshot_date&.strftime("%Y/%m/%d") %>


### PR DESCRIPTION
## Summary
- 管理画面のスナップショット一覧（`admin/unit_snapshots#index`、ユニット編集画面の `_snapshots_list` パーシャル）にID列を追加
- 親issue #953 で導入予定の `{{snapshot key,snapshot_id}}` 記法用に、`snapshot_id` を管理画面上で確認しやすくするための準備作業

## Test plan
- [x] `bundle exec rails test test/controllers/admin/unit_snapshots_controller_test.rb` — pass
- [x] `bundle exec rails test test/controllers/admin/units_controller_test.rb` — pass
- [x] pre-push フック（RuboCop + 全テスト161件）— pass

Closes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)