### PR TITLE
管理画面カスタムページ編集にサーバーサイドプレビューを追加

### DIFF
--- a/app/controllers/admin/custom_pages_controller.rb
+++ b/app/controllers/admin/custom_pages_controller.rb
@@ -70,6 +70,14 @@ module Admin
       render json: { url: rails_blob_path(@custom_page.images.last, disposition: :inline) }
     end
 
+    # {{include}}/{{snapshot}}/{{item}} 等のプラグイン記法を含め、実際の公開ページと
+    # 同じ ApplicationHelper#markdown でレンダリングしたHTMLを返す（issue #1089）。
+    # 新規作成中（未保存）の場合は id が渡らないため sectionable は nil になる。
+    def preview
+      custom_page = params[:id].present? ? CustomPage.with_discarded.find_by(id: params[:id]) : nil
+      render json: { html: helpers.markdown(params[:body].to_s, sectionable: custom_page) }
+    end
+
     private
 
     def set_custom_page

--- a/app/javascript/controllers/markdown_preview_controller.js
+++ b/app/javascript/controllers/markdown_preview_controller.js
@@ -1,8 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["textarea", "previewContent", "imageInput", "uploadStatus"]
-  static values = { uploadUrl: String }
+  static targets = ["textarea", "previewContent", "imageInput", "uploadStatus", "previewStatus"]
+  static values = { uploadUrl: String, previewUrl: String, customPageId: String }
 
   async connect() {
     const { marked } = await import("marked")
@@ -16,6 +16,41 @@ export default class extends Controller {
     this.previewContentTarget.innerHTML = text && this._marked
       ? this._marked.parse(text)
       : '<p class="text-gray-400 dark:text-gray-500 italic">本文を入力するとプレビューが表示されます</p>'
+    this.#setPreviewStatus("")
+  }
+
+  // {{include}}/{{snapshot}}/{{item}} 等のプラグイン記法を含め、実際の公開ページと
+  // 同じサーバーサイドレンダリングでプレビューする（issue #1089）。
+  // 本文を編集すると input イベントで updatePreview が呼ばれ、通常のクライアント側
+  // プレビューに自動的に戻る。
+  async serverPreview() {
+    if (!this.hasPreviewUrlValue) return
+
+    this.#setPreviewStatus("サーバーでレンダリング中...")
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+    const formData = new FormData()
+    formData.append("body", this.textareaTarget.value)
+    if (this.hasCustomPageIdValue && this.customPageIdValue) {
+      formData.append("id", this.customPageIdValue)
+    }
+
+    try {
+      const response = await fetch(this.previewUrlValue, {
+        method: "POST",
+        headers: { "X-CSRF-Token": csrfToken },
+        body: formData
+      })
+
+      if (!response.ok) throw new Error("Preview failed")
+
+      const data = await response.json()
+      this.previewContentTarget.innerHTML = data.html
+        || '<p class="text-gray-400 dark:text-gray-500 italic">本文を入力するとプレビューが表示されます</p>'
+      this.#setPreviewStatus("サーバーでの実際の描画結果です（編集すると通常のプレビューに戻ります）")
+    } catch {
+      this.#setPreviewStatus("プレビューの取得に失敗しました", 5000)
+    }
   }
 
   selectImage() {
@@ -69,6 +104,15 @@ export default class extends Controller {
       this.uploadStatusTarget.textContent = message
       if (clearAfterMs) {
         setTimeout(() => { this.uploadStatusTarget.textContent = "" }, clearAfterMs)
+      }
+    }
+  }
+
+  #setPreviewStatus(message, clearAfterMs = null) {
+    if (this.hasPreviewStatusTarget) {
+      this.previewStatusTarget.textContent = message
+      if (clearAfterMs) {
+        setTimeout(() => { this.previewStatusTarget.textContent = "" }, clearAfterMs)
       }
     }
   }

