### PR TITLE
feat: Unit/People管理一覧にStatus一括更新機能を追加

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class PeopleController < Admin::BaseController # rubocop:disable Metrics/ClassLength
     before_action :set_person, only: %i[edit update destroy undiscard change_key purge]
     before_action :require_super_operator, only: %i[destroy]
-    before_action :require_admin, only: %i[change_key purge]
+    before_action :require_admin, only: %i[change_key purge bulk_update_status]
 
     def index
       @q = params[:q]
@@ -125,6 +125,23 @@ module Admin
         diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
       )
       redirect_to admin_people_path(redirect_source: 'only'), notice: 'リダイレクト元レコードを物理削除しました。'
+    end
+
+    def bulk_update_status
+      ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
+      status = params[:status].presence
+      return redirect_back_or_to admin_people_path, alert: '項目が選択されていません' if ids.empty?
+      return redirect_back_or_to admin_people_path, alert: 'Statusを選択してください' unless Person.statuses.key?(status)
+
+      count = 0
+      Person.with_discarded.where(id: ids).find_each do |person|
+        next if person.status == status
+
+        person.update!(status: status)
+        record_update_log(person, action: 'update')
+        count += 1
+      end
+      redirect_back_or_to admin_people_path, notice: "#{count}件のStatusを更新しました"
     end
 
     def search

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
     before_action :set_unit, only: %i[show edit update destroy undiscard change_key purge]
     before_action :require_super_operator, only: %i[destroy]
-    before_action :require_admin, only: %i[change_key purge]
+    before_action :require_admin, only: %i[change_key purge bulk_update_status]
 
     def index
       @q = params[:q]
@@ -141,6 +141,23 @@ module Admin
         diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
       )
       redirect_to admin_units_path(redirect_source: 'only'), notice: 'リダイレクト元レコードを物理削除しました。'
+    end
+
+    def bulk_update_status
+      ids = Array(params[:ids]).map(&:to_i).reject(&:zero?)
+      status = params[:status].presence
+      return redirect_back_or_to admin_units_path, alert: '項目が選択されていません' if ids.empty?
+      return redirect_back_or_to admin_units_path, alert: 'Statusを選択してください' unless Unit.statuses.key?(status)
+
+      count = 0
+      Unit.with_discarded.where(id: ids).find_each do |unit|
+        next if unit.status == status
+
+        unit.update!(status: status)
+        record_update_log(unit, action: 'update')
+        count += 1
+      end
+      redirect_back_or_to admin_units_path, notice: "#{count}件のStatusを更新しました"
     end
 
     def search

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -47,6 +47,11 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
+          <% if current_user.admin? %>
+            <th class="px-4 py-3">
+              <input type="checkbox" id="check_all" class="rounded border-gray-300" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
+            </th>
+          <% end %>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Parts</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Key</th>
@@ -57,6 +62,11 @@
       <tbody class="bg-white divide-y divide-gray-200">
         <% @people.each do |person| %>
           <tr class="<%= person.discarded? ? 'bg-red-50' : '' %>">
+            <% if current_user.admin? %>
+              <td class="px-4 py-4">
+                <input type="checkbox" value="<%= person.id %>" class="row-check rounded border-gray-300" aria-label="<%= person.name %> を選択">
+              </td>
+            <% end %>
             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
               <%= person.name %>
               <% if person.discarded? %>
@@ -109,6 +119,51 @@
       </tbody>
     </table>
   </div>
+
+  <% if current_user.admin? %>
+    <div class="sticky bottom-0 z-10 flex flex-wrap items-center gap-2 bg-white border-t border-gray-200 px-4 py-3 shadow-md mb-4">
+      <label class="text-sm text-gray-600">一括更新:</label>
+      <select id="bulk-status-select"
+              class="text-sm rounded border-gray-300 py-1.5 pr-8"
+              aria-label="一括更新するStatus">
+        <% Person::STATUS_TRANSLATIONS.each do |key, label| %>
+          <option value="<%= key %>"><%= label %></option>
+        <% end %>
+      </select>
+      <button type="button"
+              onclick="submitBulkStatus()"
+              class="px-4 py-2 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 cursor-pointer">
+        選択した項目のStatusを更新
+      </button>
+    </div>
+
+    <%= form_with url: bulk_update_status_admin_people_path, method: :patch, id: "bulk-status-form", class: "hidden" do %>
+      <input type="hidden" name="status" id="bulk-status-value">
+    <% end %>
+
+    <script>
+      function submitBulkStatus() {
+        var checked = document.querySelectorAll('.row-check:checked');
+        if (checked.length === 0) {
+          alert('項目が選択されていません');
+          return;
+        }
+        if (!confirm('選択した ' + checked.length + ' 件のStatusを更新します。よろしいですか？')) return;
+
+        var form = document.getElementById('bulk-status-form');
+        form.querySelectorAll('input[name="ids[]"]').forEach(function(el) { el.remove(); });
+        checked.forEach(function(cb) {
+          var input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = 'ids[]';
+          input.value = cb.value;
+          form.appendChild(input);
+        });
+        document.getElementById('bulk-status-value').value = document.getElementById('bulk-status-select').value;
+        form.requestSubmit();
+      }
+    </script>
+  <% end %>
 
   <div class="mt-4">
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -50,6 +50,11 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
+          <% if current_user.admin? %>
+            <th class="px-4 py-3">
+              <input type="checkbox" id="check_all" class="rounded border-gray-300" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
+            </th>
+          <% end %>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
           <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Key</th>
