### PR TITLE
一覧のAmazon購入ボタンをマウスオーバー時に半透明にして書影を見えるように

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -18,7 +18,7 @@
         <% end %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer",
             style: "position:absolute; bottom:8px; left:50%; transform:translateX(-50%);",
-            class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-500 hover:bg-amber-600 text-black font-bold rounded-lg transition text-xs whitespace-nowrap z-10 sm:opacity-0 sm:group-hover:opacity-100" do %>
+            class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-500 hover:bg-amber-600 hover:opacity-50! text-black font-bold rounded-lg transition text-xs whitespace-nowrap z-10 sm:opacity-0 sm:group-hover:opacity-100" do %>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-3.5 h-3.5 shrink-0">
             <path d="M2.25 2.25a.75.75 0 0 0 0 1.5h1.386c.17 0 .318.114.362.278l2.558 9.592a3.752 3.752 0 0 0-2.806 3.63c0 .414.336.75.75.75h15.75a.75.75 0 0 0 0-1.5H5.378A2.25 2.25 0 0 1 7.5 15h11.218a.75.75 0 0 0 .674-.421 60.358 60.358 0 0 0 2.96-7.228.75.75 0 0 0-.525-.965A60.864 60.864 0 0 0 5.68 4.509l-.232-.867A1.875 1.875 0 0 0 3.636 2.25H2.25ZM3.75 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0ZM16.5 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Z" />
           </svg>


### PR DESCRIPTION
## Summary
- 一覧カードの「Amazonで購入」ボタンをマウスオーバーした際、ボタンの不透明度を50%に下げ、背後の書影画像が透けて見えるようにした

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] 一覧画面でボタンにマウスを乗せ、半透明になり書影が見えることを目視確認

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)