### PR TITLE
fix: オムニバス作品の参加アーティストをメイン領域に表示

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -86,7 +86,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # 一度デコードして元の文字列に戻したうえで、<title>に必要な最小限（"&"と"<"）だけを
   # 再エスケープする。
   def page_title_text(text)
-    CGI.unescapeHTML(text.to_s).gsub('&', '&amp;').gsub('<', '&lt;').html_safe # rubocop:disable Rails/OutputSafety
+    CGI.unescapeHTML(text.to_s).gsub('&', '&amp;').gsub('<', '&lt;').html_safe
   end
 
   def markdown(text, sectionable: nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   class ExternalAwareHtmlRenderer < Redcarpet::Render::HTML
     def initialize(site_host:, **options)
@@ -74,6 +76,17 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
 
   def logged_in?
     false
+  end
+
+  # <title> はHTML5仕様上RCDATA要素で、タグとして解釈されるのは "&" と "<" のみ。
+  # content_for(:title, ...)にプレーン文字列を渡すとActionViewの内部バッファ格納時に
+  # 一度HTMLエスケープされる（例: "'" → "&#39;"）ため、そのまま出力すると
+  # デフォルトのHTMLエスケープ(h)で数値文字参照が二重化されたり、ブラウザ上は
+  # 正しく表示されるとはいえソースに不要な参照が残ったりする。
+  # 一度デコードして元の文字列に戻したうえで、<title>に必要な最小限（"&"と"<"）だけを
+  # 再エスケープする。
+  def page_title_text(text)
+    CGI.unescapeHTML(text.to_s).gsub('&', '&amp;').gsub('<', '&lt;').html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def markdown(text, sectionable: nil)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,19 +27,6 @@
         <% end %>
         <span><%= @item.title %></span>
       </h1>
-      <% if other_artists.any? %>
-        <div class="mt-2 flex flex-wrap items-center gap-1">
-          <% other_artists.each do |artist_data| %>
-            <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
-            <% artist_path = artist_profile_path(artist_data) %>
-            <% if artist_path %>
-              <%= link_to artist_label, artist_path, class: "px-2 py-0.5 rounded text-sm font-medium bg-white/60 text-zinc-800 hover:bg-white/80 transition-colors border border-white/40" %>
-            <% else %>
-              <span class="px-2 py-0.5 rounded text-sm font-medium bg-white/40 text-zinc-800 border border-white/30"><%= artist_label %></span>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
     </div>
 
     <div class="p-5 md:p-8">
@@ -136,6 +123,23 @@
           </div>
         </div>
       </div>
+
+      <% if other_artists.any? %>
+        <div class="mt-8 pt-6 border-t border-slate-100 dark:border-slate-700">
+          <h2 class="text-base font-bold text-slate-600 dark:text-slate-400 mb-4">参加アーティスト</h2>
+          <div class="flex flex-wrap gap-2">
+            <% other_artists.each do |artist_data| %>
+              <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
+              <% artist_path = artist_profile_path(artist_data) %>
+              <% if artist_path %>
+                <%= link_to artist_label, artist_path, class: "px-3 py-1 rounded text-sm font-bold bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/50 border border-amber-200 dark:border-amber-700 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500" %>
+              <% else %>
+                <span class="px-3 py-1 rounded text-sm font-bold bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 border border-zinc-200 dark:border-zinc-700"><%= artist_label %></span>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
       <div class="mt-8 pt-6 border-t border-slate-100 dark:border-slate-700">
         <%= link_to "Back to Items", items_path, class: "text-sm font-bold text-indigo-500 hover:text-indigo-600 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="motion-safe:scroll-smooth">
   <head>
-    <title><%= content_for?(:title) ? "#{yield(:title)} - #{Rails.application.config.site_name}" : Rails.application.config.site_name %></title>
+    <title><%= page_title_text(content_for?(:title) ? "#{yield(:title)} - #{Rails.application.config.site_name}" : Rails.application.config.site_name) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Vkdby">


### PR DESCRIPTION
## Summary
- オムニバス作品で参加アーティストが多いとヘッダーが肥大化する問題に対応し、ヘッダーからメイン領域の「参加アーティスト」セクションへ表示位置を変更
- あわせて、Titleタグでアポストロフィ等が不要に数値文字参照化（`&#39;`等）される問題を修正（`content_for(:title, ...)` が内部バッファ格納時に一度エスケープすることに起因）

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] 19アーティスト参加のサンプルデータでヘッダーが肥大化しないことを画面確認
- [x] `&` や `</title><script>` を含むタイトルでXSS対策（エスケープ）が効いていることを確認
- [x] アポストロフィ・引用符を含むタイトルでTitleタグに不要な数値文字参照が出ないことを確認

Closes #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)