### PR TITLE
ItemにVarious Artistsフラグを追加する

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -60,7 +60,7 @@ module Admin
     end
 
     def item_params
-      params.require(:item).permit(:title, :release_date, :link_url, :asin, :image_url)
+      params.require(:item).permit(:title, :release_date, :link_url, :asin, :image_url, :various_artists)
     end
 
     def build_artist_from_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,21 +4,20 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
 
-    scopes = @item.artists.flat_map do |a|
-      [
-        (Item.by_artist_key(a['key']) if a['key'].present?),
-        (Item.by_artist_old_key(a['old_key']) if a['old_key'].present?),
-        (Item.by_artist_name(a['name']) if a['name'].present?)
-      ].compact
-    end
+    scoped_artists = @item.artists.filter_map { |a| [a, artist_item_scope(a)] if artist_item_scope(a) }
 
-    if scopes.any?
-      base_query = scopes.reduce(:or).where.not(id: @item.id)
-      @related_items_count = base_query.count
+    if scoped_artists.any?
+      base_query = scoped_artists.map(&:last).reduce(:or).where.not(id: @item.id)
       @related_items = base_query.order(Arel.sql('RANDOM()')).limit(10)
     else
-      @related_items_count = 0
       @related_items = Item.none
+    end
+
+    # アーティストごとに「もっと見る」ボタンを出す必要があるかを判定する
+    # (関連作品グリッドは全アーティストのOR結果からのランダム抽出なので、
+    #  特定の1人だけの作品数が多くても網羅されているとは限らないため)
+    @artists_with_more_items = scoped_artists.filter_map do |a, scope|
+      a if scope.where.not(id: @item.id).count > 10
     end
   end
 
@@ -41,6 +40,22 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  # key/old_keyが分かっているアーティストはそれらのみで一致を判定する。
+  # nameは表記揺れがなく一意なサイト内ページ識別子ではない
+  # (例: 「オムニバス」は多数の無関係な作品で使われる汎用的な名前)ため、
+  # key/old_keyが無い(サイト内にページが存在しない)場合のみnameでの一致にフォールバックする。
+  def artist_item_scope(artist)
+    if artist['key'].present? || artist['old_key'].present?
+      scopes = [
+        (Item.by_artist_key(artist['key']) if artist['key'].present?),
+        (Item.by_artist_old_key(artist['old_key']) if artist['old_key'].present?)
+      ].compact
+      scopes.reduce(:or)
+    elsif artist['name'].present?
+      Item.by_artist_name(artist['name'])
+    end
+  end
 
   def filter_by_artist(scope)
     if params[:old_key].present?

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,24 +4,27 @@
 #
 # Table name: items
 #
-#  id           :bigint           not null, primary key
-#  artists      :jsonb            not null
-#  asin         :string
-#  image_url    :string
-#  link_url     :string           not null
-#  release_date :date             not null
-#  title        :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  old_item_id  :integer
+#  id              :bigint           not null, primary key
+#  artists         :jsonb            not null
+#  asin            :string
+#  image_url       :string
+#  link_url        :string           not null
+#  release_date    :date             not null
+#  title           :string           not null
+#  various_artists :boolean          default(FALSE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  old_item_id     :integer
 #
 # Indexes
 #
 #  index_items_on_artists       (artists) USING gin
+#  index_items_on_artists_trgm  (((artists)::text) gin_trgm_ops) USING gin
 #  index_items_on_asin          (asin) UNIQUE
 #  index_items_on_link_url      (link_url) UNIQUE
 #  index_items_on_release_date  (release_date)
 #  index_items_on_title         (title)
+#  index_items_on_title_trgm    (title) USING gin
 #
 class Item < ApplicationRecord
   validates :title, presence: true

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -38,6 +38,11 @@
     <%= form.url_field :image_url, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.check_box :various_artists, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700" %>
