### PR TITLE
fix: Item#newページにパラメータ有りで遷移した時にアーティストを確定しないようにする

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -66,7 +66,9 @@ module Admin
     def build_artist_from_params
       return [] if params[:artist_name].blank?
 
-      [{ 'name' => params[:artist_name], 'key' => params[:artist_key], 'old_key' => params[:artist_old_key] }.compact_blank]
+      artist = { 'name' => params[:artist_name], 'key' => params[:artist_key], 'old_key' => params[:artist_old_key] }.compact_blank
+      artist['confirmed'] = false
+      [artist]
     end
 
     def build_artists_from_json(json)

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -51,7 +51,7 @@
     <%# Row container %>
     <div data-artist-rows-target="container" class="space-y-2">
       <% (item.artists || []).each do |artist| %>
-        <% search_mode = artist['name'].blank? %>
+        <% search_mode = artist['confirmed'] == false || artist['name'].blank? %>
         <div class="flex items-center gap-2" data-artist-rows-target="row" data-mode="unit">
           <span class="drag-handle flex-none px-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-grab" aria-hidden="true">⠿</span>
           <button type="button"

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -49,6 +49,17 @@ module Admin
       assert item.reload.various_artists?
     end
 
+    test 'new does not auto-confirm an artist passed via query params, even with an artist_key' do
+      get new_admin_item_path, params: {
+        artist_name: 'シド',
+        artist_key: 'shid'
+      }
+
+      assert_response :success
+      assert_match(/artist-search-input[^>]*value="シド"/, response.body)
+      assert_no_match(/artist-name-hidden[^>]*value="シド"/, response.body)
+    end
+
     test 'edit renders a previously saved name-only artist as a selected chip, not a blank search box' do
       item = Item.create!(
         title: 'Test Item',


### PR DESCRIPTION
## Summary
- `/admin/items/new` に `artist_name` クエリパラメータのみで遷移した際、`search_mode` の判定が `artist['name'].blank?` のみだったため、name があれば無条件に確定済みチップ表示になってしまっていた（`artist_key` の有無に関わらず自動確定）
- `new` アクションでクエリパラメータから組み立てるアーティストにのみ `confirmed: false` を付与し、常に検索入力状態（未確定）で表示するように修正
- 編集画面で name-only の確定済みアーティストをチップ表示する既存の挙動（#972）には影響しない

## Test plan
- [x] `bin/rails test` が全件パスすること（235 runs, 0 failures）
- [x] RuboCop パス
- [ ] 実際の管理画面で `/admin/items/new?artist_name=...&artist_key=...` を開き、Artists欄が確定チップではなく検索入力状態で表示されることを確認

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)