### PR TITLE
スナップショット管理画面の並び替え・表示状態を整理

### DIFF
--- a/app/controllers/admin/unit_snapshots_controller.rb
+++ b/app/controllers/admin/unit_snapshots_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def index
       @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person)
-                             .order(snapshot_date: :desc)
+                             .order(:snapshot_index)
     end
 
     def new

--- a/app/views/admin/unit_snapshots/index.html.erb
+++ b/app/views/admin/unit_snapshots/index.html.erb
@@ -19,6 +19,9 @@
           <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
             <thead class="bg-gray-50 dark:bg-gray-800">
               <tr>
+                <th scope="col" class="relative py-3.5 pl-4 pr-3 sm:pl-6 w-10">
+                  <span class="sr-only">並び替え</span>
+                </th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">ID</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">日付</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">ラベル</th>
@@ -30,9 +33,16 @@
                 </th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700">
+            <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700"
+                   data-controller="sortable"
+                   data-sortable-url-value="<%= reorder_admin_unit_unit_snapshots_path(@unit) %>">
               <% @unit_snapshots.each do |snapshot| %>
-                <tr>
+                <tr data-id="<%= snapshot.id %>">
+                  <td class="whitespace-nowrap px-3 py-4 text-sm font-medium text-gray-900 sm:pl-6 drag-handle cursor-move">
+                    <svg class="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                    </svg>
+                  </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
                     <%= snapshot.id %>
                   </td>

--- a/app/views/admin/units/_snapshots_list.html.erb
+++ b/app/views/admin/units/_snapshots_list.html.erb
@@ -13,27 +13,18 @@
       <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
         <thead class="bg-gray-50 dark:bg-gray-800">
           <tr>
-            <th scope="col" class="relative py-2 pl-4 pr-3 sm:pl-6 w-10">
-              <span class="sr-only">Sort</span>
-            </th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">ID</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Date</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Label</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Members</th>
             <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Current</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Status</th>
             <th scope="col" class="relative py-2 pl-3 pr-4 sm:pr-6"><span class="sr-only">Edit</span></th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700"
-               data-controller="sortable"
-               data-sortable-url-value="<%= reorder_admin_unit_unit_snapshots_path(unit) %>">
+        <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700">
           <% unit_snapshots.each do |snapshot| %>
-            <tr data-id="<%= snapshot.id %>">
-              <td class="whitespace-nowrap px-3 py-3 text-sm font-medium text-gray-900 sm:pl-6 drag-handle cursor-move">
-                <svg class="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-              </td>
+            <tr>
               <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400">
                 <%= snapshot.id %>
               </td>
@@ -49,6 +40,13 @@
               <td class="whitespace-nowrap px-3 py-3 text-sm">
                 <% if snapshot.current? %>
                   <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">Current</span>
+                <% end %>
+              </td>
+              <td class="whitespace-nowrap px-3 py-3 text-sm">
+                <% if snapshot.active? %>
+                  <span class="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">公開</span>
+                <% else %>
+                  <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-400">非公開</span>
                 <% end %>
               </td>
               <td class="relative whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">

--- a/test/controllers/admin/unit_snapshots_controller_test.rb
+++ b/test/controllers/admin/unit_snapshots_controller_test.rb
@@ -87,6 +87,18 @@ module Admin
       assert_redirected_to copy_to_unit_admin_unit_unit_snapshot_path(@unit, @snapshot)
     end
 
+    test 'should reorder unit_snapshots' do
+      other_snapshot = unit_snapshots(:two)
+
+      patch reorder_admin_unit_unit_snapshots_path(@unit), params: {
+        ids: [other_snapshot.id, @snapshot.id]
+      }, as: :json
+
+      assert_response :success
+      assert_equal 1, other_snapshot.reload.snapshot_index
+      assert_equal 2, @snapshot.reload.snapshot_index
+    end
+
     test 'should redirect to login when not authenticated' do
       delete logout_path
       get admin_unit_unit_snapshots_path(@unit)


### PR DESCRIPTION
## Summary
- `/admin/units/:unit_id/unit_snapshots` の一覧に並び替え機能を追加（既存の `reorder` アクション・`snapshot_index` カラムを活用）
- ユニット管理画面のスナップショット一覧から並び替え機能を削除し、代わりに表示状態（公開/非公開）を追加

## Test plan
- [x] `bundle exec rails test` が全件パスすること
- [ ] `/admin/units/:unit_id/unit_snapshots` でスナップショットをドラッグ&ドロップして並び替えできること
- [ ] ユニット管理画面のスナップショット一覧に並び替えUIが表示されず、公開/非公開バッジが表示されること

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)