+    <%= form.label :various_artists, "Various Artists（オムニバス）", class: "text-sm font-medium text-gray-700 dark:text-gray-300" %>
+  </div>
+
   <div data-controller="artist-rows"
        data-artist-rows-url-units-value="<%= search_admin_units_path %>"
        data-artist-rows-url-people-value="<%= search_admin_people_path %>">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,8 +8,15 @@
           <%= link_to "Edit", edit_admin_item_path(@item), class: "px-3 py-1 bg-white/10 hover:bg-white/20 text-amber-900/80 hover:text-amber-900 text-xs font-bold rounded border border-amber-900/20 backdrop-blur-sm transition" %>
         </div>
       <% end %>
+      <%
+        headline_artists, other_artists = if @item.various_artists?
+                                             @item.artists.partition { |a| a['name'] == 'オムニバス' }
+                                           else
+                                             [@item.artists, []]
+                                           end
+      %>
       <h1 class="text-xl font-black text-zinc-900 leading-snug flex flex-wrap items-center gap-2">
-        <% @item.artists.each do |artist_data| %>
+        <% headline_artists.each do |artist_data| %>
           <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
           <% artist_path = artist_profile_path(artist_data) %>
           <% if artist_path %>
@@ -20,6 +27,19 @@
         <% end %>
         <span><%= @item.title %></span>
       </h1>
+      <% if other_artists.any? %>
+        <div class="mt-2 flex flex-wrap items-center gap-1">
+          <% other_artists.each do |artist_data| %>
+            <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
+            <% artist_path = artist_profile_path(artist_data) %>
+            <% if artist_path %>
+              <%= link_to artist_label, artist_path, class: "px-2 py-0.5 rounded text-sm font-medium bg-white/60 text-zinc-800 hover:bg-white/80 transition-colors border border-white/40" %>
+            <% else %>
+              <span class="px-2 py-0.5 rounded text-sm font-medium bg-white/40 text-zinc-800 border border-white/30"><%= artist_label %></span>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
 
     <div class="p-5 md:p-8">
@@ -130,9 +150,9 @@
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <%= render ItemCardComponent.with_collection(@related_items) %>
           </div>
-          <% if @related_items_count > 10 %>
-            <% first_artist = @item.artists.find { |a| a['old_key'].present? || a['key'].present? } %>
-            <%= render ArtistItemsButtonComponent.new(artist_name: artist_names, old_key: first_artist&.dig('old_key'), key: first_artist&.dig('key')) %>
+          <% @artists_with_more_items.each do |artist_data| %>
+            <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
+            <%= render ArtistItemsButtonComponent.new(artist_name: artist_label, old_key: artist_data['old_key'], key: artist_data['key']) %>
           <% end %>
         </div>
       <% end %>

--- a/db/migrate/20260720013836_add_various_artists_to_items.rb
+++ b/db/migrate/20260720013836_add_various_artists_to_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVariousArtistsToItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :items, :various_artists, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_19_132618) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_013836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -93,6 +93,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_19_132618) do
     t.date "release_date", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.boolean "various_artists", default: false, null: false
     t.index "((artists)::text) gin_trgm_ops", name: "index_items_on_artists_trgm", using: :gin
     t.index ["artists"], name: "index_items_on_artists", using: :gin
     t.index ["asin"], name: "index_items_on_asin", unique: true

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -29,6 +29,26 @@ module Admin
       assert_equal [{ 'name' => '名称のみのアーティスト' }], item.artists
     end
 
