### PR TITLE
Wiki記法の打ち消し線 ==xxx== をMarkdownの~~xxx~~に変換する

### DIFF
--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -11,7 +11,7 @@ class CustomPageDraftGenerator
 
   # CustomPage の markdown ヘルパー（ApplicationHelper#expand_plugin_macros）が
   # そのまま解釈できるプラグイン。変換せず残す。
-  SUPPORTED_PLUGINS = %w[include snapshot].freeze
+  SUPPORTED_PLUGINS = %w[include snapshot item].freeze
 
   def self.generate(wikipage)
     new(wikipage).generate
@@ -30,6 +30,7 @@ class CustomPageDraftGenerator
     body = convert_lists(body)
     body = convert_links(body)
     body = convert_horizontal_rules(body)
+    body = convert_strikethrough(body)
     body = flag_unsupported_plugins(body)
 
     Draft.new(
@@ -107,6 +108,11 @@ class CustomPageDraftGenerator
 
   def convert_horizontal_rules(text)
     text.gsub(/^-{4,}\s*$/, '---')
+  end
+
+  # ==打ち消し線== → ~~打ち消し線~~
+  def convert_strikethrough(text)
+    text.gsub(/==(.+?)==/) { "~~#{Regexp.last_match(1)}~~" }
   end
 
   # include / snapshot 以外のプラグイン記法はそのまま残すと崩れるため、

--- a/docs/import/custom_page_draft_generation.md
+++ b/docs/import/custom_page_draft_generation.md
@@ -80,12 +80,13 @@ warning:      内部リンク [[編集について]] はリンク解決できな
 | `[[label\|target]]`（targetがURLでない） | `label`（平文化）＋警告 | wikiページ名やサービス独自記法（例: `TBTV-Visual:452`）を誤ってリンク化しないため |
 | `[[PageName]]` | `[PageName](/key)` または `PageName`（平文化）＋警告 | 同名の `Unit`/`Person` を `kept` スコープで検索し、見つかればプロフィールページへのリンクに自動解決。見つからなければ平文化 |
 | `----` | `---` | |
-| `{{include ...}}` / `{{snapshot ...}}` | そのまま維持 | `CustomPage` のMarkdownヘルパーが解釈できるプラグインのため変換不要（[docs/custom_page_plugins.md](../custom_page_plugins.md)参照） |
+| `==打ち消し線==` | `~~打ち消し線~~` | |
+| `{{include ...}}` / `{{snapshot ...}}` / `{{item ...}}` | そのまま維持 | `CustomPage` のMarkdownヘルパーが解釈できるプラグインのため変換不要（[docs/custom_page_plugins.md](../custom_page_plugins.md)参照） |
 | 上記以外の `{{プラグイン ...}}` | `<!-- TODO: 要手動対応 元記法: {{...}} -->` ＋警告 | `{{tweet}}` `{{a2s}}` `{{category_list_db}}` 等、新サイトに対応機能がないもの |
 
 ## 既知の限界
 
-- Amazon商品埋め込み（`{{a2s ASIN}}`）は現時点では変換できず、TODOコメントとして残るのみ。[issue #1087](https://github.com/kuwavkdb/vkdby/issues/1087)（Item card埋め込みプラグイン）が実装されれば `{{item ASIN}}` 等への置き換えが可能になる見込み。
+- Amazon商品埋め込み（`{{a2s ASIN}}`）は現時点では変換できず、TODOコメントとして残るのみ。[issue #1087](https://github.com/kuwavkdb/vkdby/issues/1087)（Item card埋め込みプラグイン、`{{item ASIN}}`）は実装済みだが、`{{a2s}}` から `{{item}}` への自動置換はこのジェネレーターにはまだ組み込んでいない（要手動対応）。
 - `{{category_list_db ...}}` のような動的一覧プラグインは、そもそも静的なMarkdownページでは同じ機能を再現できない。該当ページ（例: `events`）は個別に「簡易化して残すか」「対応を見送るか」を人手で判断する必要がある。
 - 単一ブラケット `[label|url]` は実データ上すべてURL/相対パスだったため常にリンク化している。今後想定外のデータが出てきた場合は要調整。
 

--- a/test/services/custom_page_draft_generator_test.rb
+++ b/test/services/custom_page_draft_generator_test.rb
@@ -74,10 +74,16 @@ class CustomPageDraftGeneratorTest < ActiveSupport::TestCase
     assert_includes draft.body, '---'
   end
 
-  test 'include/snapshot プラグインはそのまま残る' do
-    draft = generate(name: 'test', wiki: '{{include about,概要}} {{snapshot merry,1}}')
+  test '==打ち消し線== はMarkdownの~~打ち消し線~~に変換される' do
+    draft = generate(name: 'test', wiki: '==受領証が届き次第画像を差し替えます==')
+    assert_includes draft.body, '~~受領証が届き次第画像を差し替えます~~'
+  end
+
+  test 'include/snapshot/item プラグインはそのまま残る' do
+    draft = generate(name: 'test', wiki: '{{include about,概要}} {{snapshot merry,1}} {{item B004X86P9U}}')
     assert_includes draft.body, '{{include about,概要}}'
     assert_includes draft.body, '{{snapshot merry,1}}'
+    assert_includes draft.body, '{{item B004X86P9U}}'
   end
 
   test '未対応プラグインはTODOコメントに置き換えられ警告が積まれる' do


### PR DESCRIPTION
## Summary
- CustomPageDraftGenerator に、Wiki記法の打ち消し線 `==xxx==` をMarkdownの `~~xxx~~` に変換する処理を追加
- SUPPORTED_PLUGINS に `item` を追加（#1087 で `{{item ASIN}}` プラグインが実装済みのため、下書き生成時にTODOマーカーで誤って囲われないように）
- docs/import/custom_page_draft_generation.md の変換ルール表を更新

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rubocop` が通ること
- [x] 実データ（義捐活動ページ）で `==受領証が届き次第画像を差し替えます==` が `~~受領証が届き次第画像を差し替えます~~` に変換されることを確認

Closes #1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)