### PR TITLE
カスタムページ編集フォームの操作ボタンをカード内で下部固定に

### DIFF
--- a/app/views/admin/custom_pages/_form.html.erb
+++ b/app/views/admin/custom_pages/_form.html.erb
@@ -86,7 +86,7 @@
     <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">公開する（チェックなしは下書き）</span>
   </div>
 
-  <div class="flex items-center justify-end gap-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+  <div class="sticky bottom-0 z-10 -mx-6 -mb-6 flex items-center justify-end gap-x-4 rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
     <span class="text-xs text-gray-500 dark:text-gray-400"
           data-markdown-preview-target="previewStatus"
           aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- カスタムページ管理画面（新規作成・編集）のキャンセル/プレビュー/更新ボタン行を、フォームを囲むカード内で `position: sticky; bottom: 0` により画面下部に固定表示するようにした
- 背景を半透明+ぼかしにして、スクロールされてくる本文プレビュー等が透けて読みにくくならないようにした
- `_form.html.erb` は new/edit 両画面で共有されているため、どちらにも同じ挙動が適用される

## Test plan
- [x] `bin/rails test` が全件パスすること（322 runs, 0 failures）
- [ ] カスタムページの新規作成・編集画面で、本文を長く入力した状態でスクロールしてもボタン行が画面下部に留まることを目視確認
- [ ] ダークモードでも背景・コントラストが崩れないことを確認

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)