### PR TITLE
[管理画面] アーティスト検索結果でname/alias/key/old_keyを個別表示し、key/old_keyをリンク化

### DIFF
--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -27,23 +27,48 @@
             </td>
           <% end %>
           <td class="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
-            <%= link_to item.title, item_path(item), class: "text-indigo-600 hover:text-indigo-900" %>
+            <%= link_to item.title, item_path(item), class: "text-indigo-600 hover:text-indigo-900 max-w-xs line-clamp-2 block" %>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= item.release_date %></td>
           <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
             <% if @show_bulk_artist_ui %>
-              <% (item.artists || []).each do |a| %>
+              <% (item.artists || []).each_with_index do |a, i| %>
                 <% matched = a[@match_type].to_s == @match_value %>
-                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs mr-1 mb-1 <%= matched ? 'bg-amber-100 text-amber-800 ring-1 ring-amber-400 dark:bg-amber-900 dark:text-amber-200' : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' %>">
-                  <%= a['name'] %><% if a['alias'].present? %>（<%= a['alias'] %>）<% end %><% if a['key'].blank? %> (未紐付け)<% end %>
-                </span>
+                <div class="text-xs space-y-0.5 <%= 'mt-2 pt-2 border-t border-gray-100 dark:border-gray-700' if i.positive? %>">
+                  <div>
+                    <span class="inline-block w-14 text-gray-400 dark:text-gray-500 uppercase tracking-wide">name</span>
+                    <span class="font-medium <%= matched ? 'text-amber-800 dark:text-amber-300' : 'text-gray-900 dark:text-gray-100' %>"><%= a['name'].presence || '—' %></span>
+                  </div>
+                  <% if a['alias'].present? %>
+                    <div>
+                      <span class="inline-block w-14 text-gray-400 dark:text-gray-500 uppercase tracking-wide">alias</span>
+                      <span class="font-medium <%= 'text-amber-800 dark:text-amber-300' if matched %>"><%= a['alias'] %></span>
+                    </div>
+                  <% end %>
+                  <div>
+                    <span class="inline-block w-14 text-gray-400 dark:text-gray-500 uppercase tracking-wide">key</span>
+                    <% if a['key'].present? %>
+                      <%= link_to a['key'], profile_path(a['key']), target: "_blank", rel: "noopener", class: "font-medium text-indigo-600 hover:underline" %>
+                    <% else %>
+                      <span class="font-medium text-gray-400 dark:text-gray-500">—</span>
+                    <% end %>
+                  </div>
+                  <div>
+                    <span class="inline-block w-14 text-gray-400 dark:text-gray-500 uppercase tracking-wide">old_key</span>
+                    <% if a['old_key'].present? %>
+                      <%= link_to a['old_key'], "#{Rails.application.config.old_key_url_base}/#{a['old_key']}.html", target: "_blank", rel: "noopener", class: "font-medium text-indigo-600 hover:underline" %>
+                    <% else %>
+                      <span class="font-medium text-gray-400 dark:text-gray-500">—</span>
+                    <% end %>
+                  </div>
+                </div>
               <% end %>
             <% else %>
               <%= item.artists.map { |a| a['alias'].present? ? "#{a['name']}（#{a['alias']}）" : a['name'] }.join(', ') %>
             <% end %>
           </td>
           <% unless @show_bulk_artist_ui %>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= item.asin %></td>
+            <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 break-words"><%= item.asin %></td>
           <% end %>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
             <% if current_user.super_operator_or_above? %>

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -144,15 +144,43 @@ module Admin
       assert_includes response.body, 'ムック（MUCC）'
     end
 
-    test 'index shows both name and alias for each artist in the bulk artist search results too' do
+    test 'index shows name, alias, key and old_key separately for each artist in the bulk artist search results' do
       Item.create!(title: 'Matching Item', release_date: Date.today,
                    link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
-                   artists: [{ 'name' => 'ムック', 'alias' => 'MUCC' }])
+                   artists: [{ 'name' => 'ムック', 'alias' => 'MUCC', 'key' => 'mucc', 'old_key' => '%A5%E0%A5%C3%A5%AF' }])
 
       get admin_items_path(match_type: 'alias', match_value: 'MUCC')
 
       assert_response :success
-      assert_includes response.body, 'ムック（MUCC）'
+      assert_match(%r{>name</span>\s*<span[^>]*>ムック</span>}, response.body)
+      assert_match(%r{>alias</span>\s*<span[^>]*>MUCC</span>}, response.body)
+      assert_match(%r{>key</span>\s*<a[^>]*>mucc</a>}, response.body)
+      assert_match(%r{>old_key</span>\s*<a[^>]*>%A5%E0%A5%C3%A5%AF</a>}, response.body)
+    end
+
+    test 'index links key to the profile page and old_key to the old wiki page' do
+      Item.create!(title: 'Matching Item', release_date: Date.today,
+                   link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                   artists: [{ 'name' => 'ムック', 'key' => 'mucc', 'old_key' => '%A5%E0%A5%C3%A5%AF' }])
+
+      get admin_items_path(match_type: 'key', match_value: 'mucc')
+
+      assert_response :success
+      assert_match(%r{<a[^>]*href="/mucc"[^>]*>mucc</a>}, response.body)
+      assert_match(%r{<a[^>]*href="#{Regexp.escape(Rails.application.config.old_key_url_base)}/%A5%E0%A5%C3%A5%AF\.html"[^>]*>%A5%E0%A5%C3%A5%AF</a>},
+                   response.body)
+    end
+
+    test 'index shows an em dash for key/old_key when the artist entry has neither' do
+      Item.create!(title: 'Unlinked Item', release_date: Date.today,
+                   link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                   artists: [{ 'name' => 'ムック' }])
+
+      get admin_items_path(match_type: 'name', match_value: 'ムック')
+
+      assert_response :success
+      assert_match(%r{>key</span>\s*<span[^>]*>—</span>}, response.body)
+      assert_match(%r{>old_key</span>\s*<span[^>]*>—</span>}, response.body)
     end
 
     test 'index does not show the bulk artist replace UI for an operator, even with an artist search condition' do


### PR DESCRIPTION
## Summary
- Item アーティスト一括変更の検索結果で、これまで一律「(未紐付け)」としていた表示をやめ、`name` / `alias` / `key` / `old_key` を個別のラベル＋値で表示するように変更
- バッジ状の枠を廃止し、ラベル（グレー・小さめ）と値（濃い色・太字）を区別できるシンプルな表示にした
- `key` はプロフィールページ（`/#{key}`）へ、`old_key` は旧wikiページ（`old_key_url_base` + `.html`）へのリンクにして、クリックで実際の紐づけ先を確認できるようにした
- 一致した検索条件の要素は name/alias の値を琥珀色で強調表示
- Title 列が幅を取りすぎて Artists 列が窮屈になっていたレイアウト崩れも修正（Titleに `max-w-xs line-clamp-2` を設定）

## Test plan
- [x] `bin/rails test` が全件パスすること（270 runs, 916 assertions, 0 failures）
- [x] `bundle exec rubocop` で指摘なし（309 files inspected, no offenses detected）
- [ ] Item 一覧でアーティスト検索後、各アーティストの name/alias/key/old_key が個別に表示されることを確認
- [ ] key/old_key のリンクが正しい紐づけ先（プロフィールページ/旧wiki）に飛ぶことを確認
- [ ] Title 列とArtists列のバランスが改善されていることを確認

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)