### PR TITLE
Markdownに{{member}}プラグインを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,7 +122,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     'snapshot' => :expand_snapshot_plugin,
     'item' => :expand_item_plugin,
     'div_begin' => :expand_div_begin_plugin,
-    'div_end' => :expand_div_end_plugin
+    'div_end' => :expand_div_end_plugin,
+    'member' => :expand_member_plugin
   }.freeze
 
   # パラメータ（{{プラグイン名 ...}} の "..." 部分）を省略した記法
@@ -212,6 +213,40 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
 
     html = render(ItemCardComponent.new(item_card: item)).to_s
     register_plugin_placeholder(placeholders, html)
+  end
+
+  # {{member パート,表示名,old_key}}（old_keyは未エンコード）
+  # 例: {{member Vocal,のる,のる(ex-ふりぃ)}}
+  # old_keyをEUC-JPエンコードしてPeopleを検索し、Unitページのメンバー行
+  # （MemberRowComponent）と同じ経歴カードを出力する。
+  def expand_member_plugin(args, _sectionable, placeholders, _open_tags)
+    part, display_name, raw_old_key = args.split(',', 3).map { |v| v&.strip }
+    return '' if part.blank? || display_name.blank? || raw_old_key.blank?
+
+    person = Person.kept.find_by(old_key: encode_member_old_key(raw_old_key))
+    return '' unless person
+
+    member = MemberPluginRow.new(part: part, name: display_name, person: person)
+    html = render(MemberRowComponent.new(member: member, hide_status: true))
+    register_plugin_placeholder(placeholders, html)
+  end
+
+  # People#old_key は URI.encode_www_form_component(EUC-JP) 形式で保存されている
+  # （app/services/person_importer.rb, wikipage_importer.rb と同じ変換）
+  def encode_member_old_key(text)
+    URI.encode_www_form_component(text.encode('EUC-JP'))
+  rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
+    text
+  end
+
+  # {{member}}プラグイン用の軽量な行データ。UnitPerson/SnapshotPersonと異なりDBに
+  # 永続化しない埋め込み表示のためのラッパーで、MemberRowComponentが要求する
+  # インターフェース（part / name / person / part_alias / sns / inline_history / status / support?）
+  # のうち、プラグインが受け取らない属性はすべて未指定（nil・非サポート）として扱う。
+  MemberPluginRow = Struct.new(:part, :name, :person, :part_alias, :sns, :inline_history, :status, keyword_init: true) do
+    def support?
+      false
+    end
   end
 
   # HTML属性インジェクション対策のため、div_beginで出力できる属性は class / subject のみに限定する。

--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -10,9 +10,10 @@ class CustomPageDraftGenerator
   Draft = Struct.new(:wikipage_id, :key, :title, :old_key, :body, :warnings, keyword_init: true)
 
   # 変換せずそのまま残すプラグイン。
-  # snapshot / item / div_begin は CustomPage の markdown ヘルパー
-  # （ApplicationHelper#expand_plugin_macros）がそのまま解釈できる（Issue#1105でdiv_begin/div_end対応）。
-  # div / member は現時点では未対応だが、CustomPage側での対応を予定しているため、
+  # snapshot / item / div_begin / member は CustomPage の markdown ヘルパー
+  # （ApplicationHelper#expand_plugin_macros）がそのまま解釈できる
+  # （Issue#1105でdiv_begin/div_end対応、Issue#1107でmember対応）。
+  # div は現時点では未対応だが、CustomPage側での対応を予定しているため、
   # TODOコメント化せず元の記法のまま残す。
   # include は旧FreeStyleWiki記法と引数の意味が異なる（IncludePluginConverter参照）ため対象外。
   SUPPORTED_PLUGINS = %w[snapshot item div_begin div member].freeze

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -214,4 +214,39 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(%r{</div>}, result)
     assert_match(%r{</details>}, result)
   end
+
+  test '{{member パート,表示名,old_key}}でold_keyに一致するPersonの経歴カードが埋め込まれる' do
+    Person.create!(name: 'のる', key: 'member-plugin-person',
+                   old_key: URI.encode_www_form_component('のる(ex-ふりぃ)'.encode('EUC-JP')))
+
+    result = markdown('{{member Vocal,のる,のる(ex-ふりぃ)}}')
+
+    assert_match(/のる/, result)
+    assert_match(%r{href="/member-plugin-person"}, result)
+  end
+
+  test '{{member}}は表示名(第2引数)をそのまま表示し、Personのnameとは独立している' do
+    Person.create!(name: 'DB上の名前', key: 'member-plugin-person2',
+                   old_key: URI.encode_www_form_component('旧名'.encode('EUC-JP')))
+
+    result = markdown('{{member Vocal,表示用の名前,旧名}}')
+
+    assert_match(/表示用の名前/, result)
+    assert_no_match(/DB上の名前/, result)
+  end
+
+  test '{{member}}で一致するPersonが見つからない場合は空文字になる' do
+    result = markdown('前{{member Vocal,のる,存在しないキー}}後')
+
+    assert_match(/前後/, result)
+  end
+
+  test '{{member}}はステータスバッジを表示しない' do
+    Person.create!(name: 'のる', key: 'member-plugin-person3',
+                   old_key: URI.encode_www_form_component('のる3'.encode('EUC-JP')))
+
+    result = markdown('{{member Vocal,のる,のる3}}')
+
+    assert_no_match(/undefined/, result)
+  end
 end


### PR DESCRIPTION
## Summary
- `{{member パート,表示名,old_key}}`（old_keyは未エンコード）記法を追加。old_keyをEUC-JPエンコードして一致する`Person`を検索し、Unitページのメンバー行（`MemberRowComponent`）と同じ経歴カードを埋め込む
- 一致する`Person`が見つからない場合は空文字列を出力する（他プラグインと同様の挙動）
- `custom_page_draft_generator.rb`のコメントを実装状況に合わせて更新（Issue#1105でdiv_begin/div_end対応、Issue#1107でmember対応）

## Test plan
- [x] `bin/rails test` が全件パスすること（326 runs, 0 failures）
- [x] `bundle exec rubocop` がクリーンであること
- [ ] 実際にold_keyが一致するPersonを含むMarkdown（CustomPage/Section）でプレビュー表示を確認する

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)