--- a/app/views/admin/custom_pages/_form.html.erb
+++ b/app/views/admin/custom_pages/_form.html.erb
@@ -1,4 +1,10 @@
-<%= form_with(model: [:admin, custom_page], class: "space-y-6") do |form| %>
+<%= form_with(model: [:admin, custom_page], class: "space-y-6",
+    data: {
+      controller: "markdown-preview",
+      markdown_preview_preview_url_value: preview_admin_custom_pages_path,
+      markdown_preview_custom_page_id_value: custom_page.persisted? ? custom_page.id : nil,
+      markdown_preview_upload_url_value: (custom_page.persisted? && current_user.admin?) ? upload_image_admin_custom_page_path(custom_page) : nil
+    }) do |form| %>
   <% if custom_page.errors.any? %>
     <div class="bg-red-50 p-4 rounded text-red-700 dark:bg-red-900 dark:text-red-200">
       <h2 class="font-semibold mb-2"><%= pluralize(custom_page.errors.count, "件") %>のエラーがあります:</h2>
@@ -32,11 +38,10 @@
         class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
   </div>
 
-  <div data-controller="markdown-preview"
-       <%= "data-markdown-preview-upload-url-value=\"#{upload_image_admin_custom_page_path(custom_page)}\"".html_safe if custom_page.persisted? && current_user.admin? %>>
+  <div>
     <div class="flex justify-between items-baseline">
       <%= form.label :body, "本文", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
-      <p class="text-xs text-gray-500 dark:text-gray-400">Markdown形式で記述できます</p>
+      <p class="text-xs text-gray-500 dark:text-gray-400">Markdown形式で記述できます（<code>{{include}}</code>/<code>{{snapshot}}</code>/<code>{{item}}</code> は「プレビュー」を押すと確認できます）</p>
     </div>
     <% if custom_page.persisted? && current_user.admin? %>
       <div class="mt-1 mb-2 flex items-center gap-3">
@@ -81,9 +86,18 @@
     <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">公開する（チェックなしは下書き）</span>
   </div>
 
-  <div class="flex justify-end gap-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+  <div class="flex items-center justify-end gap-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+    <span class="text-xs text-gray-500 dark:text-gray-400"
+          data-markdown-preview-target="previewStatus"
+          aria-live="polite"></span>
     <%= link_to "キャンセル", admin_custom_pages_path,
         class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
-    <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
+    <button type="button"
+            class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium border border-gray-300 rounded-md text-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:text-gray-100 dark:hover:bg-gray-700"
+            data-action="click->markdown-preview#serverPreview">
+      プレビュー
+    </button>
+    <%= form.submit custom_page.persisted? ? "更新" : "作成",
+        class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
   </div>
 <% end %>

--- a/app/views/admin/sections/_list.html.erb
+++ b/app/views/admin/sections/_list.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-white shadow rounded-lg p-6 mb-6 dark:bg-gray-900">
   <div class="flex items-center justify-between mb-4">
-    <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">Sections</h3>
-    <%= link_to "Add Section",
+    <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">セクション</h3>
+    <%= link_to "セクションを追加",
           new_admin_section_path(sectionable_type: sectionable.class.name, sectionable_id: sectionable.id),
           class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
   </div>
@@ -11,11 +11,11 @@
         <thead class="bg-gray-50 dark:bg-gray-800">
           <tr>
             <th scope="col" class="relative py-2 pl-4 pr-3 sm:pl-6 w-10">
-              <span class="sr-only">Sort</span>
+              <span class="sr-only">並び替え</span>
             </th>
-            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Name</th>
-            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">Format</th>
-            <th scope="col" class="relative py-2 pl-3 pr-4 sm:pr-6"><span class="sr-only">Actions</span></th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">名前</th>
+            <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">形式</th>
+            <th scope="col" class="relative py-2 pl-3 pr-4 sm:pr-6"><span class="sr-only">操作</span></th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700"
@@ -49,10 +49,10 @@
                         class: "text-green-600 hover:text-green-900 dark:text-green-400 dark:hover:text-green-300 bg-transparent border-0 p-0 cursor-pointer",
                         form_class: "inline" %>
                 <% else %>
