### PR TITLE
custom_pageページの下書き生成タスクを追加

### DIFF
--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# Issue#1086: page_type=custom_page に仕訳された Wikipage から、
+# CustomPage (Markdown) の下書きをベストエフォートで生成する。
+#
+# 本番DBとローカルDBが分離しているため、このクラスはローカル環境でのみ使用し、
+# 生成した下書きは人手で本番の管理画面へ貼り付けて仕上げる運用を想定している。
+# （lib/tasks/custom_page_drafts.rake から呼び出す）
+class CustomPageDraftGenerator
+  Draft = Struct.new(:wikipage_id, :key, :title, :old_key, :body, :warnings, keyword_init: true)
+
+  # CustomPage の markdown ヘルパー（ApplicationHelper#expand_plugin_macros）が
+  # そのまま解釈できるプラグイン。変換せず残す。
+  SUPPORTED_PLUGINS = %w[include snapshot].freeze
+
+  def self.generate(wikipage)
+    new(wikipage).generate
+  end
+
+  def initialize(wikipage)
+    @wikipage = wikipage
+    @warnings = []
+  end
+
+  def generate
+    body = @wikipage.wiki.to_s.dup
+    body = strip_hidden_blocks(body)
+    body = strip_comment_lines(body)
+    body = convert_headings(body)
+    body = convert_lists(body)
+    body = convert_links(body)
+    body = convert_horizontal_rules(body)
+    body = flag_unsupported_plugins(body)
+
+    Draft.new(
+      wikipage_id: @wikipage.id,
+      key: "page-#{@wikipage.id}",
+      title: @wikipage.title.presence || @wikipage.name,
+      old_key: encoded_old_key,
+      body: body.strip,
+      warnings: @warnings
+    )
+  end
+
+  private
+
+  # {{b_hidden ...}} ブロックの除去（BaseWikipageImporter#preprocess_content と同様）
+  def strip_hidden_blocks(text)
+    text.gsub(/\{\{b_hidden.*?(?:^\}\}|\z)/m, '')
+  end
+
+  # // で始まるコメント行の除去
+  def strip_comment_lines(text)
+    text.lines.reject { |line| line.strip.start_with?('//') }.join
+  end
+
+  # PukiWiki記法では ! の数が多いほど上位の見出し（!!! が最大）。
+  # !!! → #, !! → ##, ! → ### に変換する。
+  def convert_headings(text)
+    text.gsub(/^(!{1,3})(?!!)\s*(.*)$/) do
+      level = 4 - Regexp.last_match(1).length
+      ('#' * level) + " #{Regexp.last_match(2)}"
+    end
+  end
+
+  # *** / ** / * の箇条書きをMarkdownの入れ子リストに変換
+  def convert_lists(text)
+    text.gsub(/^(\*{1,3})(?!\*)\s*(.*)$/) do
+      depth = Regexp.last_match(1).length - 1
+      ('  ' * depth) + "- #{Regexp.last_match(2)}"
+    end
+  end
+
+  URL_LIKE = %r{\Ahttps?://|\A/}
+
+  # [[label|target]]: target がURL（http(s)://・相対パス）ならMarkdownリンクに変換。
+  #   それ以外（wikiページ名や TBTV-Visual:xxx のようなサービス記法）は自動変換できないため
+  #   [[PageName]] と同様に unresolved 扱いにする。
+  # [label|url]（シングルブラケット）は常にURLとして扱う（実データではURL/相対パスのみ）。
+  # [[PageName]]（パイプなし）: Unit/Person を名前で解決できればプロフィールへのリンクにする。
+  #   解決できなければ平文化し、要手動対応として警告に積む。
+  def convert_links(text)
+    text = text.gsub(/\[\[([^|\]]+)\|([^\]]+)\]\]/) do
+      label = Regexp.last_match(1)
+      target = Regexp.last_match(2)
+      URL_LIKE.match?(target) ? "[#{label}](#{target})" : unresolved_link(label, "[[#{label}|#{target}]]")
+    end
+    text = text.gsub(/\[([^|\]]+)\|([^\]]+)\]/) { "[#{Regexp.last_match(1)}](#{Regexp.last_match(2)})" }
+    text.gsub(/\[\[([^|\]]+)\]\]/) do
+      label = Regexp.last_match(1)
+      resolve_internal_link(label) || unresolved_link(label, "[[#{label}]]")
+    end
+  end
+
+  # Unit/Person を完全一致の名前で検索し、見つかればプロフィールページへのMarkdownリンクを返す
+  def resolve_internal_link(label)
+    target = Unit.kept.find_by(name: label) || Person.kept.find_by(name: label)
+    return nil unless target
+
+    "[#{label}](/#{target.key})"
+  end
+
+  def unresolved_link(label, original_notation)
+    @warnings << "内部リンク #{original_notation} はリンク解決できないため平文化しました（要手動対応）"
+    label
+  end
+
+  def convert_horizontal_rules(text)
+    text.gsub(/^-{4,}\s*$/, '---')
+  end
+
+  # include / snapshot 以外のプラグイン記法はそのまま残すと崩れるため、
+  # コメントで目印を付けて後で人手対応してもらう
+  def flag_unsupported_plugins(text)
+    text.gsub(/\{\{(\w[\w-]*)\s+.+?\}\}/m) do
+      match = Regexp.last_match(0)
+      plugin_name = Regexp.last_match(1)
+      next match if SUPPORTED_PLUGINS.include?(plugin_name)
+
+      @warnings << "未対応プラグイン #{plugin_name} を検出しました（要手動対応）"
+      "<!-- TODO: 要手動対応 元記法: #{match} -->"
+    end
+  end
+
+  def encoded_old_key
+    URI.encode_www_form_component(@wikipage.name.to_s.encode('EUC-JP'))
+  rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
+    @warnings << 'old_key の EUC-JP エンコードに失敗しました（要手動確認）'
+    @wikipage.name.to_s
+  end
+end

