### PR TITLE
fix: スナップショットラベルを大文字強制せず登録どおりに表示

### DIFF
--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -7,7 +7,7 @@
             <%= snapshot.past? ? 'Related' : 'Members' %>
           </h2>
           <% if @show_label && snapshot.label.present? %>
-            <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= snapshot.label %></span>
+            <span class="text-xs font-black px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= snapshot.label %></span>
           <% end %>
           <% if snapshot.current? %>
             <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">Current</span>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -91,7 +91,7 @@
                   <span class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Members</span>
                 </h2>
                 <% if @snapshot.label.present? && @trend.snapshot_date.blank? %>
-                  <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= @snapshot.label %></span>
+                  <span class="text-xs font-black px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= @snapshot.label %></span>
                 <% end %>
                 <% if @snapshot.current? %>
                   <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">Current</span>


### PR DESCRIPTION
## Summary
- Members セクションのラベルバッジに `uppercase` クラスが付与されており、登録されたラベル文字列に関わらず英大文字表示になっていた問題を修正
- `unit_snapshots_component.html.erb`（プロフィールページ Members セクション）と `trends/show.html.erb`（トレンドページ）の同一パターンを両方修正

## Test plan
- [x] RuboCop / 既存テストスイート（pre-push フックで実行、211 tests all passed）
- [ ] 実際に小文字・混在ケースを含むラベルを持つスナップショットを表示し、登録どおりに表示されることを目視確認

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)