### PR TITLE
カスタムページの旧URL(.html)リダイレクトに対応する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,4 @@ Metrics/ClassLength:
   Exclude:
     - 'app/models/person.rb'
     - 'app/services/base_wikipage_importer.rb'
+    - 'test/services/custom_page_draft_generator_test.rb'

--- a/app/controllers/admin/custom_pages_controller.rb
+++ b/app/controllers/admin/custom_pages_controller.rb
@@ -101,7 +101,7 @@ module Admin
     end
 
     def custom_page_params
-      params.require(:custom_page).permit(:key, :title, :body, :active)
+      params.require(:custom_page).permit(:key, :title, :body, :active, :old_key)
     end
   end
 end

--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -22,6 +22,15 @@ class LegacyRedirectsController < ApplicationController
       return
     end
 
+    # Try to find CustomPage by old_key（issue #1085）
+    if (custom_page = CustomPage.published.find_by(old_key: old_key) ||
+                      CustomPage.published.find_by(old_key: encoded_old_key))
+      new_url = custom_page_url(custom_page.key)
+      response.headers['Link'] = "<#{new_url}>; rel=\"canonical\""
+      redirect_to new_url, status: :moved_permanently
+      return
+    end
+
     # Try to find Unit by old_key
     if (unit = Unit.find_by(old_key: old_key) || Unit.find_by(old_key: encoded_old_key) ||
                Unit.where('aliases @> ?', [{ old_key: old_key }].to_json).first ||

--- a/app/models/custom_page.rb
+++ b/app/models/custom_page.rb
@@ -9,6 +9,7 @@
 #  body         :text
 #  discarded_at :datetime
 #  key          :string           not null
+#  old_key      :string
 #  title        :string           not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
@@ -16,7 +17,8 @@
 # Indexes
 #
 #  index_custom_pages_on_discarded_at  (discarded_at)
-#  index_custom_pages_on_key          (key) UNIQUE
+#  index_custom_pages_on_key           (key) UNIQUE
+#  index_custom_pages_on_old_key       (old_key) UNIQUE
 #
 
 class CustomPage < ApplicationRecord

--- a/app/views/admin/custom_pages/_form.html.erb
+++ b/app/views/admin/custom_pages/_form.html.erb
@@ -19,6 +19,14 @@
   </div>
 
   <div>
+    <%= form.label :old_key, "旧キー (old_key)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">旧サイトの <code>xxxxx.html</code> のURLエンコード済み部分。設定すると <code>/{old_key}.html</code> へのアクセスがこのページへ301リダイレクトされる。</p>
+    <%= form.text_field :old_key,
+        class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 font-mono dark:bg-gray-700 dark:border-gray-600 dark:text-white",
+        placeholder: "例: events, %B5%C1%B1%E7%B3%E8%C6%B0" %>
+  </div>
+
+  <div>
     <%= form.label :title, "タイトル", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
     <%= form.text_field :title,
         class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>

--- a/db/migrate/20260808071018_add_old_key_to_custom_pages.rb
+++ b/db/migrate/20260808071018_add_old_key_to_custom_pages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOldKeyToCustomPages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :custom_pages, :old_key, :string
+    add_index :custom_pages, :old_key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_013836) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_08_071018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -59,10 +59,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_013836) do
     t.datetime "created_at", null: false
     t.datetime "discarded_at"
     t.string "key", null: false
+    t.string "old_key"
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["discarded_at"], name: "index_custom_pages_on_discarded_at"
     t.index ["key"], name: "index_custom_pages_on_key", unique: true
+    t.index ["old_key"], name: "index_custom_pages_on_old_key", unique: true
   end
 
   create_table "external_sites", force: :cascade do |t|

