### PR TITLE
feat: 管理画面の人物サジェストに経歴情報を表示

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -158,11 +158,33 @@ module Admin
       @people = scope.limit(10).order(:name)
 
       render json: @people.map { |p|
-        { id: p.id, name: p.name.presence || p.key, name_kana: p.name_kana, key: p.key, destination_key: p.destination_key }
+        {
+          id: p.id,
+          name: p.name.presence || p.key,
+          name_kana: p.name_kana,
+          key: p.key,
+          destination_key: p.destination_key,
+          history_summary: person_history_summary(p)
+        }
       }
     end
 
     private
+
+    def person_history_summary(person)
+      # 末尾が「{{category ...}}」等のステータスタグのみの場合 unit_name が空になるため、
+      # unit_name を持つ項目が含まれる直近の履歴グループまで遡る
+      recent_history = person.parse_old_history.reverse.find { |group| group.any? { |item| item[:unit_name].present? } }
+      return nil if recent_history.blank?
+
+      recent_history.filter_map do |item|
+        next if item[:unit_name].blank?
+
+        text = helpers.strip_tags(item[:unit_name].to_s)
+        text += "(#{helpers.strip_tags(item[:part_and_name])})" if item[:part_and_name].present?
+        text
+      end.join('、')
+    end
 
     def set_person
       @person = Person.with_discarded.find(params[:id])

--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -218,6 +218,7 @@ export default class extends Controller {
            data-destination-key="${this.escapeHtml(item.destination_key || "")}">
         <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
         ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ""}
+        ${item.history_summary ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.history_summary)}</div>` : ""}
         ${item.destination_key ? `<div class="text-xs text-amber-600 dark:text-amber-400">→ ${this.escapeHtml(item.destination_key)}</div>` : ""}
       </div>
     `).join("") + freeTextHtml

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -153,6 +153,7 @@ export default class extends Controller {
              data-key="${this.escapeHtml(item.key || '')}">
           <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
           ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ''}
+          ${item.history_summary ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.history_summary)}</div>` : ''}
         </div>
       `).join('')
 

--- a/app/javascript/controllers/person_select_controller.js
+++ b/app/javascript/controllers/person_select_controller.js
@@ -113,6 +113,7 @@ export default class extends Controller {
            data-name="${this.escapeHtml(item.name)}">
         <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
         ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ''}
+        ${item.history_summary ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.history_summary)}</div>` : ''}
       </div>
     `).join('')
 

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -18,6 +18,32 @@ module Admin
       assert_includes response.parsed_body.pluck('name'), 'ABC123'
     end
 
+    test 'search includes a history summary to distinguish same-named people' do
+      Person.create!(
+        name: '同名太郎', key: 'history-summary-search-test', status: :active,
+        old_history: '[[サンプルユニット]](Vocal)'
+      )
+
+      get search_admin_people_path(q: '同名太郎')
+
+      assert_response :success
+      result = response.parsed_body.find { |p| p['key'] == 'history-summary-search-test' }
+      assert_equal 'サンプルユニット(Vocal)', result['history_summary']
+    end
+
+    test 'search history summary skips a trailing status-only tag with no unit name' do
+      Person.create!(
+        name: '状況不明太郎', key: 'history-summary-status-tag-test', status: :active,
+        old_history: '[[サンプルユニット]](Vocal) → {{category 個人/状況不明}}'
+      )
+
+      get search_admin_people_path(q: '状況不明太郎')
+
+      assert_response :success
+      result = response.parsed_body.find { |p| p['key'] == 'history-summary-status-tag-test' }
+      assert_equal 'サンプルユニット(Vocal)', result['history_summary']
+    end
+
     test 'create allows setting key' do
       assert_difference('Person.count') do
         post admin_people_path, params: {


### PR DESCRIPTION
## Summary
- 管理画面の人物サジェスト（Items/Trends/SnapshotPeopleフォーム）で同名の人物を区別できるよう、直近の経歴要約（history_summary）を検索結果に表示
- `Admin::PeopleController#search` のJSONレスポンスに `history_summary` を追加（People#indexカードと同じ `parse_old_history` を再利用）
- 経歴の末尾が `{{category ...}}` のようなステータスタグのみで unit_name が空になるケースで経歴が空表示になるバグを修正し、実際にユニット名を持つ直近の履歴グループまで遡るように変更

## Test plan
- [x] `bin/rails test test/controllers/admin/people_controller_test.rb` が全件パスすること
- [x] `bundle exec rubocop` がクリーンであること
- [x] 実データ（dev DB）で `Admin::PeopleController#search` のレスポンスに正しい経歴要約が含まれることを確認

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)