### PR TITLE
feat: Item#editでartistの表示順をドラッグで並び替えられるようにする

### DIFF
--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -12,15 +12,22 @@ export default class extends Controller {
     urlPeople: String
   }
 
-  connect() {
+  async connect() {
     this.timeout = null
     this.handleClickOutside = this.handleClickOutside.bind(this)
     document.addEventListener("click", this.handleClickOutside)
     this.syncHiddenField()
+
+    const { default: Sortable } = await import("sortablejs")
+    this.sortable = Sortable.create(this.containerTarget, {
+      handle: ".drag-handle",
+      onEnd: () => this.syncHiddenField()
+    })
   }
 
   disconnect() {
     document.removeEventListener("click", this.handleClickOutside)
+    if (this.sortable) this.sortable.destroy()
   }
 
   handleClickOutside(event) {

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -53,6 +53,7 @@
       <% (item.artists || []).each do |artist| %>
         <% search_mode = artist['name'].blank? %>
         <div class="flex items-center gap-2" data-artist-rows-target="row" data-mode="unit">
+          <span class="drag-handle flex-none px-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-grab" aria-hidden="true">⠿</span>
           <button type="button"
                   class="flex-none px-2 py-1 text-xs rounded border border-indigo-300 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300 dark:border-indigo-700 whitespace-nowrap"
                   data-action="click->artist-rows#toggleMode">Units</button>
@@ -106,6 +107,7 @@
     <%# Template for new empty rows %>
     <template data-artist-rows-target="template">
       <div class="flex items-center gap-2 mt-2" data-artist-rows-target="row" data-mode="unit">
+        <span class="drag-handle flex-none px-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-grab" aria-hidden="true">⠿</span>
         <button type="button"
                 class="flex-none px-2 py-1 text-xs rounded border border-indigo-300 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300 dark:border-indigo-700 whitespace-nowrap"
                 data-action="click->artist-rows#toggleMode">Units</button>


### PR DESCRIPTION
## Summary
- Item#edit の artist 行にドラッグハンドル（⠿）を追加し、SortableJS（importmap で pin 済み）でドラッグ並び替えできるようにした
- 並び替え後は `syncHiddenField()` が DOM 順を `item[artists_json]` に反映するため、既存の保存フローのまま並び順が保存される
- Item#show は元々 `items.artists` の配列順をそのまま描画する実装だったため変更不要

## Test plan
- [x] `bin/rails test` が全件パスすること
- [ ] Item#edit で artist 行をドラッグして並び替え、保存後 Item#show の表示順が変わることを確認する

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)