### PR TITLE
カスタムページ一覧にシステム用ページの絞り込み機能を追加

### DIFF
--- a/app/controllers/admin/custom_pages_controller.rb
+++ b/app/controllers/admin/custom_pages_controller.rb
@@ -19,6 +19,12 @@ module Admin
 
       scope = scope.where('key ILIKE :q OR title ILIKE :q', q: "%#{@q}%") if @q.present?
 
+      scope = case params[:system]
+              when 'only'    then scope.system_pages
+              when 'exclude' then scope.non_system_pages
+              else                scope
+              end
+
       @pagy, @custom_pages = pagy(scope.order(updated_at: :desc), limit: 20)
     end
 

--- a/app/models/custom_page.rb
+++ b/app/models/custom_page.rb
@@ -32,12 +32,18 @@ class CustomPage < ApplicationRecord
   # 削除不可のページkey一覧（ルートとして使用されるなど、システム上必須のページ）
   PROTECTED_KEYS = %w[index].freeze
 
+  # サイトの仕組み（トップページ本体・グローバルフッター・トップメッセージ・IPブロックリスト）として
+  # 参照される「システム用ページ」のkey一覧。今後増える場合はここに追加する。
+  SYSTEM_KEYS = (%w[index footer top_message] + [Middleware::IpBlocker::CUSTOM_PAGE_KEY]).freeze
+
   validates :key, presence: true, uniqueness: true,
                   format: { with: /\A[a-z0-9_-]+\z/, message: '半角英数字・アンダースコア・ハイフンのみ使用可' }
   validates :title, presence: true
   validate :no_circular_includes, if: :body_changed?
 
   scope :published, -> { kept.where(active: true) }
+  scope :system_pages, -> { where(key: SYSTEM_KEYS) }
+  scope :non_system_pages, -> { where.not(key: SYSTEM_KEYS) }
 
   after_commit :expire_sidebar_cache
   after_commit :expire_blocked_ips_cache, if: -> { key == Middleware::IpBlocker::CUSTOM_PAGE_KEY }
@@ -45,6 +51,10 @@ class CustomPage < ApplicationRecord
 
   def protected?
     PROTECTED_KEYS.include?(key)
+  end
+
+  def system?
+    SYSTEM_KEYS.include?(key)
   end
 
   def expire_cache

--- a/app/views/admin/custom_pages/index.html.erb
+++ b/app/views/admin/custom_pages/index.html.erb
@@ -14,12 +14,21 @@
   </div>
 
   <div class="mb-4 flex items-center gap-4 text-sm">
-    <%= link_to "通常", admin_custom_pages_path(q: params[:q]),
+    <%= link_to "通常", admin_custom_pages_path(q: params[:q], system: params[:system]),
         class: "#{params[:discarded].blank? ? 'font-bold underline' : 'text-indigo-600 hover:underline'}" %>
-    <%= link_to "削除済み", admin_custom_pages_path(q: params[:q], discarded: 'only'),
+    <%= link_to "削除済み", admin_custom_pages_path(q: params[:q], discarded: 'only', system: params[:system]),
         class: "#{params[:discarded] == 'only' ? 'font-bold underline' : 'text-indigo-600 hover:underline'}" %>
-    <%= link_to "すべて", admin_custom_pages_path(q: params[:q], discarded: 'all'),
+    <%= link_to "すべて", admin_custom_pages_path(q: params[:q], discarded: 'all', system: params[:system]),
         class: "#{params[:discarded] == 'all' ? 'font-bold underline' : 'text-indigo-600 hover:underline'}" %>
+  </div>
+
+  <div class="mb-4 flex items-center gap-4 text-sm">
+    <%= link_to "すべて表示", admin_custom_pages_path(q: params[:q], discarded: params[:discarded]),
+        class: "#{params[:system].blank? ? 'font-bold underline' : 'text-indigo-600 hover:underline'}" %>
+    <%= link_to "システム用ページのみ", admin_custom_pages_path(q: params[:q], discarded: params[:discarded], system: 'only'),
+        class: "#{params[:system] == 'only' ? 'font-bold underline' : 'text-indigo-600 hover:underline'}" %>
+    <%= link_to "システム用ページを除く", admin_custom_pages_path(q: params[:q], discarded: params[:discarded], system: 'exclude'),
+        class: "#{params[:system] == 'exclude' ? 'font-bold underline' : 'text-indigo-600 hover:underline'}" %>
   </div>
 
   <div class="mb-4 flex justify-center">

--- a/test/controllers/admin/custom_pages_controller_test.rb
+++ b/test/controllers/admin/custom_pages_controller_test.rb
@@ -29,5 +29,25 @@ module Admin
       custom_page.reload
       assert_equal '%B5%C1%B1%E7%B3%E8%C6%B0', custom_page.old_key
     end
+
+    test 'index with system=only shows only system pages' do
+      CustomPage.find_or_create_by!(key: 'footer') { |p| p.title = 'フッター' }
+      CustomPage.create!(key: 'events', title: 'イベント')
+
+      get admin_custom_pages_path(system: 'only')
+
+      assert_includes @controller.view_assigns['custom_pages'].map(&:key), 'footer'
+      assert_not_includes @controller.view_assigns['custom_pages'].map(&:key), 'events'
+    end
+
+    test 'index with system=exclude hides system pages' do
+      CustomPage.find_or_create_by!(key: 'footer') { |p| p.title = 'フッター' }
+      CustomPage.create!(key: 'events', title: 'イベント')
+
+      get admin_custom_pages_path(system: 'exclude')
+
+      assert_not_includes @controller.view_assigns['custom_pages'].map(&:key), 'footer'
+      assert_includes @controller.view_assigns['custom_pages'].map(&:key), 'events'
+    end
   end
 end


### PR DESCRIPTION
## Summary
- `CustomPage::SYSTEM_KEYS` でシステム用ページ（index/footer/top_message/blocking_ip_address）を判定できるようにし、`system_pages` / `non_system_pages` スコープと `system?` メソッドを追加
- `Admin::CustomPagesController#index` に `system=only` / `system=exclude` パラメータを追加（`q`・`discarded` フィルタと組み合わせ可能）
- 一覧画面（[app/views/admin/custom_pages/index.html.erb](app/views/admin/custom_pages/index.html.erb)）に「すべて表示 / システム用ページのみ / システム用ページを除く」の絞り込みリンクを追加

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `rubocop` で対象ファイルに指摘なし
- [x] `system=only` / `system=exclude` それぞれの絞り込み結果をコントローラテストで検証

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)