### PR TITLE
経歴・メンバー・Links・Trendsのリンクをホバー前から視認できるように改善

### DIFF
--- a/app/components/history_row_component.html.erb
+++ b/app/components/history_row_component.html.erb
@@ -5,9 +5,16 @@
     <% end %>
     <span class="font-bold text-slate-600 dark:text-slate-300">
         <% if item[:external_url].present? %>
-          <%= link_to helpers.sanitize_with_ruby(item[:unit_name]), item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
+          <%= link_to item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "inline-flex items-center gap-0.5 text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" do %>
+            <%= helpers.sanitize_with_ruby(item[:unit_name]) %>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 flex-shrink-0" aria-hidden="true">
+              <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+              <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+            </svg>
+            <span class="sr-only">(外部サイト)</span>
+          <% end %>
         <% elsif item[:old_key].present? %>
-          <%= link_to helpers.sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
+          <%= link_to helpers.sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
         <% else %>
           <% if item[:is_temp] %>
             <span class="text-slate-400 dark:text-slate-500"><%= helpers.sanitize_with_ruby(item[:unit_name]) %></span>

--- a/app/components/links_component.html.erb
+++ b/app/components/links_component.html.erb
@@ -5,7 +5,13 @@
       <li>
         <%= link_to link.url, target: "_blank", rel: "noopener", class: "group block p-4 bg-slate-50 dark:bg-slate-900/50 border border-slate-100 dark:border-slate-700 rounded-xl hover:border-unit hover:scale-[1.02] transition-all relative pr-10" do %>
           <span class="text-sm font-bold text-slate-800 dark:text-slate-200 group-hover:text-unit break-all"><%= link.display_text %></span>
-          <span class="absolute right-4 top-1/2 -translate-y-1/2 opacity-30 group-hover:opacity-100 group-hover:translate-x-1 transition-all text-unit">→</span>
+          <span class="absolute right-4 top-1/2 -translate-y-1/2 opacity-30 group-hover:opacity-100 group-hover:translate-x-1 transition-all text-unit">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4" aria-hidden="true">
+              <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+              <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+            </svg>
+            <span class="sr-only">(外部サイト)</span>
+          </span>
         <% end %>
       </li>
     <% end %>

--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -8,7 +8,7 @@
         <h3 class="text-base md:text-lg font-black text-slate-800 dark:text-slate-100">
 
           <% if @member.person && @member.person.key.present? %>
-            <%= link_to @member.name, profile_path(@member.person.key), class: "hover:text-person transition-colors" %>
+            <%= link_to @member.name, profile_path(@member.person.key), class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
           <% else %>
 
             <%= @member.name %>

--- a/app/components/trend_list_row_component.html.erb
+++ b/app/components/trend_list_row_component.html.erb
@@ -14,13 +14,13 @@
   </div>
 <% else %>
   <%= link_to trend_path(@trend), class: "flex items-start gap-3 text-sm group" do %>
-    <div class="shrink-0 w-24 text-slate-600 dark:text-slate-400 font-mono text-sm pt-0.5 font-bold group-hover:text-indigo-500 transition-colors">
+    <div class="shrink-0 w-24 text-indigo-600 dark:text-indigo-400 font-mono text-sm pt-0.5 font-bold group-hover:text-indigo-500 transition-colors">
       <%= @trend.date.strftime('%Y/%m/%d') %>
     </div>
     <div class="grow">
-      <p class="font-bold text-slate-700 dark:text-slate-200 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
+      <p class="font-bold text-indigo-700 dark:text-indigo-300 underline decoration-indigo-600/25 dark:decoration-indigo-400/40 underline-offset-2 group-hover:decoration-indigo-600 dark:group-hover:decoration-indigo-400 transition-colors">
         <% unit_badges.each do |name| %>
-          <span class="px-1.5 py-0.5 rounded text-[11px] align-middle bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400"><%= name %></span>
+          <span class="px-1.5 py-0.5 rounded text-[11px] align-middle bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 no-underline"><%= name %></span>
         <% end %>
         <%= format_wiki_title(@trend.title, link: false) %>
       </p>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -114,9 +114,16 @@
                                   <%= sanitize_with_ruby(item[:unit_name]) %>
                                 </span>
                               <% elsif item[:external_url].present? %>
-                                <%= link_to sanitize_with_ruby(item[:unit_name]), item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "hover:text-unit transition-colors" %>
+                                <%= link_to item[:external_url], target: '_blank', rel: 'noopener noreferrer', class: "inline-flex items-center gap-0.5 text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" do %>
+                                  <%= sanitize_with_ruby(item[:unit_name]) %>
+                                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3 flex-shrink-0" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                                    <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                                  </svg>
+                                  <span class="sr-only">(外部サイト)</span>
+                                <% end %>
                               <% elsif item[:old_key].present? %>
-                                <%= link_to sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "hover:text-unit transition-colors" %>
+                                <%= link_to sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
                               <% else %>
                                 <%= sanitize_with_ruby(item[:unit_name]) %>
                               <% end %>


### PR DESCRIPTION
## Summary
- 個人ページ/ユニットページの経歴表示で、リンクありのバンド名とリンクなしのバンド名が同じスタイルで区別できなかったため、リンクに色+下線を常時付与
- 経歴の外部リンクには内部リンクとの区別として外部サイトアイコンを追加（`profiles/show.html.erb`, `history_row_component`）
- ユニットページのメンバー名→個人ページリンクも同様に色+下線を常時付与（`member_row_component`）
- Links セクションの矢印アイコンを、経歴で使用している外部リンクアイコンに統一（`links_component`）
- Trends セクションのリンク行も indigo色+下線を常時付与（`trend_list_row_component`）

## Test plan
- [x] `bin/rails test` が全件パスすること（244 runs, 0 failures）
- [x] RuboCop パス
- [x] 個人ページ・ユニットページで、リンクあり/なしのバンド名・メンバー名が常時見分けられることを目視確認
- [x] 外部リンク（例: `/urara-0727`）にアイコンが表示されることを目視確認
- [x] ダークモードでも文字色・下線が視認しやすいことを確認

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)