### PR TITLE
fix: YouTube動画が無い場合に発生していた不要な余白を削除 (issue #965)

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -62,9 +62,11 @@
 
         <div class="column-right">
           <% if @resource.is_a?(Unit) %>
-            <div class="hidden md:block mb-4">
-              <%= render YoutubeEmbedComponent.new(links: @youtube_links) %>
-            </div>
+            <% if @youtube_links.present? %>
+              <div class="hidden md:block mb-4">
+                <%= render YoutubeEmbedComponent.new(links: @youtube_links) %>
+              </div>
+            <% end %>
 
             <div id="members">
               <%= render UnitSnapshotsComponent.new(snapshots: @snapshots, unit: @resource, admin: defined?(logged_in?) && logged_in?) %>


### PR DESCRIPTION
## Summary
- ユニット詳細ページで YouTube リンクが未登録の場合、`YoutubeEmbedComponent` 自体は `render?` で空になるが、ラッパー div の `mb-4` だけが残りヘッダーとMEMBERSセクションの間に不要な余白ができていた
- `@youtube_links.present?` でラッパー div ごと出し分けるように修正

## Test plan
- [x] `bin/rails test` が全件パスすること（172 runs, 0 failures）
- [x] RuboCop（298 files, no offenses）
- [x] `/nightmare`（YouTubeリンク無し）でヘッダー直下の余白が消え、Membersセクションが直後に続くことを確認
- [x] `/wyse`（YouTubeリンクあり）で従来通り埋め込みが表示されることを確認（回帰なし）

Closes #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)