### PR TITLE
index/showページで論理削除済みのUnit/Personを除外する

### DIFF
--- a/app/controllers/indices_controller.rb
+++ b/app/controllers/indices_controller.rb
@@ -18,7 +18,7 @@ class IndicesController < ApplicationController
 
   def show
     @index = TagIndex.find(params[:id])
-    @people = @index.people.order(:name_kana, :name)
-    @units = @index.units.order(:name_kana, :name)
+    @people = @index.people.kept.order(:name_kana, :name)
+    @units = @index.units.kept.order(:name_kana, :name)
   end
 end

--- a/test/controllers/indices_controller_test.rb
+++ b/test/controllers/indices_controller_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class IndicesControllerTest < ActionDispatch::IntegrationTest
+  test 'show excludes discarded units and people' do
+    tag_index = TagIndex.create!(name: "Discard Test Index #{SecureRandom.hex(4)}")
+
+    kept_unit = Unit.create!(name: 'Kept Unit', key: "kept-unit-#{SecureRandom.hex(4)}", status: :active)
+    discarded_unit = Unit.create!(name: 'Discarded Unit', key: "discarded-unit-#{SecureRandom.hex(4)}",
+                                  status: :active)
+    discarded_unit.discard
+
+    kept_person = Person.create!(name: 'Kept Person', key: "kept-person-#{SecureRandom.hex(4)}", status: :active)
+    discarded_person = Person.create!(name: 'Discarded Person', key: "discarded-person-#{SecureRandom.hex(4)}",
+                                      status: :active)
+    discarded_person.discard
+
+    TagIndexItem.create!(tag_index:, indexable: kept_unit)
+    TagIndexItem.create!(tag_index:, indexable: discarded_unit)
+    TagIndexItem.create!(tag_index:, indexable: kept_person)
+    TagIndexItem.create!(tag_index:, indexable: discarded_person)
+
+    get index_show_path(tag_index)
+
+    assert_response :success
+    assert_includes response.body, 'Kept Unit'
+    assert_includes response.body, 'Kept Person'
+    assert_not_includes response.body, 'Discarded Unit'
+    assert_not_includes response.body, 'Discarded Person'
+  end
+end


### PR DESCRIPTION
## Summary
- `IndicesController#show` にのみ `.kept` スコープが漏れており、論理削除（discard）済みのUnit/Personがindex/showページ（例: http://localhost:3000/index/show/2464）に表示され続けていた
- `UnitsController`/`PeopleController` と同様に `.kept` を適用し、discard済みレコードを除外するよう修正

## Test plan
- [x] `bin/rails test` が全件パスすること（208 runs, 0 failures）
- [x] discard済みUnit/Personがindex/showページの一覧・件数から除外されることを検証するテストを追加（`test/controllers/indices_controller_test.rb`）
- [x] 修正前のコードで同テストが失敗すること（バグの再現）を確認済み

Closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)