### PR TITLE
商品カードのグラデーション統一・クリック領域拡大・ホバー挙動を改善

### DIFF
--- a/app/components/item_card_component.html.erb
+++ b/app/components/item_card_component.html.erb
@@ -31,9 +31,13 @@
       <% end %>
     </div>
   <% else %>
-    <div class="relative shrink-0 w-40 h-40 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center">
-      <span class="text-zinc-400 dark:text-zinc-500 text-sm">画像なし</span>
+    <div class="relative shrink-0 w-40 h-40 bg-zinc-100 dark:bg-zinc-800">
       <% if @item.link_url.present? %>
+        <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer",
+            "aria-label": "#{@item.title} をAmazonで購入",
+            class: "absolute inset-0 flex items-center justify-center hover:opacity-90 transition-opacity" do %>
+          <span class="text-zinc-400 dark:text-zinc-500 text-sm">画像なし</span>
+        <% end %>
         <%= link_to @item.link_url, target: "_blank", rel: "noopener noreferrer",
             style: "position:absolute; bottom:8px; left:50%; transform:translateX(-50%);",
             class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-500 hover:bg-amber-600 text-black font-bold rounded-lg transition text-xs whitespace-nowrap z-10 sm:opacity-0 sm:group-hover:opacity-100" do %>
@@ -42,24 +46,30 @@
           </svg>
           Amazonで購入
         <% end %>
+      <% else %>
+        <div class="w-40 h-40 flex items-center justify-center">
+          <span class="text-zinc-400 dark:text-zinc-500 text-sm">画像なし</span>
+        </div>
       <% end %>
     </div>
   <% end %>
 
-  <!-- 情報（右側） -->
-  <div class="flex-1 px-4 py-2 min-w-0 flex flex-col">
-    <!-- タイトル + アーティスト（上部、残りスペースを占有） -->
-    <div class="flex-1 flex flex-col gap-2">
+  <!-- 情報（右側。全体をitem#showへのリンクにし、アーティストタグだけ上に重ねてクリック可能にする） -->
+  <div class="relative flex-1 px-4 py-2 min-w-0 flex flex-col" data-controller="item-card-artists">
+    <%# タイトル下のoverflow-hiddenラッパーに阻まれず領域全体を覆うため、専用のリンクを重ねる（実体のリンクはタイトルの方） %>
+    <%= link_to "", item_path(@item), class: "absolute inset-0", "aria-hidden": "true", tabindex: "-1" %>
+    <!-- タイトル + アーティスト（合わせて5行相当の高さに制限し、実際の溢れをJSで検知してフェードアウトさせる） -->
+    <div class="max-h-[7rem] flex flex-col gap-2 overflow-hidden" data-item-card-artists-target="content">
       <!-- タイトル -->
-      <div>
+      <div class="relative z-10">
         <%= link_to item_path(@item), class: "block" do %>
-          <h3 class="font-bold text-zinc-900 dark:text-zinc-100 hover:text-amber-600 dark:hover:text-amber-400 transition-colors overflow-hidden" style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;"><%= @item.title %></h3>
+          <h3 class="font-bold text-zinc-900 dark:text-zinc-100 hover:text-amber-600 dark:hover:text-amber-400 transition-colors"><%= @item.title %></h3>
         <% end %>
       </div>
 
-      <!-- アーティスト（3行を超えて折り返した場合のみ、実際の溢れをJSで検知してフェードアウトさせる） -->
+      <!-- アーティスト -->
       <% if @item.artists.present? %>
-        <div class="flex flex-wrap gap-1 max-h-[5.5rem] overflow-hidden" data-controller="item-card-artists">
+        <div class="relative z-10 flex flex-wrap gap-1">
           <% @item.artists.each do |artist_data| %>
             <% artist_label = artist_data['alias'].presence || artist_data['name'] %>
             <% artist_path = artist_items_path(artist_data) %>
@@ -73,10 +83,10 @@
       <% end %>
     </div>
 
-    <!-- 発売日（下部固定） -->
-    <div class="pt-2">
-      <span class="text-zinc-400 dark:text-zinc-500 font-mono text-sm font-bold">
-        <%= @item.release_date.strftime('%Y/%m/%d') %> 発売
+    <!-- 発売日（下部固定。フェードアウト時のみJSでpt-2からpt-1に詰める） -->
+    <div class="pt-2" data-item-card-artists-target="date">
+      <span class="text-zinc-500 dark:text-zinc-400 font-mono text-sm font-bold">
+        <%= @item.release_date.strftime('%Y/%m/%d') %> <%= @item.release_date.future? ? '発売予定' : '発売' %>
       </span>
     </div>
   </div>

--- a/app/javascript/controllers/item_card_artists_controller.js
+++ b/app/javascript/controllers/item_card_artists_controller.js
@@ -1,17 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
-// 参加アーティストのタグが3行を超えて折り返された場合のみ、下端をフェードアウトさせる。
-// アーティスト数ではなく実際の折り返し行数（バンド名の長さで変わる）で判定するため、
-// レイアウト後にscrollHeightで溢れを検知してからマスクを適用する。
+// 商品名とアーティストタグを合わせた表示領域が、カードの高さに収まりきらない場合のみ
+// 下端をフェードアウトさせる。商品名の長さによってグラデーションの位置がばらつかないよう、
+// 商品名単独・アーティスト単独ではなく両者をまとめたコンテナの溢れをレイアウト後に
+// scrollHeightで検知してからマスクを適用する。
+// フェードアウトが発生する場合のみ、発売日との余白も詰める（フェードなしの場合は詰めない）。
 const FADE_MASK_CLASSES = [
     "[mask-image:linear-gradient(to_bottom,black_63%,transparent_100%)]",
     "[-webkit-mask-image:linear-gradient(to_bottom,black_63%,transparent_100%)]",
 ]
 
 export default class extends Controller {
+    static targets = ["content", "date"]
+
     connect() {
-        if (this.element.scrollHeight > this.element.clientHeight) {
-            this.element.classList.add(...FADE_MASK_CLASSES)
+        if (this.contentTarget.scrollHeight > this.contentTarget.clientHeight) {
+            this.contentTarget.classList.add(...FADE_MASK_CLASSES)
+            this.dateTarget.classList.replace("pt-2", "pt-1")
         }
     }
 }


### PR DESCRIPTION
## Summary
- 商品名+アーティストタグを合わせて5行相当に統一し、商品名の長さに関わらずフェード（グラデーション）位置が揃うように修正
- 画像なし商品でも、画像領域からAmazonへ遷移できるように修正
- カード右側（画像以外）の領域全体をitem#showへのリンクにし、アーティストタグは従来通り個別のアーティスト絞り込みリンクを維持
- マウスオーバー時に商品名が常にハイライトされるよう修正（透明なストレッチリンクがタイトルより上のレイヤーに来ていた問題を解消）
- 発売日が未到達の場合は「発売予定」と表示
- 発売日の文字色のコントラストを改善（アクセシビリティ対応）

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] headless Chromeで商品一覧ページをスクリーンショット確認（グラデーション位置の統一、カード高さの統一、クリック領域、ホバー挙動）
- [ ] 実ブラウザでの最終目視確認

Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)