### PR TITLE
Item編集画面でArtistをサイト内に存在しない名称のみで追加できるようにする

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -14,16 +14,12 @@ module ItemsHelper
   end
 
   # アーティストのプロフィールページへのパスを生成
-  # 優先順位: key > old_key > name(EUCエンコード)
+  # 優先順位: key > old_key。どちらも無い(名前のみの)アーティストはページが存在しないためリンクにしない
   def artist_profile_path(artist_data)
     if artist_data['key'].present?
       "/#{artist_data['key']}"
     elsif artist_data['old_key'].present?
       "/#{artist_data['old_key']}.html"
-    elsif artist_data['name'].present?
-      # nameをEUC-JPでURLエンコードしてold_key形式として扱う
-      encoded_name = ERB::Util.url_encode(artist_data['name'].encode('EUC-JP'))
-      "/#{encoded_name}.html"
     end
   end
 

--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -182,19 +182,24 @@ export default class extends Controller {
       })
       if (!response.ok) throw new Error("Search failed")
       const data = await response.json()
-      this.displayResults(row, data)
+      this.displayResults(row, data, query)
     } catch (e) {
       console.error("Artist search failed", e)
     }
   }
 
-  displayResults(row, items) {
+  displayResults(row, items, query) {
     const resultsEl = row.querySelector(".artist-results")
 
-    if (items.length === 0) {
-      this.hideResults(row)
-      return
-    }
+    const freeTextHtml = `
+      <div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer border-t border-gray-200 dark:border-gray-700"
+           data-result-item
+           data-active="false"
+           data-action="click->artist-rows#selectFreeText"
+           data-name="${this.escapeHtml(query)}">
+        <div class="text-sm text-gray-600 dark:text-gray-400">「${this.escapeHtml(query)}」を名前のみで追加</div>
+      </div>
+    `
 
     resultsEl.innerHTML = items.map(item => `
       <div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
@@ -208,9 +213,16 @@ export default class extends Controller {
         ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ""}
         ${item.destination_key ? `<div class="text-xs text-amber-600 dark:text-amber-400">→ ${this.escapeHtml(item.destination_key)}</div>` : ""}
       </div>
-    `).join("")
+    `).join("") + freeTextHtml
 
     resultsEl.classList.remove("hidden")
+  }
+
+  selectFreeText(event) {
+    const resultItem = event.currentTarget
+    const row = resultItem.closest("[data-artist-rows-target='row']")
+    const mode = row.dataset.mode || "unit"
+    this.applySelection(row, resultItem.dataset.name, "", mode)
   }
 
   async selectItem(event) {

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -46,7 +46,7 @@
     <%# Row container %>
     <div data-artist-rows-target="container" class="space-y-2">
       <% (item.artists || []).each do |artist| %>
-        <% search_mode = artist['key'].blank? && artist['old_key'].blank? %>
+        <% search_mode = artist['name'].blank? %>
         <div class="flex items-center gap-2" data-artist-rows-target="row" data-mode="unit">
           <button type="button"
                   class="flex-none px-2 py-1 text-xs rounded border border-indigo-300 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300 dark:border-indigo-700 whitespace-nowrap"

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class ItemsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+    end
+
+    test 'update accepts a name-only artist that has no matching unit/person record' do
+      item = Item.create!(
+        title: 'Test Item',
+        release_date: Date.today,
+        link_url: "https://example.com/item-#{SecureRandom.hex(4)}"
+      )
+
+      patch admin_item_path(item), params: {
+        item: {
+          title: item.title,
+          release_date: item.release_date,
+          link_url: item.link_url,
+          artists_json: [{ name: '名称のみのアーティスト' }].to_json
+        }
+      }
+
+      assert_redirected_to admin_items_path
+      item.reload
+      assert_equal [{ 'name' => '名称のみのアーティスト' }], item.artists
+    end
+
+    test 'edit renders a previously saved name-only artist as a selected chip, not a blank search box' do
+      item = Item.create!(
+        title: 'Test Item',
+        release_date: Date.today,
+        link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+        artists: [{ 'name' => '名称のみのアーティスト' }]
+      )
+
+      get edit_admin_item_path(item)
+
+      assert_response :success
+      assert_match(/artist-name-hidden[^>]*value="名称のみのアーティスト"/, response.body)
+    end
+  end
+end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -40,6 +40,21 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, 'Item Two'
   end
 
+  test 'show does not render a link for a name-only artist' do
+    item = Item.create!(
+      title: 'Name Only Artist Item',
+      artists: [{ 'name' => '名前のみのアーティスト' }],
+      release_date: '2026-03-01',
+      link_url: "http://example.com/name-only-artist-item-#{SecureRandom.hex(4)}"
+    )
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, '名前のみのアーティスト'
+    assert_not_includes response.body, %(href="/#{ERB::Util.url_encode('名前のみのアーティスト'.encode('EUC-JP'))}.html")
+  end
+
   test 'index filters by artist name with q param' do
     item = Item.create!(
       title: 'Searchable Artist Item',

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ItemsHelperTest < ActionView::TestCase
+  include ItemsHelper
+
+  test 'key があればkeyベースのパスを返す' do
+    assert_equal '/some-key', artist_profile_path({ 'key' => 'some-key', 'old_key' => 'legacy', 'name' => '名前' })
+  end
+
+  test 'key が無く old_key があれば old_key ベースのパスを返す' do
+    assert_equal '/legacy.html', artist_profile_path({ 'old_key' => 'legacy', 'name' => '名前' })
+  end
+
+  test 'key も old_key も無い名前のみのアーティストはリンク先を持たない(nil)' do
+    assert_nil artist_profile_path({ 'name' => '名前のみのアーティスト' })
+  end
+end


### PR DESCRIPTION
## Summary
- Edit Itemページのartist検索で、サイト内のUnit/Personに一致する候補が無い場合でも「名前のみで追加」を選べるようにした（closes #972）
- 併せて、name-onlyで保存済みのartistが編集画面再表示時に「選択済み」表示にならず、そのまま保存すると消えてしまう既存の不具合を修正した（`search_mode`判定をkey/old_keyの有無からnameの有無に変更）

## Test plan
- [x] `bin/rails test test/controllers/admin/items_controller_test.rb`（新規追加: name-onlyでの保存・編集画面再表示の確認）
- [x] `bin/rails test`（全176件）
- [ ] 実ブラウザでの手動確認（開発DBの管理者アカウントのパスワードが不明なため未実施。ローカルで動作確認をお願いします）

🤖 Generated with [Claude Code](https://claude.com/claude-code)