### PR TITLE
管理画面の新規/編集/詳細ページにtitleタグの画面名を追加

### DIFF
--- a/app/views/admin/custom_pages/edit.html.erb
+++ b/app/views/admin/custom_pages/edit.html.erb
@@ -1,7 +1,9 @@
+<% title = "カスタムページ編集: #{@custom_page.title}" %>
+<% content_for :title, title %>
 <div class="py-4">
   <div class="max-w-none">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">カスタムページを編集</h1>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100"><%= title %></h1>
       <div class="flex items-center gap-4">
         <%= link_to "ページを開く", custom_page_path(@custom_page.key),
             target: "_blank", rel: "noopener noreferrer",

--- a/app/views/admin/custom_pages/new.html.erb
+++ b/app/views/admin/custom_pages/new.html.erb
@@ -1,7 +1,9 @@
+<% title = "新規カスタムページ" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-4xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">新規カスタムページ</h1>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100"><%= title %></h1>
       <%= link_to "一覧に戻る", admin_custom_pages_path,
           class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
     </div>

--- a/app/views/admin/external_sites/edit.html.erb
+++ b/app/views/admin/external_sites/edit.html.erb
@@ -1,8 +1,10 @@
+<% title = "外部サイト編集" %>
+<% content_for :title, title %>
 <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
   <div class="mx-auto max-w-3xl">
     <div class="md:flex md:items-center md:justify-between mb-8">
       <div class="min-w-0 flex-1">
-        <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:truncate sm:text-3xl sm:tracking-tight">Edit External Site</h2>
+        <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:truncate sm:text-3xl sm:tracking-tight"><%= title %></h2>
       </div>
     </div>
 

--- a/app/views/admin/external_sites/new.html.erb
+++ b/app/views/admin/external_sites/new.html.erb
@@ -1,8 +1,10 @@
+<% title = "外部サイト新規作成" %>
+<% content_for :title, title %>
 <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
   <div class="mx-auto max-w-3xl">
     <div class="md:flex md:items-center md:justify-between mb-8">
       <div class="min-w-0 flex-1">
-        <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:truncate sm:text-3xl sm:tracking-tight">New External Site</h2>
+        <h2 class="text-2xl font-bold leading-7 text-gray-900 dark:text-gray-100 sm:truncate sm:text-3xl sm:tracking-tight"><%= title %></h2>
       </div>
     </div>
 

--- a/app/views/admin/images/show.html.erb
+++ b/app/views/admin/images/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "画像: #{@attachment.blob.filename}" %>
 <div class="container mx-auto px-4 py-8 max-w-4xl">
   <div class="flex items-center gap-4 mb-6">
     <%= link_to admin_images_path, class: "text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 flex items-center gap-1" do %>

--- a/app/views/admin/index_groups/_form.html.erb
+++ b/app/views/admin/index_groups/_form.html.erb
@@ -1,6 +1,8 @@
+<% title = @index_group.new_record? ? "Index Group新規作成" : "Index Group編集: #{@index_group.name}" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-md mx-auto bg-white shadow rounded-lg p-6">
-    <h1 class="text-2xl font-bold mb-6"><%= @index_group.new_record? ? "New Index Group" : "Edit Index Group" %></h1>
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
 
     <%= form_with model: [:admin, @index_group], local: true do |f| %>
       <% if @index_group.errors.any? %>

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Index Group: #{@index_group.name}" %>
 <div class="container mx-auto px-4 py-8">
   <div class="mb-6">
     <div class="flex items-center text-sm text-gray-500 mb-2">

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,7 +1,9 @@
+<% title = "アイテム編集: #{@item.title}" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">Edit Item: <%= @item.title %></h1>
+      <h1 class="text-2xl font-bold"><%= title %></h1>
       <%= link_to "Back to Public Page", item_path(@item), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
     <div class="bg-white shadow rounded-lg p-6">

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,6 +1,8 @@
+<% title = "アイテム新規作成" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">New Item</h1>
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", item: @item %>
     </div>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -1,7 +1,9 @@
+<% title = "Person編集: #{@person.name}" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-2 py-4">
   <div class="max-w-7xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold dark:text-white">Edit Person: <%= @person.name %></h1>
