### PR TITLE
fix: 全角英数字での検索がヒットしない問題を修正

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -151,7 +151,7 @@ module Admin
       if q.present?
         scope = scope.where(
           'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',
-          q: "%#{q}%"
+          q: "%#{normalize_search_query(q)}%"
         )
       end
 

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -167,7 +167,7 @@ module Admin
       if q.present?
         scope = scope.where(
           'name ILIKE :q OR name_kana ILIKE :q OR key ILIKE :q OR name_log::text ILIKE :q OR aliases::text ILIKE :q',
-          q: "%#{q}%"
+          q: "%#{normalize_search_query(q)}%"
         )
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,6 +64,12 @@ class ApplicationController < ActionController::Base
     nil
   end
 
+  # 全角英数字（ＡＢＣ１２３など）で検索してもDB上の半角表記とマッチするよう、
+  # 検索クエリをNFKCで正規化する（全角→半角、半角カナ→全角カナなど）。
+  def normalize_search_query(query)
+    query.to_s.unicode_normalize(:nfkc)
+  end
+
   def valid_year?(year)
     year >= 1970 && year <= Date.today.year + 10
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -76,7 +76,7 @@ class ItemsController < ApplicationController
   def filter_by_query(scope)
     return scope if params[:q].blank?
 
-    scope.where('title ILIKE :q OR artists::text ILIKE :q', q: "%#{params[:q]}%")
+    scope.where('title ILIKE :q OR artists::text ILIKE :q', q: "%#{normalize_search_query(params[:q])}%")
   end
 
   def filter_by_decade(scope)

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,7 +12,7 @@ class PeopleController < ApplicationController
     if params[:q].present?
       scope = scope.where(
         'people.name ILIKE :q OR people.name_kana ILIKE :q OR people.name_log::text ILIKE :q OR people.aliases::text ILIKE :q OR people.old_history ILIKE :q',
-        q: "%#{params[:q]}%"
+        q: "%#{normalize_search_query(params[:q])}%"
       )
     end
     @selected_tag_ids = params[:tag_ids]&.to_unsafe_h&.transform_values(&:presence)&.compact || {}
@@ -26,7 +26,7 @@ class PeopleController < ApplicationController
   end
 
   def search
-    q = params[:q].to_s.strip.first(100)
+    q = normalize_search_query(params[:q].to_s.strip.first(100))
     if q.length < 2
       render json: []
       return

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,8 +5,9 @@ class SearchController < ApplicationController
     @query = params[:q]
 
     if @query.present?