--- a/docs/import/custom_page_draft_generation.md
+++ b/docs/import/custom_page_draft_generation.md
@@ -63,7 +63,7 @@ warning:      内部リンク [[編集について]] はリンク解決できな
 ...
 ```
 
-- `old_key` は Unit/Person importer と同じ規約（`URI.encode_www_form_component(name.encode('EUC-JP'))`）で算出している。[issue #1085](https://github.com/kuwavkdb/vkdby/issues/1085)（旧URLリダイレクト対応）で `custom_pages.old_key` 列が追加され次第、この値をそのまま使える。
+- `old_key` は Unit/Person importer と同じ規約（`URI.encode_www_form_component(name.encode('EUC-JP'))`）で算出している。[issue #1085](https://github.com/kuwavkdb/vkdby/issues/1085)（旧URLリダイレクト対応）で `custom_pages.old_key` 列が追加済みなので、この値を本番の管理画面フォームの「旧キー」欄にそのまま貼り付ければ `/{old_key}.html` からのリダイレクトが有効になる（詳細: [docs/redirects.md](../redirects.md)）。
 - `key(仮)` は自動採番していない（対象ページにはカナ読みがなく、Unit/Personのようなローマ字変換ができないため）。公開時に管理画面で正式な `key` に変更する前提。
 
 ## 変換ルール（`CustomPageDraftGenerator`）

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -24,13 +24,17 @@
 
 旧システムで使われていた `.html` 拡張子付きURLを、現行プロフィールページへ転送する。
 
-**検索順序（Unit → Person の順で探す）:**
+**検索順序（CustomPage → Unit → Person の順で探す）:**
 
-1. `Unit.old_key` が一致
-2. `Unit.old_key` がURLエンコード済み old_key と一致
-3. `Unit.aliases` 配列内の `old_key` フィールドが一致
-4. `Unit.aliases` 配列内の `old_key` フィールドがURLエンコード済み old_key と一致
-5. 上記4パターンを Person でも同様に確認
+1. `CustomPage.old_key`（`published` スコープのみ）が一致
+2. `CustomPage.old_key` がURLエンコード済み old_key と一致
+3. `Unit.old_key` が一致
+4. `Unit.old_key` がURLエンコード済み old_key と一致
+5. `Unit.aliases` 配列内の `old_key` フィールドが一致
+6. `Unit.aliases` 配列内の `old_key` フィールドがURLエンコード済み old_key と一致
+7. 上記4〜6パターンを Person でも同様に確認
+
+CustomPage は `Unit`/`Person` と異なり `aliases` を持たない（[issue #1085](https://github.com/kuwavkdb/vkdby/issues/1085)、初回実装のため単一の `old_key` のみ。複数の旧名を持つページが出てきたら `aliases` の追加を検討）。
 
 **見つからない場合:** 404ページを表示（EUC-JP デコードを試みてユニット名を表示）
 

--- a/test/controllers/admin/custom_pages_controller_test.rb
+++ b/test/controllers/admin/custom_pages_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class CustomPagesControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+    end
+
+    test 'create allows setting old_key' do
+      assert_difference('CustomPage.count') do
+        post admin_custom_pages_path, params: {
+          custom_page: { key: 'events', title: 'イベント', body: '本文', old_key: 'events' }
+        }
+      end
+
+      assert_equal 'events', CustomPage.last.old_key
+    end
+
+    test 'update allows changing old_key' do
+      custom_page = CustomPage.create!(key: 'events', title: 'イベント', old_key: 'old-value')
+
+      patch admin_custom_page_path(custom_page), params: {
+        custom_page: { old_key: '%B5%C1%B1%E7%B3%E8%C6%B0' }
+      }
+
+      assert_redirected_to edit_admin_custom_page_path(custom_page)
+      custom_page.reload
+      assert_equal '%B5%C1%B1%E7%B3%E8%C6%B0', custom_page.old_key
+    end
+  end
+end

--- a/test/controllers/legacy_redirects_controller_test.rb
+++ b/test/controllers/legacy_redirects_controller_test.rb
@@ -16,6 +16,12 @@ class LegacyRedirectsControllerTest < ActionDispatch::IntegrationTest
       old_key: 'old_person_k',
       status: :active
     )
+    @custom_page = CustomPage.create!(
+      key: 'events',
+      title: 'イベント',
+      old_key: 'events',
+      active: true
+    )
   end
 
   test 'should redirect to unit page if old_key matches unit' do
@@ -23,6 +29,19 @@ class LegacyRedirectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :moved_permanently
     assert_redirected_to profile_path(@unit.key)
     assert_match(/<#{Regexp.escape(profile_url(@unit.key))}>; rel="canonical"/, response.headers['Link'])
+  end
+
+  test 'should redirect to custom page if old_key matches a published custom page' do
+    get "/#{@custom_page.old_key}.html"
+    assert_response :moved_permanently
+    assert_redirected_to custom_page_path(@custom_page.key)
+    assert_match(/<#{Regexp.escape(custom_page_url(@custom_page.key))}>; rel="canonical"/, response.headers['Link'])
+  end
+
+  test 'should not redirect to an unpublished (draft) custom page' do
+    @custom_page.update!(active: false)
+    get "/#{@custom_page.old_key}.html"
+    assert_response :not_found
   end
 
   test 'should redirect to person page if old_key matches person' do


### PR DESCRIPTION
## Summary
- `custom_pages` に `old_key`(unique index)を追加するマイグレーションを追加
- `LegacyRedirectsController#show` の検索チェーンに `CustomPage.published` を追加（Unit/Personより先に検索し、ヒットすれば `/pages/:key` へ301リダイレクト）
- `Admin::CustomPagesController` / 管理画面フォームに `old_key` 入力欄を追加
- `docs/redirects.md`・`docs/import/custom_page_draft_generation.md` を更新
- ついでに `.rubocop.yml` の `Metrics/ClassLength` Exclude に `test/services/custom_page_draft_generator_test.rb` を追加（#1092と#1094はそれぞれ単独では閾値内だったが、マージ後に合算されて100行を超えていたため。`bundle exec rubocop` を全体実行すると検出されていました）

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rubocop` が通ること
- [x] `/{old_key}.html` で公開済みcustom_pageへ301リダイレクトされることを確認するテストを追加
- [x] 下書き（未公開）のcustom_pageは旧URLでリダイレクトされない(404)ことを確認するテストを追加
- [x] 管理画面から old_key を作成・変更できることを確認するテストを追加

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)