### PR TITLE
Unit/People管理画面にタグ検索とStatusフィルタを追加

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -11,6 +11,7 @@ module Admin
       @tag_index_id = params[:tag_index_id]
       @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
       @redirect_source = params[:redirect_source]
+      @status_filter = params[:status]
       scope = if @redirect_source == 'only'
                 Person.with_discarded.where.not(destination_key: nil)
               else
@@ -30,7 +31,9 @@ module Admin
         @tag_index = TagIndex.find_by(id: @tag_index_id)
         scope = scope.joins(:tag_index_items).where(tag_index_items: { tag_index_id: @tag_index_id })
       end
+      scope = scope.where(status: @status_filter) if @status_filter.present?
       @pagy, @people = pagy(scope.order(updated_at: :desc))
+      @tag_filter_groups = IndexGroup.tag_filter_options_for_people
     end
 
     def new

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -14,6 +14,7 @@ module Admin
       @show_discarded = @tag_index_id.present? ? 'all' : params[:discarded]
       @unit_type_filter = params[:unit_type]
       @redirect_source = params[:redirect_source]
+      @status_filter = params[:status]
       scope = case @show_discarded
               when 'only' then Unit.discarded
               when 'all'  then Unit.with_discarded
@@ -36,7 +37,9 @@ module Admin
         @tag_index = TagIndex.find_by(id: @tag_index_id)
         scope = scope.joins(:tag_index_items).where(tag_index_items: { tag_index_id: @tag_index_id })
       end
+      scope = scope.where(status: @status_filter) if @status_filter.present?
       @pagy, @units = pagy(scope.order(updated_at: :desc))
+      @tag_filter_groups = IndexGroup.tag_filter_options_for_units
     end
 
     def new

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,9 +7,6 @@ import { application } from "controllers/application"
 import ArtistRowsController from "controllers/artist_rows_controller"
 application.register("artist-rows", ArtistRowsController)
 
-import ItemFormController from "controllers/item_form_controller"
-application.register("item-form", ItemFormController)
-
 import AutocompleteController from "controllers/autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
 
@@ -19,26 +16,29 @@ application.register("date-picker", DatePickerController)
 import DropdownController from "controllers/dropdown_controller"
 application.register("dropdown", DropdownController)
 
-import MobileMenuController from "controllers/mobile_menu_controller"
-application.register("mobile-menu", MobileMenuController)
+import ItemFormController from "controllers/item_form_controller"
+application.register("item-form", ItemFormController)
 
-import SearchSuggestController from "controllers/search_suggest_controller"
-application.register("search-suggest", SearchSuggestController)
-
-import PersonSelectController from "controllers/person_select_controller"
-application.register("person-select", PersonSelectController)
-
-import SortableController from "controllers/sortable_controller"
-application.register("sortable", SortableController)
-
-import ToggleController from "controllers/toggle_controller"
-application.register("toggle", ToggleController)
+import LinkTitleSuggestController from "controllers/link_title_suggest_controller"
+application.register("link-title-suggest", LinkTitleSuggestController)
 
 import MarkdownPreviewController from "controllers/markdown_preview_controller"
 application.register("markdown-preview", MarkdownPreviewController)
 
-import UnitGraphController from "controllers/unit_graph_controller"
-application.register("unit-graph", UnitGraphController)
+import MobileMenuController from "controllers/mobile_menu_controller"
+application.register("mobile-menu", MobileMenuController)
+
+import PersonSelectController from "controllers/person_select_controller"
+application.register("person-select", PersonSelectController)
+
+import SearchSuggestController from "controllers/search_suggest_controller"
+application.register("search-suggest", SearchSuggestController)
+
+import SortableController from "controllers/sortable_controller"
+application.register("sortable", SortableController)
+
+import TagGroupSelectController from "controllers/tag_group_select_controller"
+application.register("tag-group-select", TagGroupSelectController)
 
 import TimelineController from "controllers/timeline_controller"
 application.register("timeline", TimelineController)
