### PR TITLE
feat: スナップショットを別ユニットにコピーできる機能を追加

### DIFF
--- a/app/controllers/admin/unit_snapshots_controller.rb
+++ b/app/controllers/admin/unit_snapshots_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class UnitSnapshotsController < Admin::BaseController
     before_action :set_unit
-    before_action :set_unit_snapshot, only: %i[edit update destroy copy]
+    before_action :set_unit_snapshot, only: %i[edit update destroy copy copy_to_unit]
 
     def index
       @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person)
@@ -51,23 +51,35 @@ module Admin
     end
 
     def copy
-      new_snapshot = @unit.unit_snapshots.build(
-        snapshot_date: @unit_snapshot.snapshot_date,
-        label: @unit_snapshot.label,
-        current: false,
-        past: @unit_snapshot.past,
-        active: false
-      )
+      new_snapshot = copy_snapshot_to(@unit)
 
-      if new_snapshot.save
-        @unit_snapshot.snapshot_people.each do |sp|
-          new_snapshot.snapshot_people.create!(sp.attributes.except('id', 'unit_snapshot_id', 'created_at', 'updated_at'))
-        end
-        record_update_log(new_snapshot, action: 'create')
+      if new_snapshot.persisted?
         redirect_to edit_admin_unit_unit_snapshot_path(@unit, new_snapshot),
                     notice: 'Snapshot was successfully copied.'
       else
         redirect_to admin_unit_unit_snapshots_path(@unit),
+                    alert: 'Failed to copy snapshot.'
+      end
+    end
+
+    def copy_to_unit
+      return unless request.post?
+
+      target_unit = Unit.kept.find_by(id: params[:target_unit_id])
+
+      if target_unit.nil?
+        redirect_to copy_to_unit_admin_unit_unit_snapshot_path(@unit, @unit_snapshot),
+                    alert: 'コピー先のユニットを選択してください。'
+        return
+      end
+
+      new_snapshot = copy_snapshot_to(target_unit)
+
+      if new_snapshot.persisted?
+        redirect_to edit_admin_unit_unit_snapshot_path(target_unit, new_snapshot),
+                    notice: "#{target_unit.name} にスナップショットをコピーしました。"
+      else
+        redirect_to copy_to_unit_admin_unit_unit_snapshot_path(@unit, @unit_snapshot),
                     alert: 'Failed to copy snapshot.'
       end
     end
@@ -91,6 +103,25 @@ module Admin
 
     def unit_snapshot_params
       params.require(:unit_snapshot).permit(:snapshot_date, :label, :current, :active)
+    end
+
+    def copy_snapshot_to(target_unit)
+      new_snapshot = target_unit.unit_snapshots.build(
+        snapshot_date: @unit_snapshot.snapshot_date,
+        label: @unit_snapshot.label,
+        current: false,
+        past: @unit_snapshot.past,
+        active: false
+      )
+
+      if new_snapshot.save
+        @unit_snapshot.snapshot_people.each do |sp|
+          new_snapshot.snapshot_people.create!(sp.attributes.except('id', 'unit_snapshot_id', 'created_at', 'updated_at'))
+        end
+        record_update_log(new_snapshot, action: 'create')
+      end
+
+      new_snapshot
     end
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -52,5 +52,8 @@ application.register("toggle", ToggleController)
 import UnitGraphController from "controllers/unit_graph_controller"
 application.register("unit-graph", UnitGraphController)
 
+import UnitSelectController from "controllers/unit_select_controller"
+application.register("unit-select", UnitSelectController)
+
 import YoutubeCarouselController from "controllers/youtube_carousel_controller"
 application.register("youtube-carousel", YoutubeCarouselController)