+    test 'update sets the various_artists flag from the checkbox param' do
+      item = Item.create!(
+        title: 'Test Item',
+        release_date: Date.today,
+        link_url: "https://example.com/item-#{SecureRandom.hex(4)}"
+      )
+
+      patch admin_item_path(item), params: {
+        item: {
+          title: item.title,
+          release_date: item.release_date,
+          link_url: item.link_url,
+          various_artists: '1'
+        }
+      }
+
+      assert_redirected_to admin_items_path
+      assert item.reload.various_artists?
+    end
+
     test 'edit renders a previously saved name-only artist as a selected chip, not a blank search box' do
       item = Item.create!(
         title: 'Test Item',

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class ItemsControllerTest < ActionDispatch::IntegrationTest
+class ItemsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Metrics/ClassLength
   test 'index does not resolve artist info for a discarded unit key' do
     unit = Unit.create!(name: 'Discarded Unit', key: 'discarded-unit-items-test', status: :active)
     unit.discard
@@ -40,6 +40,43 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, 'Item Two'
   end
 
+  test 'show hides non-omnibus artists from the header when various_artists is true' do
+    item = Item.create!(
+      title: 'VA Compilation',
+      artists: [{ 'name' => 'オムニバス' }, { 'name' => 'Artist A' }, { 'name' => 'Artist B' }],
+      various_artists: true,
+      release_date: '2026-03-01',
+      link_url: "http://example.com/va-item-#{SecureRandom.hex(4)}"
+    )
+
+    get item_path(item)
+
+    assert_response :success
+    header_text = Nokogiri::HTML(response.body).at_css('h1').text
+    assert_includes header_text, 'オムニバス'
+    assert_not_includes header_text, 'Artist A'
+    assert_not_includes header_text, 'Artist B'
+    assert_includes response.body, 'Artist A'
+    assert_includes response.body, 'Artist B'
+  end
+
+  test 'show lists all artists in the header when various_artists is false' do
+    item = Item.create!(
+      title: 'Regular Item',
+      artists: [{ 'name' => 'オムニバス' }, { 'name' => 'Artist A' }],
+      various_artists: false,
+      release_date: '2026-03-01',
+      link_url: "http://example.com/non-va-item-#{SecureRandom.hex(4)}"
+    )
+
+    get item_path(item)
+
+    assert_response :success
+    header_text = Nokogiri::HTML(response.body).at_css('h1').text
+    assert_includes header_text, 'オムニバス'
+    assert_includes header_text, 'Artist A'
+  end
+
   test 'show does not render a link for a name-only artist' do
     item = Item.create!(
       title: 'Name Only Artist Item',
@@ -53,6 +90,68 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, '名前のみのアーティスト'
     assert_not_includes response.body, %(href="/#{ERB::Util.url_encode('名前のみのアーティスト'.encode('EUC-JP'))}.html")
+  end
+
+  test 'show renders a see-all button per artist whose own related item count exceeds 10, linking only to that artist' do
+    unit_a = Unit.create!(name: 'Artist A', key: "artist-a-#{SecureRandom.hex(4)}", status: :active)
+    unit_b = Unit.create!(name: 'Artist B', key: "artist-b-#{SecureRandom.hex(4)}", status: :active)
+
+    item = Item.create!(
+      title: 'Multi Artist Item',
+      artists: [
+        { 'name' => unit_a.name, 'key' => unit_a.key },
+        { 'name' => unit_b.name, 'key' => unit_b.key }
+      ],
+      release_date: '2026-03-01',
+      link_url: "http://example.com/multi-artist-item-#{SecureRandom.hex(4)}"
+    )
+    11.times do |i|
+      Item.create!(
+        title: "Artist A Related Item #{i}",
+        artists: [{ 'name' => unit_a.name, 'key' => unit_a.key }],
+        release_date: '2026-03-01',
+        link_url: "http://example.com/related-item-a-#{i}-#{SecureRandom.hex(4)}"
+      )
+    end
+    2.times do |i|
+      Item.create!(
+        title: "Artist B Related Item #{i}",
+        artists: [{ 'name' => unit_b.name, 'key' => unit_b.key }],
+        release_date: '2026-03-01',
+        link_url: "http://example.com/related-item-b-#{i}-#{SecureRandom.hex(4)}"
+      )
+    end
+
+    get item_path(item)
+
+    assert_response :success
+    assert_includes response.body, "#{unit_a.name} の全作品を見る"
+    assert_includes response.body, items_path(key: unit_a.key)
+    assert_not_includes response.body, "#{unit_b.name} の全作品を見る"
+  end
+
+  test 'show excludes items that only share an artist name when that artist has a key or old_key' do
+    item = Item.create!(
+      title: 'VA Compilation With Generic Name',
+      artists: [{ 'name' => 'オムニバス', 'old_key' => 'omnibus-generic-name-unique-old-key' }],
+      release_date: '2026-03-01',
+      link_url: "http://example.com/va-generic-name-item-#{SecureRandom.hex(4)}"
+    )
+    # 同じ「オムニバス」という名前だが、別のold_keyを持つ無関係な作品
+    15.times do |i|
+      Item.create!(
+        title: "Unrelated VA Album #{i}",
+        artists: [{ 'name' => 'オムニバス', 'old_key' => "unrelated-omnibus-old-key-#{i}" }],
+        release_date: '2026-03-01',
+        link_url: "http://example.com/unrelated-va-#{i}-#{SecureRandom.hex(4)}"
+      )
+    end
+
+    get item_path(item)
+
+    assert_response :success
+    assert_not_includes response.body, 'Unrelated VA Album'
+    assert_not_includes response.body, 'オムニバス の全作品を見る'
   end
 
   test 'index filters by artist name with q param' do

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -8,24 +8,27 @@
 #
 # Table name: items
 #
-#  id           :bigint           not null, primary key
-#  artists      :jsonb            not null
-#  asin         :string
-#  image_url    :string
-#  link_url     :string           not null
-#  release_date :date             not null
-#  title        :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  old_item_id  :integer
+#  id              :bigint           not null, primary key
+#  artists         :jsonb            not null
+#  asin            :string
+#  image_url       :string
+#  link_url        :string           not null
+#  release_date    :date             not null
+#  title           :string           not null
+#  various_artists :boolean          default(FALSE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  old_item_id     :integer
 #
 # Indexes
 #
 #  index_items_on_artists       (artists) USING gin
+#  index_items_on_artists_trgm  (((artists)::text) gin_trgm_ops) USING gin
 #  index_items_on_asin          (asin) UNIQUE
 #  index_items_on_link_url      (link_url) UNIQUE
 #  index_items_on_release_date  (release_date)
 #  index_items_on_title         (title)
+#  index_items_on_title_trgm    (title) USING gin
 #
 one:
   title: 'Item One'

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -4,24 +4,27 @@
 #
 # Table name: items
 #
-#  id           :bigint           not null, primary key
-#  artists      :jsonb            not null
-#  asin         :string
-#  image_url    :string
-#  link_url     :string           not null
-#  release_date :date             not null
-#  title        :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  old_item_id  :integer
+#  id              :bigint           not null, primary key
+#  artists         :jsonb            not null
+#  asin            :string
+#  image_url       :string
+#  link_url        :string           not null
+#  release_date    :date             not null
+#  title           :string           not null
+#  various_artists :boolean          default(FALSE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  old_item_id     :integer
 #
 # Indexes
 #
 #  index_items_on_artists       (artists) USING gin
+#  index_items_on_artists_trgm  (((artists)::text) gin_trgm_ops) USING gin
 #  index_items_on_asin          (asin) UNIQUE
 #  index_items_on_link_url      (link_url) UNIQUE
 #  index_items_on_release_date  (release_date)
 #  index_items_on_title         (title)
+#  index_items_on_title_trgm    (title) USING gin
 #
 require 'test_helper'
 


### PR DESCRIPTION
## Summary
closes #973

- `items.various_artists` (boolean, default: false) を追加し、管理画面(Admin::ItemsController)で設定可能にした
- Item#show ヘッダーは various_artists が true の場合、name が「オムニバス」のアーティストのみを冒頭に表示し、それ以外のアーティストはヘッダー下の行にTrend#showのpeopleバッジと同じスタイルで列挙する
- 副次的に発見・修正した問題:
  - 「他の作品」セクションの検索条件を修正。key/old_keyが分かっているアーティストはそれのみで一致判定し、nameでの検索はサイト内にページが存在しない(key/old_keyがない)アーティストにのみ限定した。「オムニバス」のような汎用的な名前を持つ無関係な作品が誤って関連作品扱いされていた問題を修正(実データ /items/53338 で確認)
  - 「もっと見る」ボタンをアーティストごとに表示するように変更。以前は複数アーティストの合算件数で判定していたため、リンク先(key/old_keyのみ対応)では同じ件数を再現できないことがあった

## Test plan
- [x] `bin/rails test`（全185件）
- [x] rubocop
- [x] 開発DBの実データ(item 53338)でクエリ結果を確認
- [ ] 実ブラウザでの手動確認（開発DBの管理者アカウントのパスワードが不明なため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)