### PR TITLE
Itemsページに商品名・アーティスト名の検索フォームを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,7 @@ class ItemsController < ApplicationController
 
   def index
     base_scope = filter_by_artist(Item.all)
+    base_scope = filter_by_query(base_scope)
 
     @year_counts = base_scope.where.not(release_date: nil)
                              .group('EXTRACT(year FROM release_date)::integer').count
@@ -55,6 +56,12 @@ class ItemsController < ApplicationController
     else
       scope
     end
+  end
+
+  def filter_by_query(scope)
+    return scope if params[:q].blank?
+
+    scope.where('title ILIKE :q OR artists::text ILIKE :q', q: "%#{params[:q]}%")
   end
 
   def filter_by_decade(scope)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -13,6 +13,20 @@
     </div>
     <div class="p-5 md:p-8">
 
+      <div class="mb-6">
+        <%= form_with url: items_path, method: :get, local: true, class: "flex gap-2" do |f| %>
+          <%= hidden_field_tag :key, params[:key] if params[:key].present? %>
+          <%= hidden_field_tag :old_key, params[:old_key] if params[:old_key].present? %>
+          <%= f.text_field :q, value: params[:q], placeholder: "商品名・アーティスト名で検索",
+              class: "w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-800 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-slate-400" %>
+          <%= f.button class: "bg-indigo-600 hover:bg-indigo-700 text-white p-3 rounded-xl transition-colors shadow-sm hover:shadow-md flex items-center justify-center min-w-[3rem]" do %>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            </svg>
+          <% end %>
+        <% end %>
+      </div>
+
       <div class="flex flex-wrap gap-2 mb-6">
 
         <%
@@ -28,10 +42,10 @@
             decade_counts = @year_counts.group_by { |y, _| (y / 10) * 10 }.transform_values { |pairs| pairs.sum(&:last) }
           %>
 
-          <%= link_to "ALL", items_path(key: params[:key], old_key: params[:old_key]), class: "#{base_classes} #{current_decade.nil? ? active_classes : inactive_classes}" %>
+          <%= link_to "ALL", items_path(key: params[:key], old_key: params[:old_key], q: params[:q]), class: "#{base_classes} #{current_decade.nil? ? active_classes : inactive_classes}" %>
 
           <% decades.each do |decade| %>
-            <%= link_to items_path(decade: decade, key: params[:key], old_key: params[:old_key]), class: "#{base_classes} #{current_decade == decade ? active_classes : inactive_classes}" do %>
+            <%= link_to items_path(decade: decade, key: params[:key], old_key: params[:old_key], q: params[:q]), class: "#{base_classes} #{current_decade == decade ? active_classes : inactive_classes}" do %>
               <%= "#{decade}s" %><span class="opacity-60 ml-1 font-normal text-xs">(<%= decade_counts[decade] %>)</span>
             <% end %>
           <% end %>
@@ -39,13 +53,15 @@
         <% else %>
           <%
             current_year = params[:year].presence&.to_i
+            current_decade = params[:decade].presence&.to_i
             years_by_decade = @years.group_by { |y| (y / 10) * 10 }
           %>
 
-          <%= link_to "NEWEST", items_path, class: "#{base_classes} #{current_year.nil? ? active_classes : inactive_classes}" %>
+          <%= link_to "NEWEST", items_path(q: params[:q]), class: "#{base_classes} #{current_year.nil? && current_decade.nil? ? active_classes : inactive_classes}" %>
 
           <% years_by_decade.each do |decade, years| %>
-            <% is_active_decade = years.include?(current_year) %>
+            <% is_active_decade = years.include?(current_year) || current_decade == decade %>
+            <% decade_count = years.sum { |y| @year_counts[y] } %>
             <div class="relative inline-block text-left"
                  data-controller="dropdown"
                  data-action="click@window->dropdown#hide"
@@ -62,9 +78,16 @@
               </button>
 
               <div class="absolute left-0 top-full mt-1 min-w-full w-max box-border origin-top-left bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-xl z-50 overflow-hidden py-1 hidden"
-                   data-dropdown-target="menu">
+                   data-dropdown-target="menu"
+                   data-transition-enter="transition ease-out duration-100"
+                   data-transition-enter-start="transform opacity-0 scale-95"
+                   data-transition-enter-end="transform opacity-100 scale-100"
+                   data-transition-leave="transition ease-in duration-75"
+                   data-transition-leave-start="transform opacity-100 scale-100"
+                   data-transition-leave-end="transform opacity-0 scale-95">
+                <%= link_to "ALL #{decade}s <span class='text-xs opacity-50 ml-1 font-normal'>(#{decade_count})</span>".html_safe, items_path(decade: decade, q: params[:q]), class: "block px-4 py-2 text-sm font-bold whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white border-b border-slate-100 dark:border-slate-700 #{current_decade == decade ? 'bg-indigo-50 dark:bg-slate-700 text-indigo-700 dark:text-indigo-300' : ''}" %>
                 <% years.each do |year| %>
