### PR TITLE
サイドバー「最近の更新」でkey未設定のUnit/Personを除外

### DIFF
--- a/app/controllers/custom_pages_controller.rb
+++ b/app/controllers/custom_pages_controller.rb
@@ -26,8 +26,8 @@ class CustomPagesController < ApplicationController
 
     @recently_updated = Rails.cache.fetch('sidebar/recently_updated', expires_in: 10.minutes) do
       pages   = CustomPage.published.order(updated_at: :desc).limit(10).to_a
-      units   = Unit.kept.order(updated_at: :desc).limit(10).to_a
-      persons = Person.kept.order(updated_at: :desc).limit(10).to_a
+      units   = Unit.kept.where.not(key: nil).order(updated_at: :desc).limit(10).to_a
+      persons = Person.kept.where.not(key: nil).order(updated_at: :desc).limit(10).to_a
       (pages + units + persons).sort_by(&:updated_at).reverse.first(8)
     end
 


### PR DESCRIPTION
## Summary
- `CustomPagesController#load_sidebar_data` の `@recently_updated` 取得クエリに `where.not(key: nil)` を追加
- `key` が未設定の Unit/Person があると `profile_path(item.key)` が `key: nil` でルート生成に失敗し500エラーになる不具合を修正

## Test plan
- [x] `bin/rails test` が全件パスすること（201 runs, 0 failures）
- [ ] `key` 未設定の Unit/Person が存在する状態でトップページ（サイドバー「最近の更新」）が500エラーにならず表示されること

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)