### PR TITLE
タグ（TagIndex）の追加・削除・リネーム機能を管理画面に追加

### DIFF
--- a/app/controllers/admin/tag_indices_controller.rb
+++ b/app/controllers/admin/tag_indices_controller.rb
@@ -2,13 +2,37 @@
 
 module Admin
   class TagIndicesController < Admin::BaseController
+    before_action :set_tag_index, only: %i[edit update destroy]
+
+    def new
+      @tag_index = TagIndex.new(index_group_id: params[:index_group_id])
+    end
+
+    def create
+      @tag_index = TagIndex.new(tag_index_params)
+      if @tag_index.save
+        redirect_to admin_index_group_path(id: @tag_index.index_group_id || 0), notice: 'タグを追加しました'
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
     def update
-      @tag_index = TagIndex.find(params[:id])
       if @tag_index.update(tag_index_params)
-        redirect_back(fallback_location: admin_index_groups_path, notice: 'タグのステータスを更新しました')
+        redirect_back(fallback_location: admin_index_groups_path, notice: 'タグを更新しました')
+      elsif tag_index_params.key?(:name)
+        render :edit, status: :unprocessable_entity
       else
         redirect_back(fallback_location: admin_index_groups_path, alert: '更新に失敗しました')
       end
+    end
+
+    def destroy
+      redirect_group_id = @tag_index.index_group_id || 0
+      @tag_index.destroy
+      redirect_to admin_index_group_path(id: redirect_group_id), notice: 'タグを削除しました'
     end
 
     def bulk_update
@@ -24,8 +48,12 @@ module Admin
 
     private
 
+    def set_tag_index
+      @tag_index = TagIndex.find(params[:id])
+    end
+
     def tag_index_params
-      params.require(:tag_index).permit(:active)
+      params.require(:tag_index).permit(:name, :active, :index_group_id)
     end
   end
 end

--- a/app/views/admin/index_groups/show.html.erb
+++ b/app/views/admin/index_groups/show.html.erb
@@ -49,6 +49,10 @@
         <% end %>
       </div>
 
+      <div class="mb-4">
+        <%= link_to "＋ タグを追加", new_admin_tag_index_path, class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700" %>
+      </div>
+
       <%= form_with url: move_indices_admin_index_group_path(@index_group), method: :post, local: true, html: { id: "move_indices_form" } do |f| %>
         <div class="mb-4 p-4 bg-gray-50 rounded-md border border-gray-200">
           <div class="flex items-center mb-3">
@@ -80,7 +84,9 @@
             <div class="flex items-center gap-4">
               <%= link_to "Units: #{index.units.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
               <%= link_to "People: #{index.people.count}", admin_people_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
+              <%= link_to "名称変更", edit_admin_tag_index_path(index), class: "text-xs px-2 py-1 rounded border text-gray-600 border-gray-300 hover:bg-gray-50" %>
               <%= button_to index.active? ? "非表示" : "表示", admin_tag_index_path(index, tag_index: { active: !index.active? }), method: :patch, class: "text-xs px-2 py-1 rounded border #{index.active? ? 'text-red-600 border-red-200 hover:bg-red-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'}" %>
+              <%= button_to "削除", admin_tag_index_path(index), method: :delete, class: "text-xs px-2 py-1 rounded border text-red-600 border-red-200 hover:bg-red-50", onclick: "return confirm('「#{j index.name}」を削除しますか？紐づくUnit/Personとの関連も削除されます。')" %>
             </div>
           </li>
         <% end %>
@@ -104,6 +110,10 @@
             <% end %>
           </div>
         <% end %>
+      </div>
+
+      <div class="mb-4">
+        <%= link_to "＋ タグを追加", new_admin_tag_index_path(index_group_id: @index_group.id), class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700" %>
       </div>
 
       <%= form_with url: detach_indices_admin_index_group_path(@index_group), method: :post, local: true, html: { id: "detach_indices_form" } do |f| %>
@@ -145,7 +155,9 @@
             <div class="flex items-center gap-4">
               <%= link_to "Units: #{index.units.count}", admin_units_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
               <%= link_to "People: #{index.people.count}", admin_people_path(tag_index_id: index.id), class: "text-sm text-indigo-600 hover:text-indigo-800 hover:underline" %>
+              <%= link_to "名称変更", edit_admin_tag_index_path(index), class: "text-xs px-2 py-1 rounded border text-gray-600 border-gray-300 hover:bg-gray-50" %>
               <%= button_to index.active? ? "非表示" : "表示", admin_tag_index_path(index, tag_index: { active: !index.active? }), method: :patch, class: "text-xs px-2 py-1 rounded border #{index.active? ? 'text-red-600 border-red-200 hover:bg-red-50' : 'text-blue-600 border-blue-200 hover:bg-blue-50'}" %>
+              <%= button_to "削除", admin_tag_index_path(index), method: :delete, class: "text-xs px-2 py-1 rounded border text-red-600 border-red-200 hover:bg-red-50", onclick: "return confirm('「#{j index.name}」を削除しますか？紐づくUnit/Personとの関連も削除されます。')" %>
             </div>
           </li>
         <% end %>

