### PR TITLE
Markdownにdiv_begin/div_endプラグインを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,4 @@ Metrics/ClassLength:
     - 'app/models/person.rb'
     - 'app/services/base_wikipage_importer.rb'
     - 'test/services/custom_page_draft_generator_test.rb'
+    - 'test/helpers/application_helper_test.rb'

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -43,6 +43,23 @@
     td { padding: 0.5em 0.75em; border: 1px solid #e4e4e7; }
     tr:nth-child(even) td { background-color: #fafafa; }
     img { max-width: 100%; height: auto; border-radius: 0.25em; margin: 0.5em 0; }
+
+    /* {{div_begin class="closable" subject="..."}} プラグイン（折りたたみ表示） */
+    /* 開閉マーカーはブラウザ標準の<summary>表示に任せる */
+    details.closable {
+      margin: 1em 0;
+    }
+    details.closable summary {
+      cursor: pointer;
+      font-weight: 600;
+      padding: 0.25em;
+    }
+    details.closable summary:focus-visible {
+      outline: 2px solid #d97706;
+      outline-offset: 2px;
+      border-radius: 0.25em;
+    }
+    details.closable[open] summary { margin-bottom: 0.25em; }
   }
 
   @variant dark {
@@ -58,6 +75,7 @@
       th { background-color: #18181b; border-color: #27272a; color: #71717a; }
       td { border-color: #27272a; }
       tr:nth-child(even) td { background-color: #18181b; }
+      details.closable summary:focus-visible { outline-color: #f59e0b; }
     }
   }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,15 +120,31 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   PLUGIN_HANDLERS = {
     'include' => :expand_include_plugin,
     'snapshot' => :expand_snapshot_plugin,
-    'item' => :expand_item_plugin
+    'item' => :expand_item_plugin,
+    'div_begin' => :expand_div_begin_plugin,
+    'div_end' => :expand_div_end_plugin
   }.freeze
 
+  # パラメータ（{{プラグイン名 ...}} の "..." 部分）を省略した記法
+  # （例: {{div_end}}）も許可するプラグイン
+  PLUGINS_WITHOUT_REQUIRED_ARGS = %w[div_begin div_end].freeze
+
   def expand_plugin_macros(text, sectionable: nil, placeholders: {})
-    text.gsub(/\{\{(\w[\w-]*)\s+(.+?)\}\}/m) do
+    # {{div_begin}}で開いたタグの種類（:div / :details）を対応する{{div_end}}まで
+    # 覚えておくためのスタック。gsubはテキストを先頭から順に処理するため、
+    # 通常のネストした記法であればこの単純なスタックで正しく対応付けられる。
+    open_tags = []
+
+    text.gsub(/\{\{(\w[\w-]*)(?:\s+(.+?))?\}\}/m) do
       plugin_name = Regexp.last_match(1)
-      args = Regexp.last_match(2).strip
+      args = Regexp.last_match(2)&.strip
       handler = PLUGIN_HANDLERS[plugin_name]
-      handler ? send(handler, args, sectionable, placeholders) : Regexp.last_match(0)
+
+      if handler && (args.present? || PLUGINS_WITHOUT_REQUIRED_ARGS.include?(plugin_name))
+        send(handler, args, sectionable, placeholders, open_tags)
+      else
+        Regexp.last_match(0)
+      end
     end
   end
 
@@ -154,7 +170,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # {{include person:ID,セクション名}} → Person (ID指定)
   # {{include ,セクション名}}          → 自身のページ (key省略・カンマあり)
   # {{include セクション名}}           → 自身のページ (key省略・カンマなし)
-  def expand_include_plugin(args, sectionable, _placeholders)
+  def expand_include_plugin(args, sectionable, _placeholders, _open_tags)
     identifier, section_name = args.include?(',') ? args.split(',', 2) : [nil, args]
     identifier = identifier&.strip
     section_name = section_name.strip
@@ -174,7 +190,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # {{snapshot ユニットkey,snapshot_id}}
-  def expand_snapshot_plugin(args, _sectionable, placeholders)
+  def expand_snapshot_plugin(args, _sectionable, placeholders, _open_tags)
     unit_key, snapshot_id = args.split(',', 2).map(&:strip)
     return '' if unit_key.blank? || snapshot_id.blank?
 
@@ -187,7 +203,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # {{item ASIN}}
-  def expand_item_plugin(args, _sectionable, placeholders)
+  def expand_item_plugin(args, _sectionable, placeholders, _open_tags)
     asin = args.strip
     return '' if asin.blank?
 
@@ -196,5 +212,45 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
 
     html = render(ItemCardComponent.new(item_card: item)).to_s
     register_plugin_placeholder(placeholders, html)
+  end
+
+  # HTML属性インジェクション対策のため、div_beginで出力できる属性は class / subject のみに限定する。
+  # それ以外の記述（例: {{div_begin onclick="..."}}）は無視する。
+  DIV_BEGIN_ALLOWED_ATTRS = %w[class subject].freeze
+
+  # {{div_begin class="value"}}                     → <div class="value">
+  # {{div_begin}}                                    → <div>
+  # {{div_begin class="closable" subject="見出し"}} → 折りたたみ表示（初期状態は閉じている）。
+  #   <details class="closable"><summary>見出し</summary> を出力し、
+  #   ラベルのクリックで開閉する（class="closable" と subject の両方が揃った場合のみ）。
+  #   開閉マーカーは<summary>のブラウザ標準表示に任せる。
+  def expand_div_begin_plugin(args, _sectionable, placeholders, open_tags)
+    attrs = parse_allowed_attrs(args, DIV_BEGIN_ALLOWED_ATTRS)
+    class_value = attrs['class']
+    subject_value = attrs['subject']
+
+    html = if class_value == 'closable' && subject_value.present?
+             open_tags.push(:details)
+             "<details class=\"closable\"><summary>#{CGI.escapeHTML(subject_value)}</summary>"
+           else
+             open_tags.push(:div)
+             class_value.present? ? %(<div class="#{CGI.escapeHTML(class_value)}">) : '<div>'
+           end
+    register_plugin_placeholder(placeholders, html)
+  end
+
+  # {{div_end}} → 対応する{{div_begin}}の種類に応じて </div> または </details> を出力する
+  def expand_div_end_plugin(_args, _sectionable, placeholders, open_tags)
+    html = open_tags.pop == :details ? '</details>' : '</div>'
+    register_plugin_placeholder(placeholders, html)
+  end
+
+  # "key=\"value\"" または "key='value'" 形式の属性のうち allowed_names に含まれるものだけを抽出する
+  def parse_allowed_attrs(args, allowed_names)
+    attrs = {}
+    args.to_s.scan(/(\w[\w-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/) do |name, double_quoted, single_quoted|
+      attrs[name] = double_quoted || single_quoted || '' if allowed_names.include?(name)
+    end
+    attrs
   end
 end

--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -10,9 +10,10 @@ class CustomPageDraftGenerator
   Draft = Struct.new(:wikipage_id, :key, :title, :old_key, :body, :warnings, keyword_init: true)
 
   # 変換せずそのまま残すプラグイン。
-  # snapshot / item は CustomPage の markdown ヘルパー（ApplicationHelper#expand_plugin_macros）が
-  # そのまま解釈できる。div_begin / div / member は現時点では未対応だが、CustomPage側での対応を
-  # 予定しているため、TODOコメント化せず元の記法のまま残す。
+  # snapshot / item / div_begin は CustomPage の markdown ヘルパー
+  # （ApplicationHelper#expand_plugin_macros）がそのまま解釈できる（Issue#1105でdiv_begin/div_end対応）。
+  # div / member は現時点では未対応だが、CustomPage側での対応を予定しているため、
+  # TODOコメント化せず元の記法のまま残す。
   # include は旧FreeStyleWiki記法と引数の意味が異なる（IncludePluginConverter参照）ため対象外。
   SUPPORTED_PLUGINS = %w[snapshot item div_begin div member].freeze
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -131,4 +131,87 @@ class ApplicationHelperTest < ActionView::TestCase
 
     assert_match(/前後/, result)
   end
+
+  test '{{div_begin class="..."}}と{{div_end}}でdivタグが出力される' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="closable"}}
+
+      本文
+
+      {{div_end}}
+    MARKDOWN
+
+    assert_match(/<div class="closable">/, result)
+    assert_match(%r{</div>}, result)
+    assert_match(/本文/, result)
+  end
+
+  test '{{div_begin}}（属性なし）はclass属性なしのdivタグを出力する' do
+    result = markdown('{{div_begin}}本文{{div_end}}')
+
+    assert_match(/<div>/, result)
+    assert_no_match(/class=/, result)
+  end
+
+  test '{{div_begin}}はclass以外の属性を無視する（属性インジェクション対策）' do
+    result = markdown('{{div_begin onclick="alert(1)"}}本文{{div_end}}')
+
+    assert_no_match(/onclick/, result)
+  end
+
+  test '{{div_begin class="..."}}のclass値はHTMLエスケープされる' do
+    result = markdown('{{div_begin class="a&b"}}本文{{div_end}}')
+
+    assert_match(/class="a&amp;b"/, result)
+  end
+
+  test '{{div_begin class="closable" subject="..."}}は折りたたみ(details/summary)で出力される' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="closable" subject="メンバー"}}
+
+      本文
+
+      {{div_end}}
+    MARKDOWN
+
+    assert_match(/<details class="closable">/, result)
+    assert_match(%r{<summary>メンバー</summary>}, result)
+    assert_match(%r{</details>}, result)
+    assert_no_match(%r{</div>}, result)
+    # 初期状態は折りたたみ（open属性なし）であること
+    assert_no_match(/<details[^>]*\bopen\b/, result)
+  end
+
+  test 'subject指定でもclass="closable"がなければ通常のdivのまま(折りたたみにならない)' do
+    result = markdown('{{div_begin subject="メンバー"}}本文{{div_end}}')
+
+    assert_no_match(/<details/, result)
+    assert_no_match(/summary/, result)
+    assert_match(/<div>/, result)
+  end
+
+  test '{{div_begin class="closable" subject="..."}}のsubject値はHTMLエスケープされる' do
+    result = markdown('{{div_begin class="closable" subject="a&b"}}本文{{div_end}}')
+
+    assert_match(%r{<summary>a&amp;b</summary>}, result)
+  end
+
+  test '{{div_begin}}のネストで対応する{{div_end}}が正しいタグを閉じる' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="closable" subject="外側"}}
+
+      {{div_begin class="inner"}}
+
+      本文
+
+      {{div_end}}
+
+      {{div_end}}
+    MARKDOWN
+
+    assert_match(/<details class="closable">/, result)
+    assert_match(/<div class="inner">/, result)
+    assert_match(%r{</div>}, result)
+    assert_match(%r{</details>}, result)
+  end
 end


### PR DESCRIPTION
## Summary
- `{{div_begin class="value"}}` → `<div class="value">` を出力（出力できる属性は `class` のみに限定し、それ以外の記述はHTML属性インジェクション対策として無視）
- `{{div_begin class="closable" subject="見出し"}}` → `<details class="closable"><summary>見出し</summary>` による折りたたみ表示（初期状態は閉じる／ネイティブ要素のためキーボード操作・スクリーンリーダー対応が標準で確保される。開閉マーカーもブラウザ標準表示に任せている）
- `{{div_end}}` → 対応する `{{div_begin}}` の種類に応じて `</div>` または `</details>` を出力（開いたタグをスタックで追跡しネストにも対応）
- `markdown-content` 用CSSに `details.closable` の表示・フォーカス時アウトラインを追加（WCAG AA配慮）
- `custom_page_draft_generator.rb` のコメントを実装状況に合わせて更新

## Test plan
- [x] `bundle exec rails test` が全件パスすること（pre-pushフックで確認済み）
- [x] `bundle exec rubocop` で指摘なし
- [ ] 実際のCustomPage編集画面で `{{div_begin}}` / `{{div_end}}` の表示を目視確認

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)