-      search_pattern = "%#{@query}%"
-      exact_pattern = ActiveRecord::Base.sanitize_sql_like(@query)
+      normalized_query = normalize_search_query(@query)
+      search_pattern = "%#{normalized_query}%"
+      exact_pattern = ActiveRecord::Base.sanitize_sql_like(normalized_query)
       relevance_order = Arel.sql(
         "CASE WHEN name ILIKE #{Unit.connection.quote(exact_pattern)} THEN 0 " \
         "WHEN name ILIKE #{Unit.connection.quote("#{exact_pattern}%")} THEN 1 " \

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -12,7 +12,7 @@ class UnitsController < ApplicationController
     if params[:q].present?
       scope = scope.where(
         'units.name ILIKE :q OR units.name_kana ILIKE :q OR units.name_log::text ILIKE :q OR units.aliases::text ILIKE :q',
-        q: "%#{params[:q]}%"
+        q: "%#{normalize_search_query(params[:q])}%"
       )
     end
     @selected_tag_ids = params[:tag_ids]&.to_unsafe_h&.transform_values(&:presence)&.compact || {}
@@ -27,7 +27,7 @@ class UnitsController < ApplicationController
   end
 
   def search
-    q = params[:q].to_s.strip.first(100)
+    q = normalize_search_query(params[:q].to_s.strip.first(100))
     if q.length < 2
       render json: []
       return

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -9,6 +9,15 @@ module Admin
       @person = Person.create!(name: 'Existing Person', key: 'existing-person-controller-test', status: :active)
     end
 
+    test 'search finds a person whose name is half-width when queried with full-width alphanumerics' do
+      Person.create!(name: 'ABC123', key: 'zenkaku-search-admin-people-test', status: :active)
+
+      get search_admin_people_path(q: 'ＡＢＣ１２３')
+
+      assert_response :success
+      assert_includes response.parsed_body.pluck('name'), 'ABC123'
+    end
+
     test 'create allows setting key' do
       assert_difference('Person.count') do
         post admin_people_path, params: {

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -9,6 +9,15 @@ module Admin
       @unit = Unit.create!(name: 'Existing Unit', key: 'existing-unit-controller-test', status: :active)
     end
 
+    test 'search finds a unit whose name is half-width when queried with full-width alphanumerics' do
+      Unit.create!(name: 'ABC123', key: 'zenkaku-search-admin-units-test', status: :active)
+
+      get search_admin_units_path(q: 'ＡＢＣ１２３')
+
+      assert_response :success
+      assert_includes response.parsed_body.pluck('name'), 'ABC123'
+    end
+
     test 'update does not change key even when key param is submitted' do
       patch admin_unit_path(@unit), params: {
         unit: { name: 'Renamed Unit', key: 'attempted-new-key' }

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -40,6 +40,19 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Me
     assert_not_includes response.body, 'Item Two'
   end
 
+  test 'index filters by title with full-width alphanumeric q param' do
+    item = Item.create!(
+      title: 'ABC123',
+      release_date: '2026-03-01',
+      link_url: "http://example.com/zenkaku-search-item-#{SecureRandom.hex(4)}"
+    )
+
+    get items_path(q: 'ＡＢＣ１２３')
+
+    assert_response :success
+    assert_includes response.body, item.title
+  end
+
   test 'show hides non-omnibus artists from the header when various_artists is true' do
     item = Item.create!(
       title: 'VA Compilation',

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PeopleControllerTest < ActionDispatch::IntegrationTest
+  test 'index finds a person whose name is half-width when queried with full-width alphanumerics' do
+    Person.create!(name: 'ABC123', key: 'zenkaku-search-people-index-test', status: :active)
+
+    get people_path(q: 'ＡＢＣ１２３')
+
+    assert_response :success
+    assert_includes response.body, 'ABC123'
+  end
+
+  test 'search finds a person whose name is half-width when queried with full-width alphanumerics' do
+    Person.create!(name: 'ABC123', key: 'zenkaku-search-people-autocomplete-test', status: :active)
+
+    get search_people_path(q: 'ＡＢＣ１２３')
+
+    assert_response :success
+    assert_includes response.parsed_body.pluck('name'), 'ABC123'
+  end
+end

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SearchControllerTest < ActionDispatch::IntegrationTest
+  test 'index finds a unit whose name is half-width when queried with full-width alphanumerics' do
+    Unit.create!(name: 'ABC123', key: 'zenkaku-search-unit-test', status: :active)
+
+    get search_path(q: 'ＡＢＣ１２３')
+
+    assert_response :success
+    assert_includes response.body, 'ABC123'
+  end
+
+  test 'index finds a person whose name is half-width when queried with full-width alphanumerics' do
+    Person.create!(name: 'XYZ789', key: 'zenkaku-search-person-test', status: :active)
+
+    get search_path(q: 'ＸＹＺ７８９')
+
+    assert_response :success
+    assert_includes response.body, 'XYZ789'
+  end
+end

--- a/test/controllers/units_controller_test.rb
+++ b/test/controllers/units_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UnitsControllerTest < ActionDispatch::IntegrationTest
+  test 'index finds a unit whose name is half-width when queried with full-width alphanumerics' do
+    Unit.create!(name: 'ABC123', key: 'zenkaku-search-units-index-test', status: :active)
+
+    get units_path(q: 'ＡＢＣ１２３')
+
+    assert_response :success
+    assert_includes response.body, 'ABC123'
+  end
+
+  test 'search finds a unit whose name is half-width when queried with full-width alphanumerics' do
+    Unit.create!(name: 'ABC123', key: 'zenkaku-search-units-autocomplete-test', status: :active)
+
+    get search_units_path(q: 'ＡＢＣ１２３')
+
+    assert_response :success
+    assert_includes response.parsed_body.pluck('name'), 'ABC123'
+  end
+end


### PR DESCRIPTION
## Summary
- 検索クエリを NFKC で正規化し、全角英数字（ＡＢＣ１２３など）で検索してもDB上の半角表記データがヒットするよう修正
- SearchController、People/UnitsController の index/search、ItemsController の検索に適用
- Admin::People/UnitsController の search（Item#new のアーティストサジェスト機能）にも同様に適用

## Test plan
- [x] `bundle exec rails test` が全件パスすること
- [x] `bundle exec rubocop` で違反なし
- [x] 全角英数字クエリで半角登録済みのUnit/Person/Itemがヒットする回帰テストを追加

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)