### PR TITLE
管理画面の一覧ページにtitleタグの画面名を追加

### DIFF
--- a/app/views/admin/custom_pages/index.html.erb
+++ b/app/views/admin/custom_pages/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "カスタムページ管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0 text-gray-900 dark:text-gray-100">カスタムページ管理</h1>
+    <h1 class="text-2xl font-bold mb-4 md:mb-0 text-gray-900 dark:text-gray-100"><%= title %></h1>
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_custom_pages_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.text_field :q, value: params[:q], placeholder: "key / タイトルで検索...",

--- a/app/views/admin/external_sites/index.html.erb
+++ b/app/views/admin/external_sites/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "外部サイト管理" %>
+<% content_for :title, title %>
 <div class="sm:flex sm:items-center">
   <div class="sm:flex-auto">
-    <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">External Sites</h1>
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100"><%= title %></h1>
     <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">A list of all external site definitions.</p>
   </div>
   <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">

--- a/app/views/admin/images/index.html.erb
+++ b/app/views/admin/images/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "画像管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0 dark:text-white">画像管理</h1>
+    <h1 class="text-2xl font-bold mb-4 md:mb-0 dark:text-white"><%= title %></h1>
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_images_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.text_field :q, value: params[:q], placeholder: "ファイル名で検索...",

--- a/app/views/admin/index_groups/index.html.erb
+++ b/app/views/admin/index_groups/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "Index Groups管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0">Index Groups</h1>
+    <h1 class="text-2xl font-bold mb-4 md:mb-0"><%= title %></h1>
     <%= link_to "Add Group", new_admin_index_group_path, class: "px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700" %>
   </div>
 

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "アイテム管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0">Item Management</h1>
+    <h1 class="text-2xl font-bold mb-4 md:mb-0"><%= title %></h1>
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_items_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.text_field :q, value: params[:q], placeholder: "Search by title or ASIN...", class: "rounded-l-md border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500" %>

--- a/app/views/admin/operation_logs/index.html.erb
+++ b/app/views/admin/operation_logs/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "ログイン履歴" %>
+<% content_for :title, title %>
 <div class="sm:flex sm:items-center">
   <div class="sm:flex-auto">
-    <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">ログイン履歴</h1>
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100"><%= title %></h1>
     <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">ユーザーのログイン履歴の一覧です。</p>
   </div>
 </div>

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -1,7 +1,9 @@
+<% title = "People管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
     <div class="flex items-center gap-3 mb-4 md:mb-0">
-      <h1 class="text-2xl font-bold">People管理</h1>
+      <h1 class="text-2xl font-bold"><%= title %></h1>
       <%= link_to "Unit管理", admin_units_path,
           class: "text-sm text-gray-500 hover:text-indigo-600 hover:underline" %>
     </div>

--- a/app/views/admin/trends/index.html.erb
+++ b/app/views/admin/trends/index.html.erb
@@ -1,6 +1,8 @@
+<% title = "動向管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold mb-4 md:mb-0 text-gray-900 dark:text-gray-100">Trend Management</h1>
+    <h1 class="text-2xl font-bold mb-4 md:mb-0 text-gray-900 dark:text-gray-100"><%= title %></h1>
     <div class="flex items-center space-x-4">
       <%= form_with url: admin_trends_path, method: :get, local: true, class: "flex" do |f| %>
         <%= f.text_field :q, value: params[:q], placeholder: "Search by title or content...", class: "rounded-l-md border border-gray-300 focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>

--- a/app/views/admin/unit_logs/index.html.erb
+++ b/app/views/admin/unit_logs/index.html.erb
@@ -1,7 +1,9 @@
+<% title = "#{@unit.name}のログ" %>
+<% content_for :title, title %>
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="sm:flex sm:items-center">
     <div class="sm:flex-auto">
-      <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Unit Logs for <%= @unit.name %></h1>
+      <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= title %></h1>
       <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">A list of all career logs for this unit.</p>
     </div>
     <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">

--- a/app/views/admin/unit_snapshots/index.html.erb
+++ b/app/views/admin/unit_snapshots/index.html.erb
@@ -1,7 +1,9 @@
+<% title = "#{@unit.name} のスナップショット" %>
+<% content_for :title, title %>
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="sm:flex sm:items-center">
     <div class="sm:flex-auto">
-      <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= @unit.name %> のスナップショット</h1>
+      <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= title %></h1>
       <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">特定時点のラインアップスナップショット。</p>
     </div>
     <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -1,7 +1,9 @@
+<% title = "Unit管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex flex-col md:flex-row justify-between items-center mb-6">
     <div class="flex items-center gap-3 mb-4 md:mb-0">
-      <h1 class="text-2xl font-bold">Unit管理</h1>
+      <h1 class="text-2xl font-bold"><%= title %></h1>
       <%= link_to "People管理", admin_people_path,
           class: "text-sm text-gray-500 hover:text-indigo-600 hover:underline" %>
     </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,5 +1,7 @@
+<% title = "ユーザー管理" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
-  <h1 class="text-2xl font-bold mb-6">User Management</h1>
+  <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
   
   <%= render 'form' %>
 

--- a/app/views/admin/wiki_page_imports/index.html.erb
+++ b/app/views/admin/wiki_page_imports/index.html.erb
@@ -1,16 +1,19 @@
+<% status_label = if @show_manually_set then "手動仕訳済み - #{WikiPageImport::PAGE_TYPE_LABELS[@ms_page_type]}"
+                    elsif @show_deferred  then '保留'
+                    elsif @show_ignored   then '除外済み'
+                    elsif @show_pending          then '未処理'
+                    elsif @show_error            then 'エラー'
+                    elsif @show_imported         then '取込済み'
+                    elsif @show_imported_ignored then '取込済み（除外）'
+                    elsif @show_post_excluded   then '取込後除外'
+                    else 'スキップ済み'
+                    end %>
+<% title = "Wiki Page Imports（#{status_label}）" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-      Wiki Page Imports（<%= if @show_manually_set then "手動仕訳済み - #{WikiPageImport::PAGE_TYPE_LABELS[@ms_page_type]}"
-                             elsif @show_deferred  then '保留'
-                             elsif @show_ignored   then '除外済み'
-                             elsif @show_pending          then '未処理'
-                             elsif @show_error            then 'エラー'
-                             elsif @show_imported         then '取込済み'
-                             elsif @show_imported_ignored then '取込済み（除外）'
-                             elsif @show_post_excluded   then '取込後除外'
-                             else 'スキップ済み'
-                             end %>）
+      <%= title %>
     </h1>
     <div class="flex items-center gap-2">
       <span class="text-sm text-gray-500 dark:text-gray-400"><%= @pagy.count %> 件</span>


### PR DESCRIPTION
## Summary
- ブラウザタブで各管理画面を区別できるよう、一覧(index)画面13件に `content_for(:title)` を設定
- `title` ローカル変数を1箇所に定義し、`content_for(:title)` と `<h1>` の両方から参照する方式で二重管理を回避
- 英語表記だったh1（Trend Management等）は公開画面で使われている既存の日本語用語に合わせて統一（動向管理・アイテム管理・ユーザー管理・外部サイト管理など）
- new/edit/show画面は別issue(#993)で対応予定

## Test plan
- [x] `bin/rails test` が全件パスすること（pre-pushフックで確認済み、201 runs / 0 failures）
- [ ] 各管理画面（Unit/People/Trends/Items/Custom Pages/External Sites/Images/Index Groups/Users/Login History/Wiki Page Imports/Unit Logs/Unit Snapshots）の一覧をブラウザで開き、タブに画面名が表示されることを確認

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)