--- a/app/javascript/controllers/unit_select_controller.js
+++ b/app/javascript/controllers/unit_select_controller.js
@@ -1,0 +1,153 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Single-select autocomplete for unit lookup.
+// Sets a hidden unit_id field.
+export default class extends Controller {
+  static targets = ["input", "results", "unitId"]
+  static values = { url: String }
+
+  connect() {
+    this.timeout = null
+    this.activeIndex = -1
+    this.handleClickOutside = this.handleClickOutside.bind(this)
+    document.addEventListener('click', this.handleClickOutside)
+  }
+
+  disconnect() {
+    document.removeEventListener('click', this.handleClickOutside)
+  }
+
+  handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideResults()
+    }
+  }
+
+  search() {
+    clearTimeout(this.timeout)
+    const query = this.inputTarget.value.trim()
+
+    this.unitIdTarget.value = ''
+
+    if (query.length < 2) {
+      this.hideResults()
+      return
+    }
+
+    this.timeout = setTimeout(() => this.performSearch(query), 300)
+  }
+
+  onKeydown(event) {
+    const items = this.resultItems
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault()
+        if (this.resultsTarget.classList.contains('hidden')) return
+        this.activeIndex = Math.min(this.activeIndex + 1, items.length - 1)
+        this.highlightItem()
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        if (this.resultsTarget.classList.contains('hidden')) return
+        this.activeIndex = Math.max(this.activeIndex - 1, 0)
+        this.highlightItem()
+        break
+      case 'Enter':
+        event.preventDefault()
+        if (this.activeIndex >= 0 && items[this.activeIndex]) {
+          items[this.activeIndex].click()
+        }
+        break
+      case 'Escape':
+        this.hideResults()
+        this.inputTarget.blur()
+        break
+    }
+  }
+
+  get resultItems() {
+    return Array.from(this.resultsTarget.querySelectorAll('[data-id]'))
+  }
+
+  highlightItem() {
+    const items = this.resultItems
+    items.forEach((item, index) => {
+      if (index === this.activeIndex) {
+        item.classList.add('bg-gray-100', 'dark:bg-gray-700')
+      } else {
+        item.classList.remove('bg-gray-100', 'dark:bg-gray-700')
+      }
+    })
+    if (items[this.activeIndex]) {
+      items[this.activeIndex].scrollIntoView({ block: 'nearest' })
+    }
+  }
+
+  async performSearch(query) {
+    try {
+      const response = await fetch(`${this.urlValue}?q=${encodeURIComponent(query)}`, {
+        headers: {
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
+      if (!response.ok) throw new Error('Search failed')
+      const data = await response.json()
+      this.displayResults(data)
+    } catch (error) {
+      console.error('Unit select error:', error)
+    }
+  }
+
+  displayResults(items) {
+    this.activeIndex = -1
+
+    if (items.length === 0) {
+      this.hideResults()
+      return
+    }
+
+    this.resultsTarget.innerHTML = items.map(item => `
+      <div class="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+           data-action="click->unit-select#selectItem"
+           data-id="${item.id}"
+           data-name="${this.escapeHtml(item.name)}">
+        <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
+        ${item.key ? `<div class="text-xs text-gray-500 dark:text-gray-400 font-mono">${this.escapeHtml(item.key)}</div>` : ''}
+      </div>
+    `).join('')
+
+    this.showResults()
+  }
+
+  selectItem(event) {
+    const id = event.currentTarget.dataset.id
+    const name = event.currentTarget.dataset.name
+
+    this.unitIdTarget.value = id
+    this.inputTarget.value = name
+
+    this.hideResults()
+  }
+
+  clear() {
+    this.unitIdTarget.value = ''
+    this.inputTarget.value = ''
+  }
+
+  showResults() {
+    this.resultsTarget.classList.remove('hidden')
+  }
+
+  hideResults() {
+    this.activeIndex = -1
+    this.resultsTarget.classList.add('hidden')
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement('div')
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/views/admin/unit_snapshots/copy_to_unit.html.erb
+++ b/app/views/admin/unit_snapshots/copy_to_unit.html.erb
@@ -1,0 +1,32 @@
+<% title = "スナップショットを別ユニットにコピー" %>
+<% content_for :title, title %>
+<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= title %></h1>
+  <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
+    <%= @unit.name %> の「<%= @unit_snapshot.label.presence || @unit_snapshot.snapshot_date&.strftime("%Y/%m/%d") %>」を、選択したユニットにコピーします。
+  </p>
+
+  <%= form_with url: copy_to_unit_admin_unit_unit_snapshot_path(@unit, @unit_snapshot), method: :post, class: "mt-6 space-y-4" do %>
+    <div data-controller="unit-select"
+         data-unit-select-url-value="<%= search_admin_units_path %>"
+         class="relative">
+      <label for="target_unit_search" class="block text-sm font-medium text-gray-700 dark:text-gray-300">コピー先ユニット</label>
+      <input type="text"
+             id="target_unit_search"
+             placeholder="ユニット名で検索..."
+             autocomplete="off"
+             class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+             data-unit-select-target="input"
+             data-action="input->unit-select#search keydown->unit-select#onKeydown">
+      <div data-unit-select-target="results"
+           class="absolute z-50 mt-1 w-full bg-white dark:bg-gray-800 shadow-lg rounded-md border border-gray-200 dark:border-gray-700 hidden max-h-60 overflow-y-auto"></div>
+      <input type="hidden" name="target_unit_id" data-unit-select-target="unitId">
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">2文字以上入力すると候補が表示されます。</p>
+    </div>
+
+    <div class="flex justify-end gap-3 pt-2">
+      <%= link_to "キャンセル", admin_unit_unit_snapshots_path(@unit), class: "inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-600" %>
+      <button type="submit" class="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 cursor-pointer">コピーを実行</button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/unit_snapshots/index.html.erb
+++ b/app/views/admin/unit_snapshots/index.html.erb
@@ -60,6 +60,7 @@
                   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                     <%= link_to "編集", edit_admin_unit_unit_snapshot_path(@unit, snapshot), class: "text-indigo-600 hover:text-indigo-900 mr-4 dark:text-indigo-400 dark:hover:text-indigo-300" %>
                     <%= button_to "コピー", copy_admin_unit_unit_snapshot_path(@unit, snapshot), method: :post, class: "text-green-600 hover:text-green-900 bg-transparent border-0 cursor-pointer p-0 inline mr-4 dark:text-green-400 dark:hover:text-green-300", form_class: "inline", onclick: "return confirm('このスナップショットをコピーしますか？')" %>
+                    <%= link_to "別ユニット", copy_to_unit_admin_unit_unit_snapshot_path(@unit, snapshot), class: "text-green-600 hover:text-green-900 mr-4 dark:text-green-400 dark:hover:text-green-300" %>
                     <% if current_user.super_operator_or_above? %>
                       <%= button_to "削除", admin_unit_unit_snapshot_path(@unit, snapshot), method: :delete, class: "text-red-600 hover:text-red-900 bg-transparent border-0 cursor-pointer p-0 inline dark:text-red-400 dark:hover:text-red-300", form_class: "inline", onclick: "return confirm('本当に削除しますか？')" %>
                     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       resources :unit_snapshots, except: %i[show] do
         member do
           post :copy
+          get :copy_to_unit
+          post :copy_to_unit
         end
         collection do
           patch :reorder

--- a/test/controllers/admin/unit_snapshots_controller_test.rb
+++ b/test/controllers/admin/unit_snapshots_controller_test.rb
@@ -59,6 +59,34 @@ module Admin
       assert_redirected_to admin_unit_unit_snapshots_path(@unit)
     end
 
+    test 'should get copy_to_unit form' do
+      get copy_to_unit_admin_unit_unit_snapshot_path(@unit, @snapshot)
+      assert_response :success
+    end
+
+    test 'should copy unit_snapshot to another unit' do
+      other_unit = units(:two)
+
+      assert_difference('UnitSnapshot.count', 1) do
+        assert_difference('SnapshotPerson.count', @snapshot.snapshot_people.count) do
+          post copy_to_unit_admin_unit_unit_snapshot_path(@unit, @snapshot), params: { target_unit_id: other_unit.id }
+        end
+      end
+
+      new_snapshot = UnitSnapshot.last
+      assert_equal other_unit, new_snapshot.unit
+      assert_equal @snapshot.label, new_snapshot.label
+      assert_not new_snapshot.current?
+      assert_redirected_to edit_admin_unit_unit_snapshot_path(other_unit, new_snapshot)
+    end
+
+    test 'should not copy unit_snapshot when target unit is missing' do
+      assert_no_difference('UnitSnapshot.count') do
+        post copy_to_unit_admin_unit_unit_snapshot_path(@unit, @snapshot), params: { target_unit_id: '' }
+      end
+      assert_redirected_to copy_to_unit_admin_unit_unit_snapshot_path(@unit, @snapshot)
+    end
+
     test 'should redirect to login when not authenticated' do
       delete logout_path
       get admin_unit_unit_snapshots_path(@unit)


### PR DESCRIPTION
## Summary
- Unitのスナップショット一覧に「別ユニット」導線を追加し、既存の同一Unit内コピーとは別に、コピー先Unitを検索して選び任意のUnitへスナップショット（メンバー構成含む）をコピーできるようにした
- コピー先Unit検索は既存の `search_admin_units_path` を利用した単一選択オートコンプリート（`unit_select_controller.js`、`person_select_controller.js`と同型）で実装
- コントローラーのコピー本体ロジックを `copy_snapshot_to` に切り出し、既存の同一Unitコピー（`copy`）と新規の別Unitコピー（`copy_to_unit`）で共通化

## Test plan
- [x] `bin/rails test` が全件パスすること（211 runs, 717 assertions, 0 failures）
- [x] RuboCop がクリーンであること
- [ ] 管理画面でスナップショット一覧の「別ユニット」リンクから別Unitを検索・選択してコピーが実行され、メンバー構成も複製されることを目視確認

Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)