-                  <%= link_to "#{year} <span class='text-xs opacity-50 ml-1 font-normal'>(#{@year_counts[year]})</span>".html_safe, items_path(year: year), class: "block px-4 py-2 text-sm whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white #{current_year == year ? 'bg-indigo-50 dark:bg-slate-700 font-bold text-indigo-700 dark:text-indigo-300' : ''}" %>
+                  <%= link_to "#{year} <span class='text-xs opacity-50 ml-1 font-normal'>(#{@year_counts[year]})</span>".html_safe, items_path(year: year, q: params[:q]), class: "block px-4 py-2 text-sm whitespace-nowrap text-slate-700 dark:text-slate-300 hover:bg-slate-100 hover:text-indigo-600 dark:hover:bg-slate-700 dark:hover:text-white #{current_year == year ? 'bg-indigo-50 dark:bg-slate-700 font-bold text-indigo-700 dark:text-indigo-300' : ''}" %>
                 <% end %>
               </div>
             </div>
@@ -80,9 +103,9 @@
             month_inactive_classes = "bg-white text-slate-500 border-slate-200 hover:bg-slate-50 dark:bg-slate-800 dark:text-slate-400 dark:border-slate-600 dark:hover:bg-slate-700"
             current_month = params[:month].presence&.to_i
           %>
-          <%= link_to params[:year], items_path(year: params[:year]), class: "#{month_base_classes} #{current_month.nil? ? month_active_classes : month_inactive_classes}" %>
+          <%= link_to params[:year], items_path(year: params[:year], q: params[:q]), class: "#{month_base_classes} #{current_month.nil? ? month_active_classes : month_inactive_classes}" %>
           <% @months.each do |month| %>
-            <%= link_to "#{month} <span class='opacity-60 ml-0.5 font-normal'>(#{@month_counts[month]})</span>".html_safe, items_path(year: params[:year], month: month), class: "#{month_base_classes} #{current_month == month ? month_active_classes : month_inactive_classes}" %>
+            <%= link_to "#{month} <span class='opacity-60 ml-0.5 font-normal'>(#{@month_counts[month]})</span>".html_safe, items_path(year: params[:year], month: month, q: params[:q]), class: "#{month_base_classes} #{current_month == month ? month_active_classes : month_inactive_classes}" %>
           <% end %>
         </div>
       <% end %>

--- a/db/migrate/20260719132618_add_trgm_indexes_to_items.rb
+++ b/db/migrate/20260719132618_add_trgm_indexes_to_items.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddTrgmIndexesToItems < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:items, :title, name: 'index_items_on_title_trgm')
+      add_index :items, :title, using: :gin, opclass: :gin_trgm_ops, name: 'index_items_on_title_trgm', algorithm: :concurrently
+    end
+
+    return if index_exists?(:items, nil, name: 'index_items_on_artists_trgm')
+
+    execute <<~SQL.squish
+      CREATE INDEX CONCURRENTLY index_items_on_artists_trgm ON items USING gin ((artists::text) gin_trgm_ops)
+    SQL
+  end
+
+  def down
+    remove_index :items, name: 'index_items_on_title_trgm', algorithm: :concurrently, if_exists: true
+    execute 'DROP INDEX CONCURRENTLY IF EXISTS index_items_on_artists_trgm'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_17_151105) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_19_132618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -93,11 +93,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_151105) do
     t.date "release_date", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index "((artists)::text) gin_trgm_ops", name: "index_items_on_artists_trgm", using: :gin
     t.index ["artists"], name: "index_items_on_artists", using: :gin
     t.index ["asin"], name: "index_items_on_asin", unique: true
     t.index ["link_url"], name: "index_items_on_link_url", unique: true
     t.index ["release_date"], name: "index_items_on_release_date"
     t.index ["title"], name: "index_items_on_title"
+    t.index ["title"], name: "index_items_on_title_trgm", opclass: :gin_trgm_ops, using: :gin
   end
 
   create_table "links", force: :cascade do |t|

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -31,4 +31,27 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'Kept Unit'
   end
+
+  test 'index filters by title with q param' do
+    get items_path(q: 'Item One')
+
+    assert_response :success
+    assert_includes response.body, 'Item One'
+    assert_not_includes response.body, 'Item Two'
+  end
+
+  test 'index filters by artist name with q param' do
+    item = Item.create!(
+      title: 'Searchable Artist Item',
+      artists: [{ 'name' => 'Unique Artist Name' }],
+      release_date: '2026-03-01',
+      link_url: 'http://example.com/searchable-artist-item'
+    )
+
+    get items_path(q: 'Unique Artist Name')
+
+    assert_response :success
+    assert_includes response.body, item.title
+    assert_not_includes response.body, 'Item One'
+  end
 end


### PR DESCRIPTION
## Summary
- Items ページに商品名・アーティスト名の LIKE 検索フォームを追加し、既存の年代・年・月フィルターと組み合わせて使えるようにした
- `title` と `artists::text`（キャスト式）に trigram (GIN) インデックスを追加し、検索効率と DB 負荷を考慮
- 年代プルダウンに「ALL 20XXs」のような10年分をまとめて絞り込むリンクを追加
- 年代プルダウンが一度開くと閉じなくなる既存バグを修正（トランジション用の data 属性欠落が原因）

## Test plan
- [x] `bin/rails test` が全件パスすること（174 tests, 0 failures）
- [x] RuboCop で offense がないこと
- [ ] `/items` で商品名・アーティスト名検索、年代/年/月フィルターとの組み合わせ、プルダウンの開閉を確認

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)