-                  <%= link_to "Edit",
+                  <%= link_to "編集",
                         edit_admin_section_path(section, sectionable_type: sectionable.class.name, sectionable_id: sectionable.id),
                         class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 mr-4" %>
-                  <%= button_to "Delete",
+                  <%= button_to "削除",
                         admin_section_path(section, sectionable_type: sectionable.class.name, sectionable_id: sectionable.id),
                         method: :delete,
                         onclick: "return confirm('本当に削除しますか？')",
@@ -66,6 +66,6 @@
       </table>
     </div>
   <% else %>
-    <p class="text-sm text-gray-500 dark:text-gray-400">No sections yet.</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400">セクションはまだありません。</p>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         patch :undiscard
         post :upload_image
       end
+      collection do
+        post :preview
+      end
     end
 
     resources :sections, only: %i[new create edit update destroy] do

--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -28,6 +28,7 @@
 | Trends — 閲覧・作成・編集 | index / new / create / edit / update |
 | External Sites | 全アクション |
 | Custom Pages — 閲覧・作成・編集 | index / new / create / edit / update |
+| Custom Pages — サーバーサイドプレビュー（`{{include}}`/`{{snapshot}}`/`{{item}}` 等のプラグイン記法を反映） | preview |
 | Sections — 全操作 | new / create / edit / update / destroy / undiscard / reorder |
 | Unit Logs / Person Logs | 閲覧 |
 

--- a/test/controllers/admin/custom_pages_controller_test.rb
+++ b/test/controllers/admin/custom_pages_controller_test.rb
@@ -49,5 +49,33 @@ module Admin
       assert_not_includes @controller.view_assigns['custom_pages'].map(&:key), 'footer'
       assert_includes @controller.view_assigns['custom_pages'].map(&:key), 'events'
     end
+
+    test 'preview renders plugin macros via ApplicationHelper#markdown' do
+      item = Item.create!(title: 'Test Item', artists: [], release_date: Date.current,
+                          link_url: 'http://example.com/preview-item', asin: 'B000000001')
+
+      post preview_admin_custom_pages_path, params: { body: "{{item #{item.asin}}}" }
+
+      assert_response :success
+      json = response.parsed_body
+      assert_includes json['html'], item.title
+    end
+
+    test 'preview resolves self-referencing include plugin when id is given' do
+      custom_page = CustomPage.create!(key: 'events', title: 'イベント')
+      custom_page.sections.create!(name: 'greeting', markdown: 'こんにちは')
+
+      post preview_admin_custom_pages_path, params: { id: custom_page.id, body: '{{include ,greeting}}' }
+
+      assert_response :success
+      assert_equal '<p>こんにちは</p>', response.parsed_body['html'].strip
+    end
+
+    test 'preview without id treats page as new and skips self-referencing include' do
+      post preview_admin_custom_pages_path, params: { body: '{{include ,greeting}}' }
+
+      assert_response :success
+      assert_equal '', response.parsed_body['html'].strip
+    end
   end
 end


### PR DESCRIPTION
## Summary
- {{include}}/{{snapshot}}/{{item}} プラグイン記法を含めて実際の公開ページと同じレンダリング結果を確認できる「プレビュー」ボタンを追加
- `POST /admin/custom_pages/preview` を新設し、`ApplicationHelper#markdown` 経由でHTMLを返す
- 通常のクライアント側プレビュー（marked）はそのまま維持し、本文編集で自動的に元に戻る
- ボタンラベルの英語表記（Create/Update, Add Section, Edit, Delete 等）を日本語に統一
- `docs/admin/permissions.md` に新規アクション（preview）の権限区分を追記

## Test plan
- [x] `bin/rails test` が全件パスすること（308 runs, 1047 assertions, 0 failures）
- [x] `bundle exec rubocop` でオフェンスなし
- [ ] 管理画面でカスタムページを編集し、`{{item ASIN}}` 等を入力して「プレビュー」ボタンで実際の描画結果が表示されること

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)