### PR TITLE
build: Brakeman を 8.0.5 → 8.0.6 に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
## 概要
CI の `scan_ruby` ジョブが、diff の内容に関係なく全PRで失敗していた問題を修正する。

## 原因
[bin/brakeman](bin/brakeman) は `--ensure-latest` オプション付きで実行される。rubygems 上の最新版が `8.0.6` にリリースされた一方、`Gemfile.lock` は `8.0.5` に固定されたままだったため、Brakeman 自身の自己バージョンチェックに引っかかり `exit code 5` で毎回失敗していた。

```
Brakeman 8.0.5 is not the latest version 8.0.6
Process completed with exit code 5.
```

dependabot の複数PR（#1108〜#1114）と、無関係な機能修正PR（#1117）の両方で同じ理由の失敗を確認済み。中身の diff とは無関係な環境要因。

## 変更内容
`bundle update brakeman` により `Gemfile.lock` の brakeman を `8.0.5` → `8.0.6` に更新のみ。

## 確認
- ローカルで `bin/brakeman --no-pager` を実行し、Security Warnings: 0 で正常終了することを確認
- pre-push フックの RuboCop / テストも全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)