### PR TITLE
見出し変換時、直前の箇条書きに取り込まれないよう空行を挿入する

### DIFF
--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -31,6 +31,7 @@ class CustomPageDraftGenerator
     body = convert_links(body)
     body = convert_horizontal_rules(body)
     body = flag_unsupported_plugins(body)
+    body = normalize_blank_lines(body)
 
     Draft.new(
       wikipage_id: @wikipage.id,
@@ -56,10 +57,13 @@ class CustomPageDraftGenerator
 
   # PukiWiki記法では ! の数が多いほど上位の見出し（!!! が最大）。
   # !!! → #, !! → ##, ! → ### に変換する。
+  # 直前が箇条書き等の場合、空行を挟まないとMarkdown上でリスト項目の続きとして
+  # 解釈されてしまう（見出しとして認識されない）ため、見出しの前に必ず空行を入れる。
+  # 連続見出し等で空行が重複した場合は normalize_blank_lines で正規化する。
   def convert_headings(text)
     text.gsub(/^(!{1,3})(?!!)\s*(.*)$/) do
       level = 4 - Regexp.last_match(1).length
-      ('#' * level) + " #{Regexp.last_match(2)}"
+      "\n#{'#' * level} #{Regexp.last_match(2)}"
     end
   end
 
@@ -120,6 +124,11 @@ class CustomPageDraftGenerator
       @warnings << "未対応プラグイン #{plugin_name} を検出しました（要手動対応）"
       "<!-- TODO: 要手動対応 元記法: #{match} -->"
     end
+  end
+
+  # convert_headings で挿入した空行により3行以上の連続改行ができた場合、空行1つに正規化する
+  def normalize_blank_lines(text)
+    text.gsub(/\n{3,}/, "\n\n")
   end
 
   def encoded_old_key

--- a/test/services/custom_page_draft_generator_test.rb
+++ b/test/services/custom_page_draft_generator_test.rb
@@ -15,6 +15,16 @@ class CustomPageDraftGeneratorTest < ActiveSupport::TestCase
     assert_includes draft.body, '### 小見出し'
   end
 
+  test '見出しの直前が箇条書きの場合、見出しがリスト項目に取り込まれないよう空行が挿入される' do
+    draft = generate(name: 'test', wiki: "!!実績\n*50,000円\n!2019/10/17 … 寄付致しました。\n")
+    assert_includes draft.body, "- 50,000円\n\n### 2019/10/17 … 寄付致しました。"
+  end
+
+  test '見出しが連続しても余計な空行が積み重ならない' do
+    draft = generate(name: 'test', wiki: "!!!大見出し\n!!中見出し\n")
+    refute_includes draft.body, "\n\n\n"
+  end
+
   test '箇条書き */**/*** は入れ子のMarkdownリストに変換される' do
     draft = generate(name: 'test', wiki: "*一階層\n**二階層\n***三階層\n")
     assert_includes draft.body, '- 一階層'


### PR DESCRIPTION
## Summary
- CustomPageDraftGenerator#convert_headings で、見出し(!!!/!!/!)の直前が箇条書きの場合に
  変換後Markdownで見出しがリスト項目へ取り込まれてしまう不具合を修正
- 見出し変換時に必ず直前へ空行を挿入するようにし、連続見出し等で空行が重複しないよう
  normalize_blank_lines で正規化

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rubocop` が通ること
- [x] 報告のあった実例（実績リスト直後の見出し）で空行が正しく入ることを確認

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)