--- a/docs/import/custom_page_draft_generation.md
+++ b/docs/import/custom_page_draft_generation.md
@@ -1,0 +1,98 @@
+# カスタムページ下書き生成（custom_page_drafts）
+
+[issue #1086](https://github.com/kuwavkdb/vkdby/issues/1086)（[issue #929](https://github.com/kuwavkdb/vkdby/issues/929) のサブIssue）で追加した、`page_type=custom_page` に仕訳済みの `Wikipage` から `CustomPage`（Markdown）の下書きをベストエフォートで生成する仕組みについて記述する。
+
+## 前提・運用方針
+
+- 本番DBとローカルDBは分離しており、DBの行データを直接移送することはできない。
+- そのためこのタスクは**ローカル環境専用**とする。生成した下書きは、人手で本番の `/admin/custom_pages/new` へコピー＆ペーストして作成・公開する運用を想定している（対象は現状30件程度のため、自動デプロイは行わない）。
+- 対象は `WikiPageImport.page_type = 'custom_page'` のみ。`live_house` / `office_label` / `omnibus` は性質が異なる（施設名・レーベル名・オムニバス盤の一覧）ため対象外。
+
+## 実行方法
+
+### 全件生成
+
+```bash
+bundle exec rails custom_page_drafts:generate
+```
+
+対象は `WikiPageImport.where(page_type: 'custom_page')` 全件。出力先は `tmp/custom_page_drafts/`（`.gitignore` 対象、コミットされない）。
+
+### 特定の1件だけ生成
+
+```bash
+WIKIPAGE_ID=8619 bundle exec rails custom_page_drafts:generate
+```
+
+`WIKIPAGE_ID` には `wikipages.id`（`WikiPageImport#wikipage_id`）を指定する。
+
+### ローカル管理画面でプレビューする
+
+```bash
+PREVIEW=1 bundle exec rails custom_page_drafts:generate
+```
+
+ファイル出力に加えて、ローカルDBに `key: "page-<wikipage_id>"` の `CustomPage`（`active: false` の下書き）を作成・更新する。ローカルで起動して `/admin/custom_pages` の編集画面を開けば、Markdownプレビュー付きで見た目を確認できる。`key` を軸に upsert するだけなので、何度再実行しても安全。
+
+### 変換ロジックだけを単体で試す（Rails console）
+
+```ruby
+wp = Wikipage.find(8619)
+draft = CustomPageDraftGenerator.generate(wp)
+draft.key       # 仮キー "page-8619"
+draft.title     # wikipage.title.presence || wikipage.name
+draft.old_key   # 旧サイトURL用（EUC-JPパーセントエンコード）
+draft.body      # 変換後のMarkdown
+draft.warnings  # 要手動対応の一覧
+```
+
+## 出力ファイルの形式
+
+`tmp/custom_page_drafts/<wikipage_id>_<title>.md` に1ページ1ファイルで出力される。
+
+```markdown
+<!--
+wikipage_id: 8619
+key(仮):      page-8619
+title:        運営方針について
+old_key:      %B1%BF%B1%C4%CA%FD%BF%CB%A4%CB%A4%C4%A4%A4%A4%C6
+warning:      内部リンク [[編集について]] はリンク解決できないため平文化しました（要手動対応）
+-->
+
+# 運営方針について
+...
+```
+
+- `old_key` は Unit/Person importer と同じ規約（`URI.encode_www_form_component(name.encode('EUC-JP'))`）で算出している。[issue #1085](https://github.com/kuwavkdb/vkdby/issues/1085)（旧URLリダイレクト対応）で `custom_pages.old_key` 列が追加され次第、この値をそのまま使える。
+- `key(仮)` は自動採番していない（対象ページにはカナ読みがなく、Unit/Personのようなローマ字変換ができないため）。公開時に管理画面で正式な `key` に変更する前提。
+
+## 変換ルール（`CustomPageDraftGenerator`）
+
+実装: [app/services/custom_page_draft_generator.rb](../../app/services/custom_page_draft_generator.rb)
+
+| 元記法（PukiWiki） | 変換後（Markdown） | 備考 |
+|---|---|---|
+| `//コメント行` | 除去 | |
+| `{{b_hidden ...}}` | 除去 | |
+| `!!!` / `!!` / `!` | `#` / `##` / `###` | `!` の数が多いほど上位見出し |
+| `*` / `**` / `***` | `-` / `  -` / `    -` | 入れ子リスト |
+| `[[label\|url]]` / `[label\|url]` | `[label](url)` | `url` が `http(s)://` または `/` で始まる場合のみ |
+| `[[label\|target]]`（targetがURLでない） | `label`（平文化）＋警告 | wikiページ名やサービス独自記法（例: `TBTV-Visual:452`）を誤ってリンク化しないため |
+| `[[PageName]]` | `[PageName](/key)` または `PageName`（平文化）＋警告 | 同名の `Unit`/`Person` を `kept` スコープで検索し、見つかればプロフィールページへのリンクに自動解決。見つからなければ平文化 |
+| `----` | `---` | |
+| `{{include ...}}` / `{{snapshot ...}}` | そのまま維持 | `CustomPage` のMarkdownヘルパーが解釈できるプラグインのため変換不要（[docs/custom_page_plugins.md](../custom_page_plugins.md)参照） |
+| 上記以外の `{{プラグイン ...}}` | `<!-- TODO: 要手動対応 元記法: {{...}} -->` ＋警告 | `{{tweet}}` `{{a2s}}` `{{category_list_db}}` 等、新サイトに対応機能がないもの |
+
+## 既知の限界
+
+- Amazon商品埋め込み（`{{a2s ASIN}}`）は現時点では変換できず、TODOコメントとして残るのみ。[issue #1087](https://github.com/kuwavkdb/vkdby/issues/1087)（Item card埋め込みプラグイン）が実装されれば `{{item ASIN}}` 等への置き換えが可能になる見込み。
+- `{{category_list_db ...}}` のような動的一覧プラグインは、そもそも静的なMarkdownページでは同じ機能を再現できない。該当ページ（例: `events`）は個別に「簡易化して残すか」「対応を見送るか」を人手で判断する必要がある。
+- 単一ブラケット `[label|url]` は実データ上すべてURL/相対パスだったため常にリンク化している。今後想定外のデータが出てきた場合は要調整。
+
+## 関連ファイル
+
+| 種別 | ファイル |
+|---|---|
+| 変換ロジック | [app/services/custom_page_draft_generator.rb](../../app/services/custom_page_draft_generator.rb) |
+| rakeタスク | [lib/tasks/custom_page_drafts.rake](../../lib/tasks/custom_page_drafts.rake) |
+| テスト | [test/services/custom_page_draft_generator_test.rb](../../test/services/custom_page_draft_generator_test.rb) |

--- a/lib/tasks/custom_page_drafts.rake
+++ b/lib/tasks/custom_page_drafts.rake
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Issue#1086: page_type=custom_page に仕訳された Wikipage から CustomPage の下書きを
+# 生成するタスク。ローカル環境での実行を想定している（本番DBとは分離されているため、
+# ここで作った下書きは人手で本番の管理画面へコピー＆ペーストして仕上げる運用）。
+namespace :custom_page_drafts do
+  desc '仕訳済み(page_type=custom_page)のWikipageからCustomPage下書きを生成する'
+  task generate: :environment do
+    wikipage_id = ENV['WIKIPAGE_ID']
+    preview = ENV['PREVIEW'] == '1'
+
+    scope = WikiPageImport.where(page_type: 'custom_page').includes(:wikipage)
+    scope = scope.where(wikipage_id: wikipage_id) if wikipage_id
+
+    output_dir = Rails.root.join('tmp/custom_page_drafts')
+    FileUtils.mkdir_p(output_dir)
+
+    puts "Target: #{scope.count} records"
+    puts "Output: #{output_dir}"
+    puts 'Mode: PREVIEW (ローカルDBにも active:false のCustomPageを作成/更新します)' if preview
+
+    generated = 0
+    skipped = 0
+
+    scope.find_each do |wpi|
+      wp = wpi.wikipage
+      unless wp
+        puts "[SKIP] WikiPageImport##{wpi.id}: wikipage not found"
+        skipped += 1
+        next
+      end
+
+      if wp.wiki.blank?
+        puts "[SKIP] #{wp.name} (ID: #{wp.id}): 本文なし"
+        skipped += 1
+        next
+      end
+
+      draft = CustomPageDraftGenerator.generate(wp)
+      write_draft_file(output_dir, draft)
+      upsert_preview_custom_page(draft) if preview
+
+      generated += 1
+      puts "[GENERATED] #{wp.title || wp.name} (ID: #{wp.id})#{' [要手動対応あり]' if draft.warnings.any?}"
+    end
+
+    puts 'Done!'
+    puts "  Generated: #{generated}"
+    puts "  Skipped:   #{skipped}"
+  end
+end
+
+def write_draft_file(output_dir, draft)
+  filename = "#{draft.wikipage_id}_#{draft.title.to_s.gsub(/[^\p{Word}-]/, '-')}.md"
+  path = output_dir.join(filename)
+
+  File.write(path, <<~MARKDOWN)
+    <!--
+    wikipage_id: #{draft.wikipage_id}
+    key(仮):      #{draft.key}
+    title:        #{draft.title}
+    old_key:      #{draft.old_key}
+    #{draft.warnings.map { |w| "warning:      #{w}" }.join("\n")}
+    -->
+
+    #{draft.body}
+  MARKDOWN
+end
+
+def upsert_preview_custom_page(draft)
+  page = CustomPage.with_discarded.find_or_initialize_by(key: draft.key)
+  page.title = draft.title
+  page.body = draft.body
+  page.active = false
+  page.save!
+end

--- a/test/services/custom_page_draft_generator_test.rb
+++ b/test/services/custom_page_draft_generator_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CustomPageDraftGeneratorTest < ActiveSupport::TestCase
+  def generate(name:, wiki:, title: nil)
+    wikipage = Wikipage.new(id: 999, name: name, title: title, wiki: wiki)
+    CustomPageDraftGenerator.generate(wikipage)
+  end
+
+  test '見出し !!!/!!/! はMarkdownの#に変換される' do
+    draft = generate(name: 'test', wiki: "!!!大見出し\n!!中見出し\n!小見出し\n")
+    assert_includes draft.body, '# 大見出し'
+    assert_includes draft.body, '## 中見出し'
+    assert_includes draft.body, '### 小見出し'
+  end
+
+  test '箇条書き */**/*** は入れ子のMarkdownリストに変換される' do
+    draft = generate(name: 'test', wiki: "*一階層\n**二階層\n***三階層\n")
+    assert_includes draft.body, '- 一階層'
+    assert_includes draft.body, '  - 二階層'
+    assert_includes draft.body, '    - 三階層'
+  end
+
+  test '[[label|url]] 形式のリンクはMarkdownリンクに変換される' do
+    draft = generate(name: 'test', wiki: '[[オフィシャル|http://example.com/]]')
+    assert_includes draft.body, '[オフィシャル](http://example.com/)'
+  end
+
+  test '[label|url] 形式のリンクもMarkdownリンクに変換される' do
+    draft = generate(name: 'test', wiki: '[オフィシャル|http://example.com/]')
+    assert_includes draft.body, '[オフィシャル](http://example.com/)'
+  end
+
+  test '[[PageName]] 形式の内部リンクは、対応するUnit/Personが見つからなければ平文化され警告が積まれる' do
+    draft = generate(name: 'test', wiki: '[[存在しないバンド名]]')
+    assert_includes draft.body, '存在しないバンド名'
+    refute_includes draft.body, '[[存在しないバンド名]]'
+    assert_equal(1, draft.warnings.count { |w| w.include?('内部リンク') })
+  end
+
+  test '[[PageName]] 形式の内部リンクは、同名のUnitが見つかればプロフィールへのMarkdownリンクになる' do
+    Unit.create!(name: 'テストバンド', key: 'test-band-for-draft-generator')
+    draft = generate(name: 'test', wiki: '[[テストバンド]]')
+    assert_includes draft.body, '[テストバンド](/test-band-for-draft-generator)'
+    assert_empty draft.warnings
+  end
+
+  test '[[PageName]] 形式の内部リンクは、同名のPersonが見つかればプロフィールへのMarkdownリンクになる' do
+    Person.create!(name: 'テスト太郎', key: 'test-taro-for-draft-generator')
+    draft = generate(name: 'test', wiki: '[[テスト太郎]]')
+    assert_includes draft.body, '[テスト太郎](/test-taro-for-draft-generator)'
+    assert_empty draft.warnings
+  end
+
+  test '[[label|target]] のtargetがURLでない場合は平文化され警告が積まれる（wikiページ名やサービス記法など）' do
+    draft = generate(name: 'test', wiki: '[[2008/09/25|カレンダー/2008-9-25]] [[トーク|TBTV-Visual:452]]')
+    assert_includes draft.body, '2008/09/25'
+    assert_includes draft.body, 'トーク'
+    refute_includes draft.body, '(カレンダー/2008-9-25)'
+    refute_includes draft.body, '(TBTV-Visual:452)'
+    assert_equal(2, draft.warnings.count { |w| w.include?('内部リンク') })
+  end
+
+  test '// で始まる行はコメントとして除去される' do
+    draft = generate(name: 'test', wiki: "本文\n//これはコメント\n続き")
+    refute_includes draft.body, 'これはコメント'
+    assert_includes draft.body, '本文'
+    assert_includes draft.body, '続き'
+  end
+
+  test '---- は Markdown の水平線に変換される' do
+    draft = generate(name: 'test', wiki: "本文\n----\n続き")
+    assert_includes draft.body, '---'
+  end
+
+  test 'include/snapshot プラグインはそのまま残る' do
+    draft = generate(name: 'test', wiki: '{{include about,概要}} {{snapshot merry,1}}')
+    assert_includes draft.body, '{{include about,概要}}'
+    assert_includes draft.body, '{{snapshot merry,1}}'
+  end
+
+  test '未対応プラグインはTODOコメントに置き換えられ警告が積まれる' do
+    draft = generate(name: 'test', wiki: '{{tweet v_ryugi}}')
+    assert_includes draft.body, '<!-- TODO: 要手動対応 元記法: {{tweet v_ryugi}} -->'
+    assert(draft.warnings.any? { |w| w.include?('tweet') })
+  end
+
+  test 'title が空の場合は name が使われる' do
+    draft = generate(name: 'events', title: nil, wiki: '本文')
+    assert_equal 'events', draft.title
+  end
+
+  test 'title がある場合はそちらが優先される' do
+    draft = generate(name: 'events', title: 'vkdb主催イベント', wiki: '本文')
+    assert_equal 'vkdb主催イベント', draft.title
+  end
+
+  test 'key は仮キー(page-<wikipage_id>)になる' do
+    draft = generate(name: 'events', wiki: '本文')
+    assert_equal 'page-999', draft.key
+  end
+
+  test 'old_key は旧サイトと同じ EUC-JP パーセントエンコードになる' do
+    draft = generate(name: '義援活動', wiki: '本文')
+    assert_equal '%B5%C1%B1%E7%B3%E8%C6%B0', draft.old_key
+  end
+
+  test 'ASCIIのnameはそのままエンコードされる' do
+    draft = generate(name: 'events', wiki: '本文')
+    assert_equal 'events', draft.old_key
+  end
+end


### PR DESCRIPTION
## Summary
- WikiPageImport(page_type=custom_page)から、wikiテキストをMarkdownへベストエフォート変換する CustomPageDraftGenerator を実装
- 見出し/リスト/リンク記法の変換、include/snapshotプラグインの保持、未対応プラグインへのTODOマーカー付与、Unit/Personへの内部リンク自動解決に対応
- ローカル専用の custom_page_drafts:generate rakeタスクを追加（本番DBとは分離しているため、本番へは人手で管理画面からコピー&ペーストする運用）
- 実行方法・変換ルールを docs/import/custom_page_draft_generation.md にまとめ

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rubocop` が通ること
- [x] 実データ(30件)に対して `bundle exec rails custom_page_drafts:generate` を実行し、出力内容を目視確認

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)