@@ -60,6 +65,11 @@
       <tbody class="bg-white divide-y divide-gray-200">
         <% @units.each do |unit| %>
           <tr class="<%= unit.discarded? ? 'bg-red-50' : '' %>">
+            <% if current_user.admin? %>
+              <td class="px-4 py-4">
+                <input type="checkbox" value="<%= unit.id %>" class="row-check rounded border-gray-300" aria-label="<%= unit.name %> を選択">
+              </td>
+            <% end %>
             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
               <%= unit.name %>
               <% if unit.discarded? %>
@@ -109,6 +119,51 @@
       </tbody>
     </table>
   </div>
+
+  <% if current_user.admin? %>
+    <div class="sticky bottom-0 z-10 flex flex-wrap items-center gap-2 bg-white border-t border-gray-200 px-4 py-3 shadow-md mb-4">
+      <label class="text-sm text-gray-600">一括更新:</label>
+      <select id="bulk-status-select"
+              class="text-sm rounded border-gray-300 py-1.5 pr-8"
+              aria-label="一括更新するStatus">
+        <% Unit::STATUS_TRANSLATIONS.each do |key, label| %>
+          <option value="<%= key %>"><%= label %></option>
+        <% end %>
+      </select>
+      <button type="button"
+              onclick="submitBulkStatus()"
+              class="px-4 py-2 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 cursor-pointer">
+        選択した項目のStatusを更新
+      </button>
+    </div>
+
+    <%= form_with url: bulk_update_status_admin_units_path, method: :patch, id: "bulk-status-form", class: "hidden" do %>
+      <input type="hidden" name="status" id="bulk-status-value">
+    <% end %>
+
+    <script>
+      function submitBulkStatus() {
+        var checked = document.querySelectorAll('.row-check:checked');
+        if (checked.length === 0) {
+          alert('項目が選択されていません');
+          return;
+        }
+        if (!confirm('選択した ' + checked.length + ' 件のStatusを更新します。よろしいですか？')) return;
+
+        var form = document.getElementById('bulk-status-form');
+        form.querySelectorAll('input[name="ids[]"]').forEach(function(el) { el.remove(); });
+        checked.forEach(function(cb) {
+          var input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = 'ids[]';
+          input.value = cb.value;
+          form.appendChild(input);
+        });
+        document.getElementById('bulk-status-value').value = document.getElementById('bulk-status-select').value;
+        form.requestSubmit();
+      }
+    </script>
+  <% end %>
 
   <div class="mt-4">
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :units do
       collection do
         get :search
+        patch :bulk_update_status
       end
       member do
         patch :undiscard
@@ -42,6 +43,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :people do
       collection do
         get :search
+        patch :bulk_update_status
       end
       member do
         patch :undiscard

--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -56,6 +56,7 @@
 | Wiki Page Imports | 全アクション |
 | Units / People — キー変更 | change_key |
 | Units / People — リダイレクト元の物理削除 | purge |
+| Units / People — 一覧からのStatus一括更新 | bulk_update_status |
 
 ---
 
@@ -87,6 +88,7 @@
 | `admin?` でない | ナビの Images リンク |
 | `admin?` でない | Units / People 編集画面の「キー変更」ボタン |
 | `admin?` でない | Units / People 一覧のリダイレクト元「物理削除」ボタン |
+| `admin?` でない | Units / People 一覧のチェックボックス・一括Status更新バー |
 
 ---
 

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -191,6 +191,49 @@ module Admin
       assert_not_includes response.body, tagged_active.name
     end
 