+      <h1 class="text-2xl font-bold dark:text-white"><%= title %></h1>
       <%= link_to "Back to Public Page", profile_path(@person.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
 

--- a/app/views/admin/people/new.html.erb
+++ b/app/views/admin/people/new.html.erb
@@ -1,5 +1,7 @@
+<% title = "Person新規作成" %>
+<% content_for :title, title %>
 <div class="max-w-2xl mx-auto px-4 py-8">
-  <h1 class="text-2xl font-bold mb-6 dark:text-white">New Person</h1>
+  <h1 class="text-2xl font-bold mb-6 dark:text-white"><%= title %></h1>
   <div class="bg-white shadow rounded-lg p-6 dark:bg-gray-800">
     <%= render "form", person: @person %>
   </div>

--- a/app/views/admin/sections/edit.html.erb
+++ b/app/views/admin/sections/edit.html.erb
@@ -1,6 +1,8 @@
+<% title = "セクション編集: #{@section.name}" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-2 py-4 max-w-4xl">
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold dark:text-white">セクション編集: <%= @section.name %></h1>
+    <h1 class="text-2xl font-bold dark:text-white"><%= title %></h1>
     <% if @section.discarded? %>
       <%= button_to "復元",
             undiscard_admin_section_path(@section),

--- a/app/views/admin/sections/new.html.erb
+++ b/app/views/admin/sections/new.html.erb
@@ -1,4 +1,6 @@
+<% title = "セクション追加" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-2 py-4 max-w-4xl">
-  <h1 class="text-2xl font-bold mb-6 dark:text-white">セクション追加</h1>
+  <h1 class="text-2xl font-bold mb-6 dark:text-white"><%= title %></h1>
   <%= render "form", section: @section, sectionable: @sectionable %>
 </div>

--- a/app/views/admin/snapshot_people/edit.html.erb
+++ b/app/views/admin/snapshot_people/edit.html.erb
@@ -1,3 +1,5 @@
+<% title = "メンバー編集: #{@snapshot_person.name}" %>
+<% content_for :title, title %>
 <div class="max-w-7xl mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
     <div class="mb-6">
@@ -12,7 +14,7 @@
           <span>日付: <%= @unit_snapshot.snapshot_date.strftime("%Y/%m/%d") %></span>
         <% end %>
       </div>
-      <h1 class="text-2xl font-bold dark:text-white">Edit Member: <%= @snapshot_person.name %></h1>
+      <h1 class="text-2xl font-bold dark:text-white"><%= title %></h1>
     </div>
     <% if @snapshot_person.person_id.nil? && @snapshot_person.person_name.present? %>
       <div class="mb-6 rounded-md border border-indigo-200 bg-indigo-50 p-4 dark:border-indigo-800 dark:bg-indigo-900/30">

--- a/app/views/admin/trends/edit.html.erb
+++ b/app/views/admin/trends/edit.html.erb
@@ -1,7 +1,9 @@
+<% title = "動向編集: #{@trend.title}" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-4xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Edit Trend</h1>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100"><%= title %></h1>
       <div class="flex gap-4">
         <%= link_to "Show", trend_path(@trend), class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
         <%= link_to "一覧", admin_trends_path, class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>

--- a/app/views/admin/trends/new.html.erb
+++ b/app/views/admin/trends/new.html.erb
@@ -1,7 +1,9 @@
+<% title = "動向新規作成" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-4xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">New Trend</h1>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100"><%= title %></h1>
       <%= link_to "Back", admin_trends_path, class: "text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white" %>
     </div>
 

--- a/app/views/admin/unit_logs/edit.html.erb
+++ b/app/views/admin/unit_logs/edit.html.erb
@@ -1,6 +1,8 @@
+<% title = "#{@unit.name}のログ編集" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">Edit Log for <%= @unit.name %></h1>
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", unit: @unit, unit_log: @unit_log %>
     </div>

--- a/app/views/admin/unit_logs/new.html.erb
+++ b/app/views/admin/unit_logs/new.html.erb
@@ -1,6 +1,8 @@
+<% title = "#{@unit.name}のログ新規作成" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">New Log for <%= @unit.name %></h1>
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", unit: @unit, unit_log: @unit_log %>
     </div>

--- a/app/views/admin/unit_snapshots/edit.html.erb
+++ b/app/views/admin/unit_snapshots/edit.html.erb
@@ -1,7 +1,9 @@
+<% title = "#{@unit.name} のスナップショット編集" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-5xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold dark:text-white"><%= @unit.name %> のスナップショット編集</h1>
+      <h1 class="text-2xl font-bold dark:text-white"><%= title %></h1>
       <%= link_to "一覧に戻る", admin_unit_unit_snapshots_path(@unit),
             class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>

--- a/app/views/admin/unit_snapshots/new.html.erb
+++ b/app/views/admin/unit_snapshots/new.html.erb
@@ -1,6 +1,8 @@
+<% title = "#{@unit.name} の新規スナップショット" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6"><%= @unit.name %> の新規スナップショット</h1>
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", unit: @unit, unit_snapshot: @unit_snapshot %>
     </div>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -1,7 +1,9 @@
+<% title = "Unit編集: #{@unit.name}" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-2 py-4">
   <div class="max-w-7xl mx-auto">
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">Edit Unit: <%= @unit.name %></h1>
+      <h1 class="text-2xl font-bold"><%= title %></h1>
       <%= link_to "Back to Public Page", profile_path(@unit.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
     <div class="md:grid md:grid-cols-5 md:gap-8">

--- a/app/views/admin/units/new.html.erb
+++ b/app/views/admin/units/new.html.erb
@@ -1,6 +1,8 @@
+<% title = "Unit新規作成" %>
+<% content_for :title, title %>
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">New Unit</h1>
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", unit: @unit %>
     </div>


### PR DESCRIPTION
## Summary
- #992（一覧画面対応）に続き、new/edit/showの22画面に `content_for(:title)` を追加
- `title` ローカル変数を1箇所に定義し、`content_for(:title)` と `<h1>`（index_groupsは`<h2>`）の両方から参照する方式で二重管理を回避
- 対象レコード名を含む画面（Unit編集、Person編集、アイテム編集、動向編集、セクション編集、Index Group編集、スナップショットメンバー編集など）はタブ上でも対象を区別できるようにした
- 英語だった見出し（New Unit, Edit Person等）は#992と同様、公開画面の既存用語に合わせて日本語化
- カスタムページ編集は管理者からのフィードバックを受け、ページ名（`@custom_page.title`）も含めるよう調整済み

## Test plan
- [x] `bin/rails test` が全件パスすること（pre-pushフックで確認済み、201 runs / 0 failures）
- [ ] Unit/Person/Item/Trend/Section/CustomPage/ExternalSite/IndexGroup/UnitLog/UnitSnapshot/SnapshotPersonの新規作成・編集・詳細画面をブラウザで開き、タブに画面名が表示されることを確認

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)