### PR TITLE
Item編集ページで更新後に編集ページへ遷移するようにする

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -42,7 +42,7 @@ module Admin
       @item.artists = build_artists_from_json(params[:item][:artists_json])
 
       if @item.save
-        redirect_to admin_items_path, notice: 'Item updated successfully.'
+        redirect_to edit_admin_item_path(@item), notice: 'Item updated successfully.'
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,6 +1,9 @@
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">Edit Item: <%= @item.title %></h1>
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">Edit Item: <%= @item.title %></h1>
+      <%= link_to "Back to Public Page", item_path(@item), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+    </div>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", item: @item %>
     </div>

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -24,7 +24,7 @@ module Admin
         }
       }
 
-      assert_redirected_to admin_items_path
+      assert_redirected_to edit_admin_item_path(item)
       item.reload
       assert_equal [{ 'name' => '名称のみのアーティスト' }], item.artists
     end
@@ -45,7 +45,7 @@ module Admin
         }
       }
 
-      assert_redirected_to admin_items_path
+      assert_redirected_to edit_admin_item_path(item)
       assert item.reload.various_artists?
     end
 


### PR DESCRIPTION
## Summary
- Item更新後のリダイレクト先を一覧ページから編集ページ自身に変更（Person/Unitと同じ挙動に統一）
- Item編集ページ上部に「Back to Public Page」リンクを追加し、公開ページへの導線を確保

## Test plan
- [x] `bundle exec rails test test/controllers/admin/items_controller_test.rb`
- [x] pre-push hook（RuboCop + 全テスト185件）通過

Fixes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)