+    test 'bulk_update_status requires admin role' do
+      other_person = Person.create!(name: 'Other Person', key: 'bulk-status-auth-person', status: :active)
+
+      patch bulk_update_status_admin_people_path, params: { ids: [@person.id, other_person.id], status: 'hiatus' }
+
+      assert_redirected_to root_path
+      assert_equal 'active', @person.reload.status
+      assert_equal 'active', other_person.reload.status
+    end
+
+    test 'bulk_update_status updates the status of the selected people and logs each change' do
+      login_as_admin
+      other_person = Person.create!(name: 'Other Person', key: 'bulk-status-person', status: :active)
+
+      patch bulk_update_status_admin_people_path, params: { ids: [@person.id, other_person.id], status: 'hiatus' }
+
+      assert_redirected_to admin_people_path
+      assert_equal '2件のStatusを更新しました', flash[:notice]
+      assert_equal 'hiatus', @person.reload.status
+      assert_equal 'hiatus', other_person.reload.status
+      assert UpdateLog.exists?(loggable: @person, action: 'update')
+      assert UpdateLog.exists?(loggable: other_person, action: 'update')
+    end
+
+    test 'bulk_update_status shows an alert when no ids are selected' do
+      login_as_admin
+
+      patch bulk_update_status_admin_people_path, params: { ids: [], status: 'hiatus' }
+
+      assert_redirected_to admin_people_path
+      assert_equal '項目が選択されていません', flash[:alert]
+    end
+
+    test 'bulk_update_status shows an alert for an invalid status' do
+      login_as_admin
+
+      patch bulk_update_status_admin_people_path, params: { ids: [@person.id], status: 'not-a-real-status' }
+
+      assert_redirected_to admin_people_path
+      assert_equal 'Statusを選択してください', flash[:alert]
+      assert_equal 'active', @person.reload.status
+    end
+
     private
 
     def login_as_admin

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -217,6 +217,49 @@ module Admin
       assert_not_includes response.body, tagged_active.name
     end
 
+    test 'bulk_update_status requires admin role' do
+      other_unit = Unit.create!(name: 'Other Unit', key: 'bulk-status-auth-unit', status: :active)
+
+      patch bulk_update_status_admin_units_path, params: { ids: [@unit.id, other_unit.id], status: 'freeze' }
+
+      assert_redirected_to root_path
+      assert_equal 'active', @unit.reload.status
+      assert_equal 'active', other_unit.reload.status
+    end
+
+    test 'bulk_update_status updates the status of the selected units and logs each change' do
+      login_as_admin
+      other_unit = Unit.create!(name: 'Other Unit', key: 'bulk-status-unit', status: :active)
+
+      patch bulk_update_status_admin_units_path, params: { ids: [@unit.id, other_unit.id], status: 'freeze' }
+
+      assert_redirected_to admin_units_path
+      assert_equal '2件のStatusを更新しました', flash[:notice]
+      assert_equal 'freeze', @unit.reload.status
+      assert_equal 'freeze', other_unit.reload.status
+      assert UpdateLog.exists?(loggable: @unit, action: 'update')
+      assert UpdateLog.exists?(loggable: other_unit, action: 'update')
+    end
+
+    test 'bulk_update_status shows an alert when no ids are selected' do
+      login_as_admin
+
+      patch bulk_update_status_admin_units_path, params: { ids: [], status: 'freeze' }
+
+      assert_redirected_to admin_units_path
+      assert_equal '項目が選択されていません', flash[:alert]
+    end
+
+    test 'bulk_update_status shows an alert for an invalid status' do
+      login_as_admin
+
+      patch bulk_update_status_admin_units_path, params: { ids: [@unit.id], status: 'not-a-real-status' }
+
+      assert_redirected_to admin_units_path
+      assert_equal 'Statusを選択してください', flash[:alert]
+      assert_equal 'active', @unit.reload.status
+    end
+
     private
 
     def login_as_admin


### PR DESCRIPTION
## Summary
- Unit/People 管理一覧にチェックボックスと全選択/全解除を追加
- 選択した行に対して、選択したStatusで一括更新できる機能を追加（admin権限のみ）
- 各レコードごとに UpdateLog を記録し、通常の編集と同様の変更履歴を残す

## Test plan
- [x] `bundle exec rails test test/controllers/admin/` が全件パスすること
- [x] RuboCop に違反がないこと
- [ ] 管理画面で実際にチェックボックス選択→一括Status更新の動作確認

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)