--- a/app/views/admin/tag_indices/_form.html.erb
+++ b/app/views/admin/tag_indices/_form.html.erb
@@ -1,0 +1,45 @@
+<% title = @tag_index.new_record? ? "タグ新規作成" : "タグ編集: #{@tag_index.name}" %>
+<% content_for :title, title %>
+<div class="container mx-auto px-4 py-8">
+  <div class="max-w-md mx-auto bg-white shadow rounded-lg p-6">
+    <h1 class="text-2xl font-bold mb-6"><%= title %></h1>
+
+    <%= form_with model: [:admin, @tag_index], local: true do |f| %>
+      <% if @tag_index.errors.any? %>
+        <div class="bg-red-50 border-l-4 border-red-500 p-4 mb-6">
+          <div class="flex">
+            <div class="ml-3">
+              <h3 class="text-sm font-medium text-red-800">
+                <%= pluralize(@tag_index.errors.count, "error") %> prohibited this tag from being saved:
+              </h3>
+              <div class="mt-2 text-sm text-red-700">
+                <ul class="list-disc pl-5 space-y-1">
+                  <% @tag_index.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <%= f.hidden_field :index_group_id %>
+
+      <div class="mb-4">
+        <%= f.label :name, "タグ名", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.text_field :name, class: "w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
+      </div>
+
+      <div class="mb-6 flex items-center">
+        <%= f.check_box :active, class: "h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded" %>
+        <%= f.label :active, "表示中にする", class: "ml-2 block text-sm text-gray-900" %>
+      </div>
+
+      <div class="flex items-center justify-between">
+        <%= link_to "Cancel", admin_index_group_path(id: @tag_index.index_group_id || 0), class: "text-gray-500 hover:text-gray-700" %>
+        <%= f.submit class: "px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/tag_indices/edit.html.erb
+++ b/app/views/admin/tag_indices/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/app/views/admin/tag_indices/new.html.erb
+++ b/app/views/admin/tag_indices/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       end
     end
 
-    resources :tag_indices, only: %i[update] do
+    resources :tag_indices, except: %i[index show] do
       collection do
         post :bulk_update
       end

--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -24,7 +24,7 @@
 |---|---|
 | Units — 閲覧・作成・編集 | index / new / create / edit / update / show / search |
 | People — 閲覧・作成・編集 | index / new / create / edit / update / search |
-| Index Groups | 全アクション |
+| Index Groups / タグ（Tag Indices）— 閲覧・作成・編集・削除・並べ替え・グループ移動 | 全アクション |
 | Trends — 閲覧・作成・編集 | index / new / create / edit / update |
 | External Sites | 全アクション |
 | Custom Pages — 閲覧・作成・編集 | index / new / create / edit / update |

--- a/test/controllers/admin/tag_indices_controller_test.rb
+++ b/test/controllers/admin/tag_indices_controller_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class TagIndicesControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+    end
+
+    test 'create adds a tag to the specified group' do
+      group = IndexGroup.create!(name: 'テストグループ', sort_order: 1)
+
+      assert_difference('TagIndex.count') do
+        post admin_tag_indices_path, params: {
+          tag_index: { name: '新規タグ', index_group_id: group.id, active: true }
+        }
+      end
+
+      tag_index = TagIndex.last
+      assert_equal 'テストグループ', tag_index.index_group.name
+      assert_redirected_to admin_index_group_path(group)
+    end
+
+    test 'create without a group leaves the tag unclassified' do
+      assert_difference('TagIndex.count') do
+        post admin_tag_indices_path, params: { tag_index: { name: '未分類タグ' } }
+      end
+
+      assert_nil TagIndex.last.index_group_id
+      assert_redirected_to admin_index_group_path(id: 0)
+    end
+
+    test 'create rejects a duplicate name' do
+      TagIndex.create!(name: '既存タグ')
+
+      assert_no_difference('TagIndex.count') do
+        post admin_tag_indices_path, params: { tag_index: { name: '既存タグ' } }
+      end
+
+      assert_response :unprocessable_entity
+    end
+
+    test 'update renames a tag' do
+      tag_index = TagIndex.create!(name: '旧名')
+
+      patch admin_tag_index_path(tag_index), params: { tag_index: { name: '新名' } }
+
+      assert_redirected_to admin_index_groups_path
+      assert_equal '新名', tag_index.reload.name
+    end
+
+    test 'update rejects renaming to a duplicate name' do
+      TagIndex.create!(name: '重複タグ')
+      tag_index = TagIndex.create!(name: '元の名前')
+
+      patch admin_tag_index_path(tag_index), params: { tag_index: { name: '重複タグ' } }
+
+      assert_response :unprocessable_entity
+      assert_equal '元の名前', tag_index.reload.name
+    end
+
+    test 'destroy removes the tag and its items' do
+      group = IndexGroup.create!(name: 'グループ', sort_order: 1)
+      tag_index = TagIndex.create!(name: '削除対象', index_group: group)
+
+      assert_difference('TagIndex.count', -1) do
+        delete admin_tag_index_path(tag_index)
+      end
+
+      assert_redirected_to admin_index_group_path(group)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Admin::TagIndicesController に `new`/`create`/`edit`/`update`/`destroy` アクションを追加し、IndexGroup配下でタグの新規作成・リネーム・削除を行えるようにした
- 削除時は確認ダイアログを表示（紐づくUnit/Personとの関連も削除される旨を明記）
- リネーム時は重複名をバリデーションエラーとして編集画面に表示
- docs/admin/permissions.md を更新

## Test plan
- [x] `bundle exec rails test` が全件パスすること
- [x] `bundle exec rubocop` でオフェンスがないこと
- [x] Admin画面でIndexGroupページからタグの追加・名称変更・削除ができること（追加/更新/削除の各コントローラーテストで確認）

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)