### PR TITLE
Itemアーティスト一括変更に「未紐付けのみ選択」ショートカットを追加

### DIFF
--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -4,12 +4,7 @@
       <tr>
         <% if @show_bulk_artist_ui %>
           <th class="px-4 py-3">
-            <div class="flex flex-col items-start gap-1">
-              <input type="checkbox" id="check_all" class="rounded border-gray-300" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
-              <button type="button" onclick="selectUnlinkedArtistsOnly()"
-                      title="Unit/Personに未紐付けの項目だけを選択します"
-                      class="text-xs text-indigo-600 hover:underline whitespace-nowrap">未紐付けのみ</button>
-            </div>
+            <input type="checkbox" id="check_all" class="rounded border-gray-300" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
           </th>
         <% end %>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>

--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -4,7 +4,12 @@
       <tr>
         <% if @show_bulk_artist_ui %>
           <th class="px-4 py-3">
-            <input type="checkbox" id="check_all" class="rounded border-gray-300" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
+            <div class="flex flex-col items-start gap-1">
+              <input type="checkbox" id="check_all" class="rounded border-gray-300" onclick="document.querySelectorAll('.row-check').forEach(c => c.checked = this.checked)" aria-label="すべて選択">
+              <button type="button" onclick="selectUnlinkedArtistsOnly()"
+                      title="Unit/Personに未紐付けの項目だけを選択します"
+                      class="text-xs text-indigo-600 hover:underline whitespace-nowrap">未紐付けのみ</button>
+            </div>
           </th>
         <% end %>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Title</th>
@@ -20,8 +25,10 @@
       <% @items.each do |item| %>
         <tr>
           <% if @show_bulk_artist_ui %>
+            <% matched_and_unlinked = (item.artists || []).any? { |a| a[@match_type].to_s == @match_value && a['key'].blank? } %>
             <td class="px-4 py-4">
-              <%= check_box_tag "ids[]", item.id, false, id: "item_#{item.id}", class: "row-check rounded border-gray-300", aria: { label: "#{item.title} を選択" } %>
+              <%= check_box_tag "ids[]", item.id, false, id: "item_#{item.id}", class: "row-check rounded border-gray-300",
+                    data: { unlinked: matched_and_unlinked }, aria: { label: "#{item.title} を選択" } %>
             </td>
           <% end %>
           <td class="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -51,6 +51,12 @@
       <%= hidden_field_tag :match_type, @match_type %>
       <%= hidden_field_tag :match_value, @match_value %>
 
+      <div class="mb-2">
+        <button type="button" onclick="selectUnlinkedArtistsOnly()"
+                title="Unit/Personに未紐付けの項目だけを選択します"
+                class="text-sm text-indigo-600 hover:underline">未紐付けのみ選択</button>
+      </div>
+
       <%= render "items_table" %>
       <%= render "artist_replacement_picker" %>
 

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -69,6 +69,13 @@
         }
         return confirm('選択した ' + checked.length + ' 件のアーティストを一括で差し替えます。よろしいですか？');
       }
+
+      function selectUnlinkedArtistsOnly() {
+        document.querySelectorAll('.row-check').forEach(function(c) {
+          c.checked = c.dataset.unlinked === 'true';
+        });
+        document.getElementById('check_all').checked = false;
+      }
     </script>
   <% else %>
     <%= render "items_table" %>

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -102,6 +102,22 @@ module Admin
       assert_includes response.body, 'function confirmBulkArtistUpdate()'
     end
 
+    test 'index marks the checkbox as unlinked only when the matching artist entry has no key' do
+      unlinked = Item.create!(title: 'Unlinked Item', release_date: Date.today,
+                              link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                              artists: [{ 'name' => 'ムック', 'old_key' => '%A5%E0%A5%C3%A5%AF' }])
+      linked = Item.create!(title: 'Linked Item', release_date: Date.today,
+                            link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                            artists: [{ 'name' => 'ムック', 'key' => 'mucc', 'old_key' => '%A5%E0%A5%C3%A5%AF' }])
+
+      get admin_items_path(match_type: 'old_key', match_value: '%A5%E0%A5%C3%A5%AF')
+
+      assert_response :success
+      assert_includes response.body, "id=\"item_#{unlinked.id}\" value=\"#{unlinked.id}\" class=\"row-check rounded border-gray-300\" data-unlinked=\"true\""
+      assert_includes response.body, "id=\"item_#{linked.id}\" value=\"#{linked.id}\" class=\"row-check rounded border-gray-300\" data-unlinked=\"false\""
+      assert_includes response.body, 'function selectUnlinkedArtistsOnly()'
+    end
+
     test 'index lists only items whose artists match the given alias (display name)' do
       matching = Item.create!(title: 'Matching Item', release_date: Date.today,
                               link_url: "https://example.com/item-#{SecureRandom.hex(4)}",


### PR DESCRIPTION
## Summary
- Item のアーティスト一括変更画面に、検索条件に一致しつつ Unit/Person に未紐付け（`key` が無い）の項目だけをワンクリックで選択できる「未紐付けのみ選択」ボタンを追加
- 各行のチェックボックスに `data-unlinked` 属性を持たせ、JS側でその属性を見て選択状態を切り替え
- ボタンはチェックボックス列のセル幅を広げないよう、テーブル直上の独立したツールバーに配置

## Test plan
- [x] `bin/rails test` が全件パスすること（268 runs, 900 assertions, 0 failures）
- [x] `bundle exec rubocop` で指摘なし（309 files inspected, no offenses detected）
- [ ] Item 一覧でアーティスト検索後、「未紐付けのみ選択」を押すと未紐付けの項目だけが選択されることを確認
- [ ] ボタンがテーブルの外に表示され、チェックボックス列の幅が広がっていないことを確認

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)