### PR TITLE
fix: Item#showのEditボタンを他ページと同じヘッダー右上に統一する

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -2,7 +2,12 @@
 <div class="flex justify-center">
   <div class="bg-white dark:bg-zinc-900 shadow-2xl rounded-none md:rounded-3xl overflow-hidden w-full max-w-5xl animate-in slide-in-from-bottom-5 duration-700">
     <!-- ヘッダー（タイトル） -->
-    <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30">
+    <div class="bg-amber-500 p-6 md:p-8 border-b border-amber-600/30 relative">
+      <% if defined?(logged_in?) && logged_in? %>
+        <div class="absolute top-4 right-4">
+          <%= link_to "Edit", edit_admin_item_path(@item), class: "px-3 py-1 bg-white/10 hover:bg-white/20 text-amber-900/80 hover:text-amber-900 text-xs font-bold rounded border border-amber-900/20 backdrop-blur-sm transition" %>
+        </div>
+      <% end %>
       <h1 class="text-xl font-black text-zinc-900 leading-snug flex flex-wrap items-center gap-2">
         <% @item.artists.each do |artist_data| %>
           <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
@@ -113,9 +118,6 @@
       </div>
 
       <div class="mt-8 pt-6 border-t border-slate-100 dark:border-slate-700">
-        <% if defined?(logged_in?) && logged_in? %>
-          <%= link_to "Edit", edit_admin_item_path(@item), class: "text-sm font-bold text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors mr-4" %>
-        <% end %>
         <%= link_to "Back to Items", items_path, class: "text-sm font-bold text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors" %>
       </div>
 


### PR DESCRIPTION
## Summary
- Item#show の Edit ボタンをページ下部から、Unit/Person/Trend と同様にヘッダー右上（`absolute top-4 right-4`）に移動
- スタイルも amber ヘッダーに合わせて `trends/show.html.erb` と同じ配色に統一

Closes #975

## Test plan
- [x] ログイン状態で `/items/:id` を表示し、ヘッダー右上に Edit ボタンが表示され `/admin/items/:id/edit` にリンクすることを curl で確認
- [x] 未ログイン状態で Edit ボタンが表示されないことを確認（既存の `logged_in?` ガードのまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)