@@ -46,8 +46,11 @@ application.register("timeline", TimelineController)
 import TimelineSearchController from "controllers/timeline_search_controller"
 application.register("timeline-search", TimelineSearchController)
 
+import ToggleController from "controllers/toggle_controller"
+application.register("toggle", ToggleController)
+
+import UnitGraphController from "controllers/unit_graph_controller"
+application.register("unit-graph", UnitGraphController)
+
 import YoutubeCarouselController from "controllers/youtube_carousel_controller"
 application.register("youtube-carousel", YoutubeCarouselController)
-
-import LinkTitleSuggestController from "controllers/link_title_suggest_controller"
-application.register("link-title-suggest", LinkTitleSuggestController)

--- a/app/javascript/controllers/tag_group_select_controller.js
+++ b/app/javascript/controllers/tag_group_select_controller.js
@@ -1,0 +1,129 @@
+import { Controller } from "@hotwired/stimulus"
+
+// IndexGroup 単位のタグをインクリメンタル検索して選択するコンボボックス。
+// 選択すると、現在のURLの他のパラメータ（status, q など）は保持したまま
+// tag_index_id だけを差し替えて一覧ページへ遷移する。
+export default class extends Controller {
+  static targets = ["input", "results"]
+  static values = {
+    tags: Array
+  }
+
+  connect() {
+    this.activeIndex = -1
+    this.handleClickOutside = this.handleClickOutside.bind(this)
+    document.addEventListener('click', this.handleClickOutside)
+  }
+
+  disconnect() {
+    document.removeEventListener('click', this.handleClickOutside)
+  }
+
+  handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideResults()
+    }
+  }
+
+  search() {
+    const query = this.inputTarget.value.trim().toLowerCase()
+    const filtered = query
+      ? this.tagsValue.filter(tag => tag.name.toLowerCase().includes(query))
+      : this.tagsValue
+
+    this.displayResults(filtered)
+  }
+
+  onKeydown(event) {
+    const items = this.resultItems
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        if (this.resultsTarget.classList.contains('hidden')) {
+          this.search()
+          return
+        }
+        this.activeIndex = Math.min(this.activeIndex + 1, items.length - 1)
+        this.highlightItem()
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        if (this.resultsTarget.classList.contains('hidden')) return
+        this.activeIndex = Math.max(this.activeIndex - 1, 0)
+        this.highlightItem()
+        break
+      case 'Enter':
+        event.preventDefault()
+        if (this.activeIndex >= 0 && items[this.activeIndex]) {
+          items[this.activeIndex].click()
+        }
+        break
+      case 'Escape':
+        this.hideResults()
+        this.inputTarget.blur()
+        break
+    }
+  }
+
+  get resultItems() {
+    return Array.from(this.resultsTarget.querySelectorAll('[data-id]'))
+  }
+
+  highlightItem() {
+    const items = this.resultItems
+    items.forEach((item, index) => {
+      if (index === this.activeIndex) {
+        item.classList.add('bg-gray-100', 'dark:bg-gray-700')
+      } else {
+        item.classList.remove('bg-gray-100', 'dark:bg-gray-700')
+      }
+    })
+    if (items[this.activeIndex]) {
+      items[this.activeIndex].scrollIntoView({ block: 'nearest' })
+    }
+  }
+
+  displayResults(items) {
+    this.activeIndex = -1
+
+    if (items.length === 0) {
+      this.resultsTarget.innerHTML = `<div class="px-4 py-2 text-sm text-gray-400 dark:text-gray-500">該当するタグがありません</div>`
+    } else {
+      this.resultsTarget.innerHTML = items.map(tag => `
+        <div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer text-sm text-gray-900 dark:text-gray-100"
+             role="option"
+             data-action="click->tag-group-select#selectItem"
+             data-id="${tag.id}">
+          ${this.escapeHtml(tag.name)}
+        </div>
+      `).join('')
+    }
+
+    this.showResults()
+  }
+
+  selectItem(event) {
+    const id = event.currentTarget.dataset.id
+    const url = new URL(window.location.href)
+    url.searchParams.set('tag_index_id', id)
+    window.location.href = url.toString()
+  }
+
+  showResults() {
+    this.resultsTarget.classList.remove('hidden')
+    this.inputTarget.setAttribute('aria-expanded', 'true')
+  }
+
+  hideResults() {
+    this.activeIndex = -1
+    this.resultsTarget.classList.add('hidden')
+    this.inputTarget.setAttribute('aria-expanded', 'false')
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement('div')
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/models/index_group.rb
+++ b/app/models/index_group.rb
@@ -22,4 +22,19 @@ class IndexGroup < ApplicationRecord
   scope :for_people, -> { active.where.not(people_filter_order: nil).order(people_filter_order: :asc) }
 
   validates :name, presence: true
+
+  def self.tag_filter_options_for_units
+    tag_filter_options(for_units)
+  end
+
+  def self.tag_filter_options_for_people
+    tag_filter_options(for_people)
+  end
+
+  def self.tag_filter_options(groups_scope)
+    groups_scope.includes(:tag_indices).filter_map do |group|
+      tags = group.tag_indices.select(&:active?).sort_by { |t| t.order_in_group || Float::INFINITY }
+      { id: group.id, name: group.name, tags: tags.map { |t| { id: t.id, name: t.name } } } if tags.any?
+    end
+  end
 end

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -8,6 +8,10 @@
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_people_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.hidden_field :discarded, value: params[:discarded] %>
+        <%= f.hidden_field :tag_index_id, value: params[:tag_index_id] %>
+        <%= f.select :status, options_for_select(Person::STATUS_TRANSLATIONS.map { |key, label| [label, key] }, params[:status]),
+              { include_blank: "すべてのStatus" },
+              { onchange: "this.form.requestSubmit()", "aria-label": "Statusで絞り込み", class: "border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500 mr-2" } %>
         <%= f.text_field :q, value: params[:q], placeholder: "Search by name or key...", class: "rounded-l-md border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500" %>
         <%= f.submit "Search", class: "px-4 py-2 bg-white text-gray-700 border border-l-0 border-gray-300 rounded-r-md hover:bg-gray-50 cursor-pointer" %>
       <% end %>
@@ -21,6 +25,8 @@
       <%= link_to "フィルター解除", admin_people_path, class: "text-indigo-600 hover:text-indigo-800 underline" %>
     </div>
   <% end %>
+
+  <%= render "admin/shared/tag_filter", groups: @tag_filter_groups %>
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_people_path(q: params[:q]),

--- a/app/views/admin/shared/_tag_filter.html.erb
+++ b/app/views/admin/shared/_tag_filter.html.erb
@@ -1,0 +1,18 @@
+<% if groups.present? %>
+  <div class="flex flex-wrap gap-3 mb-4">
+    <% groups.each do |group| %>
+      <div class="relative" data-controller="tag-group-select"
+           data-tag-group-select-tags-value="<%= group[:tags].to_json %>">
+        <label for="tag_group_<%= group[:id] %>" class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"><%= group[:name] %></label>
+        <input type="text" id="tag_group_<%= group[:id] %>"
+               placeholder="検索..."
+               role="combobox" aria-expanded="false" aria-autocomplete="list"
+               class="w-36 rounded-md border-gray-300 text-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+               data-tag-group-select-target="input"
+               data-action="input->tag-group-select#search focus->tag-group-select#search keydown->tag-group-select#onKeydown">
+        <div data-tag-group-select-target="results" role="listbox"
+             class="hidden absolute z-50 mt-1 w-48 max-h-60 overflow-y-auto bg-white dark:bg-gray-800 shadow-lg rounded-md border border-gray-200 dark:border-gray-700"></div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -9,6 +9,10 @@
       <%= form_with url: admin_units_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.hidden_field :discarded, value: params[:discarded] %>
         <%= f.hidden_field :unit_type, value: params[:unit_type] %>
+        <%= f.hidden_field :tag_index_id, value: params[:tag_index_id] %>
+        <%= f.select :status, options_for_select(Unit::STATUS_TRANSLATIONS.map { |key, label| [label, key] }, params[:status]),
+              { include_blank: "すべてのStatus" },
+              { onchange: "this.form.requestSubmit()", "aria-label": "Statusで絞り込み", class: "border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500 mr-2" } %>
         <%= f.text_field :q, value: params[:q], placeholder: "Search by name or key...", class: "rounded-l-md border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500" %>
         <%= f.submit "Search", class: "px-4 py-2 bg-white text-gray-700 border border-l-0 border-gray-300 rounded-r-md hover:bg-gray-50 cursor-pointer" %>
       <% end %>
@@ -22,6 +26,8 @@
       <%= link_to "フィルター解除", admin_units_path, class: "text-indigo-600 hover:text-indigo-800 underline" %>
     </div>
   <% end %>
+
+  <%= render "admin/shared/tag_filter", groups: @tag_filter_groups %>
 
   <div class="flex space-x-2 mb-4">
     <%= link_to "通常", admin_units_path(q: params[:q]),

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -136,6 +136,61 @@ module Admin
       assert_not_includes response.body, 'キー変更'
     end
 
+    test 'index renders tag filter comboboxes only for groups and tags visible on people' do
+      group = IndexGroup.create!(name: '属性グループ', people_filter_order: 1)
+      hidden_group = IndexGroup.create!(name: '非表示グループ', people_filter_order: nil)
+      TagIndex.create!(name: '有効タグ', index_group: group, order_in_group: 1)
+      TagIndex.create!(name: '無効タグ', index_group: group, active: false)
+      TagIndex.create!(name: '孤立タグ', index_group: hidden_group)
+
+      get admin_people_path
+
+      assert_response :success
+      assert_includes response.body, '属性グループ'
+      assert_includes response.body, '有効タグ'
+      assert_not_includes response.body, '無効タグ'
+      assert_not_includes response.body, '非表示グループ'
+      assert_not_includes response.body, '孤立タグ'
+    end
+
+    test 'index filters people by tag_index_id selected from the tag filter' do
+      group = IndexGroup.create!(name: '属性グループ', people_filter_order: 1)
+      tag = TagIndex.create!(name: '有効タグ', index_group: group, order_in_group: 1)
+      TagIndexItem.create!(tag_index: tag, indexable: @person)
+      other_person = Person.create!(name: 'Other Person', key: 'other-person-controller-test', status: :active)
+
+      get admin_people_path(tag_index_id: tag.id)
+
+      assert_response :success
+      assert_includes response.body, @person.name
+      assert_not_includes response.body, other_person.name
+    end
+
+    test 'index filters people by status' do
+      hiatus_person = Person.create!(name: 'Hiatus Person', key: 'hiatus-person-controller-test', status: :hiatus)
+
+      get admin_people_path(status: 'hiatus')
+
+      assert_response :success
+      assert_includes response.body, hiatus_person.name
+      assert_not_includes response.body, @person.name
+    end
+
+    test 'index combines tag_index_id and status filters' do
+      group = IndexGroup.create!(name: '属性グループ', people_filter_order: 1)
+      tag = TagIndex.create!(name: '有効タグ', index_group: group, order_in_group: 1)
+      tagged_active = Person.create!(name: 'Tagged Active Person', key: 'tagged-active-person-test', status: :active)
+      tagged_hiatus = Person.create!(name: 'Tagged Hiatus Person', key: 'tagged-hiatus-person-test', status: :hiatus)
+      TagIndexItem.create!(tag_index: tag, indexable: tagged_active)
+      TagIndexItem.create!(tag_index: tag, indexable: tagged_hiatus)
+
+      get admin_people_path(tag_index_id: tag.id, status: 'hiatus')
+
+      assert_response :success
+      assert_includes response.body, tagged_hiatus.name
+      assert_not_includes response.body, tagged_active.name
+    end
+
     private
 
     def login_as_admin

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -161,6 +161,62 @@ module Admin
       assert_not_includes response.body, '論理削除'
     end
 
+    test 'index renders tag filter comboboxes only for groups and tags visible on units' do
+      group = IndexGroup.create!(name: '属性グループ', units_filter_order: 1)
+      hidden_group = IndexGroup.create!(name: '非表示グループ', units_filter_order: nil)
+      TagIndex.create!(name: '有効タグ', index_group: group, order_in_group: 1)
+      TagIndex.create!(name: '無効タグ', index_group: group, active: false)
+      TagIndex.create!(name: '孤立タグ', index_group: hidden_group)
+
+      # q で一致しない検索にして、key が未設定なfixtureのUnitが一覧描画でエラーにならないようにする
+      get admin_units_path(q: 'no-such-unit-zzz')
+
+      assert_response :success
+      assert_includes response.body, '属性グループ'
+      assert_includes response.body, '有効タグ'
+      assert_not_includes response.body, '無効タグ'
+      assert_not_includes response.body, '非表示グループ'
+      assert_not_includes response.body, '孤立タグ'
+    end
+
+    test 'index filters units by tag_index_id selected from the tag filter' do
+      group = IndexGroup.create!(name: '属性グループ', units_filter_order: 1)
+      tag = TagIndex.create!(name: '有効タグ', index_group: group, order_in_group: 1)
+      TagIndexItem.create!(tag_index: tag, indexable: @unit)
+      other_unit = Unit.create!(name: 'Other Unit', key: 'other-unit-controller-test', status: :active)
+
+      get admin_units_path(tag_index_id: tag.id)
+
+      assert_response :success
+      assert_includes response.body, @unit.name
+      assert_not_includes response.body, other_unit.name
+    end
+
+    test 'index filters units by status' do
+      frozen_unit = Unit.create!(name: 'Frozen Unit', key: 'frozen-unit-controller-test', status: :freeze, unit_type: :band)
+
+      get admin_units_path(status: 'freeze')
+
+      assert_response :success
+      assert_includes response.body, frozen_unit.name
+      assert_not_includes response.body, @unit.name
+    end
+
+    test 'index combines tag_index_id and status filters' do
+      group = IndexGroup.create!(name: '属性グループ', units_filter_order: 1)
+      tag = TagIndex.create!(name: '有効タグ', index_group: group, order_in_group: 1)
+      tagged_active = Unit.create!(name: 'Tagged Active Unit', key: 'tagged-active-unit-test', status: :active)
+      tagged_frozen = Unit.create!(name: 'Tagged Frozen Unit', key: 'tagged-frozen-unit-test', status: :freeze)
+      TagIndexItem.create!(tag_index: tag, indexable: tagged_active)
+      TagIndexItem.create!(tag_index: tag, indexable: tagged_frozen)
+
+      get admin_units_path(tag_index_id: tag.id, status: 'freeze')
+
+      assert_response :success
+      assert_includes response.body, tagged_frozen.name
+      assert_not_includes response.body, tagged_active.name
+    end
+
     private
 
     def login_as_admin


### PR DESCRIPTION
## Summary
- IndexGroupごとにタグをインクリメンタル検索できるコンボボックスをUnit/People管理画面の一覧に追加
- Statusによる絞り込みプルダウンをUnit/People両画面に追加
- タグ選択・status変更のどちらの操作でも、他方のフィルタ条件（およびq検索）を維持したまま遷移するように対応
- (副次対応) `bin/rails stimulus:manifest:update` が生成する相対importが本プロジェクトの資産配信(Propshaft)と噛み合わずStimulus自体が起動しなくなる問題を修正し、既存の`controllers/xxx`形式のbare importに統一

## Test plan
- [x] `bundle exec rails test test/controllers/admin/units_controller_test.rb test/controllers/admin/people_controller_test.rb` が全件パス
- [x] `bundle exec rubocop` で対象ファイルに問題なし
- [x] ヘッドレスChromeで実際にログインし、Unit/People両画面でタグ選択→Status変更、Status変更→タグ選択の両順序でパラメータが保持され絞り込まれることを確認
- [x] pre-push hook（RuboCop全体・テスト全体）通過

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)