### PR TITLE
feat: Official LinkフォームでURLからTitleを自動推測する

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -48,3 +48,6 @@ application.register("timeline-search", TimelineSearchController)
 
 import YoutubeCarouselController from "controllers/youtube_carousel_controller"
 application.register("youtube-carousel", YoutubeCarouselController)
+
+import LinkTitleSuggestController from "controllers/link_title_suggest_controller"
+application.register("link-title-suggest", LinkTitleSuggestController)

--- a/app/javascript/controllers/link_title_suggest_controller.js
+++ b/app/javascript/controllers/link_title_suggest_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["title", "url"]
+
+    suggest() {
+        if (this.titleTarget.value.trim() !== "") return
+
+        const guessed = this.guessTitle(this.urlTarget.value.trim())
+        if (guessed) {
+            this.titleTarget.value = guessed
+        }
+    }
+
+    guessTitle(rawUrl) {
+        if (!rawUrl) return null
+
+        let url
+        try {
+            url = new URL(/^https?:\/\//i.test(rawUrl) ? rawUrl : `https://${rawUrl}`)
+        } catch {
+            return null
+        }
+
+        const host = url.hostname.replace(/^www\./i, "").toLowerCase()
+        const path = url.pathname
+
+        if (host === "x.com" || host === "twitter.com") return "X"
+        if (host === "open.spotify.com") return "Spotify"
+        if (host === "youtube.com" || host === "m.youtube.com") {
+            if (/^\/(?:watch|shorts\/)/.test(path)) return "YouTube Movie"
+            if (/^\/(?:@|channel\/|c\/|user\/)/.test(path)) return "YouTube Channel"
+            return "YouTube"
+        }
+        if (host === "youtu.be") return "YouTube Movie"
+        if (host === "instagram.com") return "Instagram"
+        if (host === "tiktok.com") return "TikTok"
+        if (host === "facebook.com" || host === "fb.com") return "Facebook"
+        if (host === "nicovideo.jp") return "niconico"
+
+        return null
+    }
+}

--- a/app/views/admin/people/_links_form.html.erb
+++ b/app/views/admin/people/_links_form.html.erb
@@ -6,7 +6,7 @@
          data-controller="sortable"
          data-sortable-url-value="<%= reorder_admin_links_path(linkable_type: person.class.name, linkable_id: person.id) %>">
       <%= form.fields_for :links, person.links.select(&:persisted?).sort_by { |l| [l.sort_order || Float::INFINITY, l.id] } do |link_form| %>
-        <div data-id="<%= link_form.object.id %>" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md border border-gray-200 dark:border-gray-700">
+        <div data-id="<%= link_form.object.id %>" data-controller="link-title-suggest" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md border border-gray-200 dark:border-gray-700">
           <div class="w-full flex gap-2 items-center">
             <span class="drag-handle cursor-move text-gray-400 shrink-0" aria-hidden="true">
               <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -14,8 +14,8 @@
               </svg>
             </span>
             <span class="sr-only">並び替え</span>
-            <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
-            <%= link_form.text_field :url, placeholder: "URL (https://...)", class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :text, placeholder: "Title", data: { "link-title-suggest-target": "title" }, class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :url, placeholder: "URL (https://...)", data: { "link-title-suggest-target": "url", action: "blur->link-title-suggest#suggest" }, class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
           </div>
           <div class="flex items-center gap-4">
             <div class="flex items-center">
@@ -33,10 +33,10 @@
 
     <div class="space-y-3 mt-3">
       <%= form.fields_for :links, person.links.reject(&:persisted?) do |link_form| %>
-        <div class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md border border-gray-200 dark:border-gray-700">
+        <div data-controller="link-title-suggest" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md border border-gray-200 dark:border-gray-700">
           <div class="w-full flex gap-2">
-            <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
-            <%= link_form.text_field :url, placeholder: "URL (https://...)", class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :text, placeholder: "Title", data: { "link-title-suggest-target": "title" }, class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :url, placeholder: "URL (https://...)", data: { "link-title-suggest-target": "url", action: "blur->link-title-suggest#suggest" }, class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 px-3 py-1.5 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
           </div>
           <div class="flex items-center gap-4">
             <div class="flex items-center">

--- a/app/views/admin/units/_links_form.html.erb
+++ b/app/views/admin/units/_links_form.html.erb
@@ -6,7 +6,7 @@
          data-controller="sortable"
          data-sortable-url-value="<%= reorder_admin_links_path(linkable_type: unit.class.name, linkable_id: unit.id) %>">
       <%= form.fields_for :links, unit.links.select(&:persisted?).sort_by { |l| [l.sort_order || Float::INFINITY, l.id] } do |link_form| %>
-        <div data-id="<%= link_form.object.id %>" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
+        <div data-id="<%= link_form.object.id %>" data-controller="link-title-suggest" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
           <div class="w-full flex gap-2 items-center">
             <span class="drag-handle cursor-move text-gray-400 shrink-0" aria-hidden="true">
               <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -14,8 +14,8 @@
               </svg>
             </span>
             <span class="sr-only">並び替え</span>
-            <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
-            <%= link_form.text_field :url, placeholder: "URL (https://...)", class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :text, placeholder: "Title", data: { "link-title-suggest-target": "title" }, class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :url, placeholder: "URL (https://...)", data: { "link-title-suggest-target": "url", action: "blur->link-title-suggest#suggest" }, class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
           </div>
           <div class="flex items-center gap-4 mt-2 sm:mt-0">
             <div class="flex items-center">
@@ -33,10 +33,10 @@
 
     <div class="space-y-3 mt-3">
       <%= form.fields_for :links, unit.links.reject(&:persisted?) do |link_form| %>
-        <div class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
+        <div data-controller="link-title-suggest" class="flex flex-col gap-2 items-start bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
           <div class="w-full flex gap-2">
-            <%= link_form.text_field :text, placeholder: "Title", class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
-            <%= link_form.text_field :url, placeholder: "URL (https://...)", class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :text, placeholder: "Title", data: { "link-title-suggest-target": "title" }, class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+            <%= link_form.text_field :url, placeholder: "URL (https://...)", data: { "link-title-suggest-target": "url", action: "blur->link-title-suggest#suggest" }, class: "block flex-1 min-w-0 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
           </div>
           <div class="flex items-center gap-4 mt-2 sm:mt-0">
             <div class="flex items-center">


### PR DESCRIPTION
## Summary
- Unit/Person Edit ページの Official Link フォームで、URL欄からフォーカスが外れた際にTitleが空なら、URLから既知のサイト名を自動推測して挿入するようにした
- 対応サイト: X（x.com/twitter.com）, Spotify, YouTube Channel（@handle, channel/, c/, user/）, YouTube Movie（watch, youtu.be, shorts）, Instagram, TikTok, Facebook, niconico
- 未知のドメインの場合は何も挿入せず、既にTitleが入力済みの場合も上書きしない

## Test plan
- [x] `bin/rails test` が全件パスすること（pre-push hookで確認済み、185 runs / 0 failures）
- [x] guessTitle のロジックをNode上で単体テストし、各プラットフォーム判定・未知ドメイン・空文字の挙動を確認
- [x] 開発サーバーでEdit画面のHTMLを取得し、data-controller/data-action/ターゲット属性が正しくレンダリングされ、importmap経由でJSが配信されることを確認
- [ ] 実ブラウザでのクリック操作による確認は未実施（環境上ブラウザ自動操作ツールが使用できなかったため）

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)