### PR TITLE
preview-pr のバージョン重複回避の仕組みを追加

### DIFF
--- a/.claude/skills/preview-pr/SKILL.md
+++ b/.claude/skills/preview-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preview-pr
-description: 指定したブランチ（指定しない場合はカレントブランチ）をもとに、release/yyyy.mm.dd.preview ブランチを作成し、PRを作成する（マージ先はmain）
+description: 指定したブランチ（指定しない場合はカレントブランチ）をもとに、release/v0.yyyy.mmdd.preview ブランチを作成し、PRを作成する（マージ先はmain）
 ---
 
 # Preview PR 作成
@@ -13,29 +13,41 @@ description: 指定したブランチ（指定しない場合はカレントブ�
    - 引数でブランチが指定された場合はそれを使う
    - 指定がない場合はカレントブランチ（`git branch --show-current`）を使う
 
-2. 今日の日付を取得して、ブランチ名を決定する
-   - フォーマット: `release/YYYY.MM.DD.preview`（例: `release/2026.03.07.preview`）
-   - Bash で `date +%Y.%m.%d` を実行して取得する
-
-3. ベースブランチに切り替えて最新化する
+2. ベースブランチに切り替えて最新化する
    ```
    git checkout <base_branch>
    git pull origin <base_branch>
    ```
 
+3. バージョン番号を確定する（`release-pr` の通常リリースタグと重複しないようにする）
+   - preview のブランチ名は、通常リリースと同じバージョン形式 `v0.YYYY.MMDD[.N]` の末尾に `.preview` を付けた形にする（例: `release/v0.2026.0227.preview`）。これにより、preview のまま `.preview` を外せばそのまま通常リリースのブランチ名として使える。
+   - 今日の日付を取得する: `date +%Y.%m%d`（例: `2026.0227`）
+   - タグと preview ブランチの両方から、今日の日付を使っているバージョンを集める（重複判定はこの両方を見る必要がある。通常リリースの `release-pr` はタグしか見ていないが、preview が先に同じ日付のバージョンを使っている場合もあるため）:
+     ```
+     git fetch origin --tags --quiet
+     git tag --list "v0.<date>*"
+     git ls-remote --heads origin "release/v0.<date>*.preview"
+     ```
+   - 上記2つの結果を合わせて、末尾のサフィックス番号を確認する
+     - サフィックスなし（`v0.<date>` または `release/v0.<date>.preview`）は 1 として扱う
+     - 見つかった中の最大値+1 を新しいサフィックスとする
+   - 該当するタグ・ブランチが1件もない場合: `v0.<date>` をそのまま使う（サフィックスなし）
+   - 該当する場合: 最大サフィックス+1 を付ける（例: `v0.2026.0227` が既に使われていれば `v0.2026.0227.2`）
+   - 確定したバージョンを `<version>` とする（例: `v0.2026.0227` または `v0.2026.0227.2`）
+
 4. プレビューブランチを作成する
    ```
-   git checkout -b release/<date>.preview
+   git checkout -b release/<version>.preview
    ```
 
 5. リモートにpushする
    ```
-   git push origin release/<date>.preview
+   git push origin release/<version>.preview
    ```
 
 6. PRを作成する（ベースブランチは `main`、タイトルに `[render preview]` を含める）
    ```
-   gh pr create --base main --title "[render preview] release/<date>.preview" --body "## Preview release/<date>.preview\n\nベースブランチ: <base_branch>"
+   gh pr create --base main --title "[render preview] release/<version>.preview" --body "## Preview release/<version>.preview\n\nベースブランチ: <base_branch>"
    ```
 
 7. 作成したPRのURLをユーザーに表示する


### PR DESCRIPTION
## Summary
- preview ブランチ名を release-pr と同じバージョン形式 `v0.YYYY.MMDD[.N]` に `.preview` を付けた形（`release/v0.YYYY.MMDD[.N].preview`）に変更。`.preview` を外せばそのまま通常リリースのブランチ名として使える
- バージョン確定時に、通常リリースのタグ（`v0.YYYY.MMDD[.N]`）と同日の既存previewブランチの両方を確認し、重複しない番号を採番するよう修正
  - 従来の `release-pr` はタグしか見ておらず、previewが先に同日のバージョンを使っていた場合に、後で通常リリースとして`.preview`を外した際に重複するおそれがあった

## Test plan
- [x] （ドキュメント/スキル定義のみの変更のため、実行系のテストなし）
- [x] `bin/rails test` が全件パスすること（変更に無関係だが念のため確認）
- [x] `bundle exec rubocop` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)