### PR TITLE
Unit/Personのkeyの一意性チェックを大文字小文字を区別しないように修正

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,6 +74,7 @@ class Person < ApplicationRecord
 
   before_save :normalize_birthday_year
 
+  validates :key, uniqueness: { case_sensitive: false }, allow_blank: true
   validate :key_immutable, on: :update
   after_create :auto_link_snapshot_people
   after_commit :expire_sidebar_cache

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -47,6 +47,7 @@ class Unit < ApplicationRecord
   enum :status, { pre: 0, active: 1, freeze: 2, disbanded: 3, unknown: 99 }
 
   validates :status, presence: true
+  validates :key, uniqueness: { case_sensitive: false }, allow_blank: true
   validate :key_immutable, on: :update
 
   STATUS_TRANSLATIONS = {

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,10 +2,12 @@ ja:
   errors:
     messages:
       blank: "を入力してください"
+      taken: "はすでに存在します"
   activerecord:
     errors:
       messages:
         blank: "を入力してください"
+        taken: "はすでに存在します"
     attributes:
       link:
         url: "URL"

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -192,6 +192,33 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert_equal '%44%65%76%65%6C%6F%70+%4F%6E%65%2527%73+%46%61%63%75%6C%74%69%65%73', item[:old_key]
   end
 
+  test 'key uniqueness is case-insensitive' do
+    Person.create!(name: 'Existing Person', key: 'case-key-test', status: :active)
+    person = Person.new(name: 'Duplicate Person', key: 'Case-Key-Test', status: :active)
+
+    assert_not person.valid?
+    assert_includes person.errors[:key], 'はすでに存在します'
+  end
+
+  test 'change_key! raises when new key duplicates an existing key by case only' do
+    Person.create!(name: 'Existing Person', key: 'case-change-target', status: :active)
+    person = Person.create!(name: 'Renaming Person', key: 'person-key-change-case-before', status: :active)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      person.change_key!('Case-Change-Target')
+    end
+  end
+
+  test 'change_key! raises when new key duplicates a discarded redirect stub by case only' do
+    person = Person.create!(name: 'Rename Target Person', key: 'person-key-stub-before', status: :active)
+    person.change_key!('person-key-stub-after')
+    other = Person.create!(name: 'Other Person', key: 'person-key-stub-other', status: :active)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      other.change_key!('Person-Key-Stub-Before')
+    end
+  end
+
   test 'change_key! updates the key and creates a discarded redirect stub' do
     person = Person.create!(name: 'Rename Target Person', key: 'person-key-change-before', status: :active)
 

--- a/test/models/unit_test.rb
+++ b/test/models/unit_test.rb
@@ -43,6 +43,33 @@ class UnitTest < ActiveSupport::TestCase
     assert_includes unit.errors[:key], 'cannot be changed once set'
   end
 
+  test 'key uniqueness is case-insensitive' do
+    Unit.create!(name: 'Existing Unit', key: 'case-key-test', status: :active)
+    unit = Unit.new(name: 'Duplicate Unit', key: 'Case-Key-Test', status: :active)
+
+    assert_not unit.valid?
+    assert_includes unit.errors[:key], 'はすでに存在します'
+  end
+
+  test 'change_key! raises when new key duplicates an existing key by case only' do
+    Unit.create!(name: 'Existing Unit', key: 'case-change-target', status: :active)
+    unit = Unit.create!(name: 'Renaming Unit', key: 'unit-key-change-case-before', status: :active)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      unit.change_key!('Case-Change-Target')
+    end
+  end
+
+  test 'change_key! raises when new key duplicates a discarded redirect stub by case only' do
+    unit = Unit.create!(name: 'Rename Target Unit', key: 'unit-key-stub-before', status: :active)
+    unit.change_key!('unit-key-stub-after')
+    other = Unit.create!(name: 'Other Unit', key: 'unit-key-stub-other', status: :active)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      other.change_key!('Unit-Key-Stub-Before')
+    end
+  end
+
   test 'other attributes can still be updated when key is unchanged' do
     unit = Unit.create!(name: 'Existing Unit', key: 'unchanged-unit-key-test', status: :active)
 


### PR DESCRIPTION
## Summary
- `Unit`/`Person`の`key`にcase-insensitiveなuniquenessバリデーションを追加（`"Band"`と`"band"`のような大文字小文字違いの重複キーが作成できてしまう問題への対応）
- `change_key!`は`update!`経由でこのバリデーションが自動適用される。discard済みのリダイレクトスタブも`default_scope`がないため重複チェックの対象に含まれる
- `ja.yml`に`taken`のエラーメッセージ翻訳を追加（既存は`blank`のみ日本語化されており未定義だったため）

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rubocop` でオフェンスなし
- [ ] 管理画面のkey変更フォームで、既存キーと大文字小文字違いのキーに変更しようとするとエラーになることを確認

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)