### PR TITLE
fix: Itemカードのアーティスト名リンク先をItem一覧の絞り込みに変更

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -62,7 +62,7 @@
         <div class="flex flex-wrap gap-1 max-h-[5.5rem] overflow-hidden" data-controller="item-card-artists">
           <% @item.artists.each do |artist_data| %>
             <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
-            <% artist_path = artist_profile_path(artist_data) %>
+            <% artist_path = artist_items_path(artist_data) %>
             <% if artist_path %>
               <%= link_to artist_label, artist_path, class: "inline-block px-2 py-0.5 rounded text-sm font-semibold bg-indigo-50 text-indigo-600 hover:bg-indigo-100 dark:bg-indigo-900/50 dark:text-indigo-200 dark:hover:bg-indigo-900/70 transition-colors border border-indigo-200 dark:border-indigo-700" %>
             <% else %>

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -23,6 +23,16 @@ module ItemsHelper
     end
   end
 
+  # アーティストで絞り込んだItem#indexへのパスを生成
+  # 優先順位: key > old_key。どちらも無い(名前のみの)アーティストは絞り込み対象を一意に特定できないためリンクにしない
+  def artist_items_path(artist_data)
+    if artist_data['key'].present?
+      items_path(key: artist_data['key'])
+    elsif artist_data['old_key'].present?
+      items_path(old_key: artist_data['old_key'])
+    end
+  end
+
   # Tower Records OnlineのValueCommerceアフィリエイトトラッキング付き検索URL
   def tower_records_search_url(item)
     artist_names = item.artists.map { |a| a['name'] }.join(' ')

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -17,8 +17,31 @@
         <%= form_with url: items_path, method: :get, local: true, class: "flex gap-2" do |f| %>
           <%= hidden_field_tag :key, params[:key] if params[:key].present? %>
           <%= hidden_field_tag :old_key, params[:old_key] if params[:old_key].present? %>
-          <%= f.text_field :q, value: params[:q], placeholder: "商品名・アーティスト名で検索",
-              class: "w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-800 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-slate-400" %>
+          <% if @artist %>
+            <span class="shrink-0 inline-flex items-center gap-1 pl-3 pr-1 py-1 rounded-xl text-sm font-bold bg-indigo-50 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-200 border border-indigo-200 dark:border-indigo-700">
+              <%= @artist.name %>
+              <%= link_to items_path(q: params[:q].presence),
+                    class: "rounded-full p-0.5 hover:bg-indigo-100 dark:hover:bg-indigo-800 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-700",
+                    "aria-label": "「#{@artist.name}」の絞り込みを解除" do %>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+                  <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+                </svg>
+              <% end %>
+            </span>
+          <% end %>
+          <div class="relative flex-1 min-w-0">
+            <%= f.text_field :q, value: params[:q], placeholder: "商品名・アーティスト名で検索",
+                class: "w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 #{'pr-10' if params[:q].present?} text-slate-800 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all placeholder:text-slate-400" %>
+            <% if params[:q].present? %>
+              <%= link_to items_path(key: params[:key].presence, old_key: params[:old_key].presence),
+                    class: "absolute inset-y-0 right-2 flex items-center text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 rounded-full p-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-700",
+                    "aria-label": "検索語をクリア" do %>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+                  <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+                </svg>
+              <% end %>
+            <% end %>
+          </div>
           <%= f.button class: "bg-indigo-600 hover:bg-indigo-700 text-white p-3 rounded-xl transition-colors shadow-sm hover:shadow-md flex items-center justify-center min-w-[3rem]" do %>
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />

--- a/test/helpers/items_helper_test.rb
+++ b/test/helpers/items_helper_test.rb
@@ -16,4 +16,16 @@ class ItemsHelperTest < ActionView::TestCase
   test 'key も old_key も無い名前のみのアーティストはリンク先を持たない(nil)' do
     assert_nil artist_profile_path({ 'name' => '名前のみのアーティスト' })
   end
+
+  test 'key があればkeyで絞り込んだitems_pathを返す' do
+    assert_equal '/items?key=some-key', artist_items_path({ 'key' => 'some-key', 'old_key' => 'legacy', 'name' => '名前' })
+  end
+
+  test 'key が無く old_key があれば old_key で絞り込んだitems_pathを返す' do
+    assert_equal '/items?old_key=legacy', artist_items_path({ 'old_key' => 'legacy', 'name' => '名前' })
+  end
+
+  test 'key も old_key も無い名前のみのアーティストは絞り込みリンク先を持たない(nil)' do
+    assert_nil artist_items_path({ 'name' => '名前のみのアーティスト' })
+  end
 end


### PR DESCRIPTION
## Summary
- Item#indexなどのItemカードに表示するアーティスト名のリンク先を、プロフィールページから該当アーティストで絞り込んだItem#indexに変更（`items_helper.rb`に`artist_items_path`を追加）
- アーティスト絞り込み中は検索フォーム先頭にアーティスト名バッジを表示し、×ボタンで絞り込みのみ解除できるように（検索語は保持）
- 検索語入力中は入力欄右端に×ボタンを表示し、検索語のみクリアできるように（アーティスト絞り込みは保持）

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `rubocop` に違反がないこと
- [x] ローカルサーバーでItem#indexの絞り込みリンク・バッジの解除ボタン・検索語クリアボタンの表示と遷移を確認

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)