### PR TITLE
Markdownに複数行プラグイン記法{{member2}}を追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -123,14 +123,25 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     'item' => :expand_item_plugin,
     'div_begin' => :expand_div_begin_plugin,
     'div_end' => :expand_div_end_plugin,
-    'member' => :expand_member_plugin
+    'member' => :expand_member_plugin,
+    'member2' => :expand_member2_plugin
   }.freeze
 
   # パラメータ（{{プラグイン名 ...}} の "..." 部分）を省略した記法
   # （例: {{div_end}}）も許可するプラグイン
   PLUGINS_WITHOUT_REQUIRED_ARGS = %w[div_begin div_end].freeze
 
+  # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。
+  # 1行目に閉じの"}}"がなければ複数行プラグインとみなし、次に現れる
+  # "}}"のみの行までをdataとして扱う（本文中に{{fn ...}}のような単行プラグインが
+  # ネストしていても、それ単体では終端と誤認しない）。
+  MULTILINE_PLUGIN_HANDLERS = {
+    'member2' => :expand_member2_plugin
+  }.freeze
+
   def expand_plugin_macros(text, sectionable: nil, placeholders: {})
+    text = expand_multiline_plugin_macros(text, sectionable, placeholders)
+
     # {{div_begin}}で開いたタグの種類（:div / :details）を対応する{{div_end}}まで
     # 覚えておくためのスタック。gsubはテキストを先頭から順に処理するため、
     # 通常のネストした記法であればこの単純なスタックで正しく対応付けられる。
@@ -146,6 +157,22 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
       else
         Regexp.last_match(0)
       end
+    end
+  end
+
+  # {{プラグイン名 1行目のパラメータ\n複数行のdata\n}}
+  # 1行目末尾に"}}"がない（=閉じていない）場合のみ複数行プラグインとして扱う。
+  # 終端は単独で"}}"だけの行。
+  def expand_multiline_plugin_macros(text, sectionable, placeholders)
+    names = Regexp.union(MULTILINE_PLUGIN_HANDLERS.keys)
+
+    text.gsub(/\{\{(#{names})(?:[ \t]+([^\n]*))?\n(.*?)\n[ \t]*\}\}[ \t]*$/m) do
+      plugin_name = Regexp.last_match(1)
+      args = Regexp.last_match(2)&.strip
+      data = Regexp.last_match(3)
+      handler = MULTILINE_PLUGIN_HANDLERS[plugin_name]
+
+      send(handler, args, sectionable, placeholders, [], data)
     end
   end
 
@@ -243,10 +270,49 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # 永続化しない埋め込み表示のためのラッパーで、MemberRowComponentが要求する
   # インターフェース（part / name / person / part_alias / sns / inline_history / status / support?）
   # のうち、プラグインが受け取らない属性はすべて未指定（nil・非サポート）として扱う。
+  # inline_historyはmember2（old_key不一致時）でのみ使用し、parse_inline_historyで
+  # UnitPerson同様WikiParser#parse_history_stringに委譲する。
   MemberPluginRow = Struct.new(:part, :name, :person, :part_alias, :sns, :inline_history, :status, keyword_init: true) do
+    include WikiParser
+
     def support?
       false
     end
+
+    def parse_inline_history
+      parse_history_string(inline_history)
+    end
+  end
+
+  # {{member2 パート,表示名,old_key,SNS\nメンバー経歴\n}}
+  # （old_key・SNSは未エンコード・省略可。old_keyは"-"でも未指定扱い）
+  # 例:
+  #   {{member2 Bass,森川泰敬
+  #   → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+  #   }}
+  # old_keyが一致するPersonが見つかればmemberプラグインと同様にそのPersonの経歴を出力する。
+  # 一致しない（またはold_key省略・"-"指定）場合は、ブロック内のdata（1行目以降）を
+  # そのメンバー自身の経歴として扱い、経歴カードを出力する（[Label](URL)形式のリンクや
+  # {{fn ...}}のような注記プラグインを含められる。WikiParser#parse_history_string参照）。
+  # SNSはold_keyの一致有無にかかわらず指定があれば表示する。
+  # 単独行（{{member2 パート,表示名,old_key}}）で使った場合はdataなしのmemberプラグイン相当になる。
+  def expand_member2_plugin(args, _sectionable, placeholders, _open_tags, data = nil)
+    part, display_name, raw_old_key, sns_value = args.to_s.split(',', 4).map { |v| v&.strip }
+    return '' if part.blank? || display_name.blank?
+
+    raw_old_key = nil if raw_old_key.blank? || raw_old_key == '-'
+    person = raw_old_key && Person.kept.find_by(old_key: encode_member_old_key(raw_old_key))
+
+    member = MemberPluginRow.new(
+      part: part,
+      name: display_name,
+      person: person,
+      sns: sns_value.presence && [sns_value],
+      inline_history: person ? nil : data.to_s.strip.presence
+    )
+
+    html = render(MemberRowComponent.new(member: member, hide_status: true))
+    register_plugin_placeholder(placeholders, html)
   end
 
   # HTML属性インジェクション対策のため、div_beginで出力できる属性は class / subject のみに限定する。

--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -12,7 +12,7 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
   #   ],
   #   ...
   # ]
-  def parse_history_string(history_text) # rubocop:disable Metrics/PerceivedComplexity
+  def parse_history_string(history_text) # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize
     return [] if history_text.blank?
 
     # Filter out comment lines starting with //
@@ -70,6 +70,21 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
             unit_name: display_unit_name,
             part_and_name: part_and_name&.strip,
             old_key: encoded_unit_name,
+            notes: metadata[:notes]
+          }
+        # Pattern 1b: [Label](target) or [Label](target)(Part) - Markdown形式のリンク
+        # （CustomPageDraftGeneratorが旧[[Label|target]]記法から変換した経歴テキストなどで使用される）
+        when /\[([^\]]+)\]\(([^)]+)\)(?:\(([^)]+)\))?/
+          link_text = ::Regexp.last_match(1)
+          target = ::Regexp.last_match(2)
+          part_and_name = ::Regexp.last_match(3)
+
+          display_link_text = wrapped_in_parens ? "(#{link_text.strip})" : link_text.strip
+
+          concurrent_items << {
+            unit_name: display_link_text,
+            part_and_name: part_and_name&.strip,
+            external_url: target.strip,
             notes: metadata[:notes]
           }
         # Pattern 2: [LinkText|URL] or [LinkText|URL](Part) - External link

--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -6,17 +6,24 @@
 # 本番DBとローカルDBが分離しているため、このクラスはローカル環境でのみ使用し、
 # 生成した下書きは人手で本番の管理画面へ貼り付けて仕上げる運用を想定している。
 # （lib/tasks/custom_page_drafts.rake から呼び出す）
-class CustomPageDraftGenerator
+class CustomPageDraftGenerator # rubocop:disable Metrics/ClassLength
   Draft = Struct.new(:wikipage_id, :key, :title, :old_key, :body, :warnings, keyword_init: true)
 
   # 変換せずそのまま残すプラグイン。
-  # snapshot / item / div_begin / member は CustomPage の markdown ヘルパー
+  # snapshot / item / div_begin / member / member2 は CustomPage の markdown ヘルパー
   # （ApplicationHelper#expand_plugin_macros）がそのまま解釈できる
-  # （Issue#1105でdiv_begin/div_end対応、Issue#1107でmember対応）。
+  # （Issue#1105でdiv_begin/div_end対応、Issue#1107でmember対応、Issue#1123でmember2対応）。
   # div は現時点では未対応だが、CustomPage側での対応を予定しているため、
   # TODOコメント化せず元の記法のまま残す。
   # include は旧FreeStyleWiki記法と引数の意味が異なる（IncludePluginConverter参照）ため対象外。
-  SUPPORTED_PLUGINS = %w[snapshot item div_begin div member].freeze
+  SUPPORTED_PLUGINS = %w[snapshot item div_begin div member member2].freeze
+
+  # 複数行プラグイン（現状member2のみ）。1行目に閉じの"}}"がない場合、次に現れる
+  # "}}"のみの行までを1つのブロックとして扱う（ApplicationHelper#expand_multiline_plugin_macros
+  # と同じ判定）。flag_unsupported_pluginsの単純な行内gsubは、ブロック内に{{fn ...}}のような
+  # 単行プラグインがネストしていると最初に現れた"}}"で閉じたと誤認し、記法を途中で
+  # 切断してしまう（Issue#1123）ため、先にこの記法をプレースホルダへ退避しておく。
+  MULTILINE_SUPPORTED_PLUGINS = %w[member2].freeze
 
   # 旧FreeStyleWikiの {{include ページ名,セクション名}} は「他ページの内容をページ名で
   # 丸ごと埋め込む」記法だが、新CustomPageの {{include}} マクロ
@@ -192,7 +199,10 @@ class CustomPageDraftGenerator
   # コメントで目印を付けて後で人手対応してもらう。include は個別に検証する
   # （IncludePluginConverter参照）ため、ここでは判定対象から除く。
   def flag_unsupported_plugins(text)
-    text.gsub(/\{\{(\w[\w-]*)\s+(.+?)\}\}/m) do
+    blocks = []
+    text = protect_multiline_plugin_blocks(text, blocks)
+
+    text = text.gsub(/\{\{(\w[\w-]*)\s+(.+?)\}\}/m) do
       match = Regexp.last_match(0)
       plugin_name = Regexp.last_match(1)
       args = Regexp.last_match(2)
@@ -203,6 +213,27 @@ class CustomPageDraftGenerator
       @warnings << "未対応プラグイン #{plugin_name} を検出しました（要手動対応）"
       "<!-- TODO: 要手動対応 元記法: #{match} -->"
     end
+
+    restore_multiline_plugin_blocks(text, blocks)
+  end
+
+  # {{member2 ...}}のような複数行プラグイン記法を丸ごとプレースホルダに退避する。
+  # 終端は単独で"}}"だけの行（ブロック内に{{fn ...}}等がネストしていても、
+  # それ単体を終端と誤認しない）。
+  def protect_multiline_plugin_blocks(text, blocks)
+    names = Regexp.union(MULTILINE_SUPPORTED_PLUGINS)
+    text.gsub(/\{\{(?:#{names})(?:[ \t]+[^\n]*)?\n.*?\n[ \t]*\}\}[ \t]*$/m) do |block|
+      token = "⟦MULTILINE_PLUGIN_#{blocks.length}⟧"
+      blocks << block
+      token
+    end
+  end
+
+  def restore_multiline_plugin_blocks(text, blocks)
+    blocks.each_with_index do |block, index|
+      text = text.sub("⟦MULTILINE_PLUGIN_#{index}⟧") { block }
+    end
+    text
   end
 
   # convert_headings で挿入した空行により3行以上の連続改行ができた場合、空行1つに正規化する

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -249,4 +249,91 @@ class ApplicationHelperTest < ActionView::TestCase
 
     assert_no_match(/undefined/, result)
   end
+
+  test '{{member2}}はold_keyが一致しない場合、複数行のdataをメンバー自身の経歴として出力する' do
+    result = markdown(<<~MARKDOWN)
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+      }}
+    MARKDOWN
+
+    assert_match(/森川泰敬/, result)
+    assert_match(/GLAMOROUS HONEY/, result)
+    assert_match(%r{href="/glamorous-honey"}, result)
+    assert_match(%r{2006/05/10加入}, result)
+  end
+
+  test '{{member2}}はブロック内にネストした{{fn ...}}を終端の"}}"と誤認しない' do
+    result = markdown(<<~MARKDOWN)
+      前
+
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+      、[別ユニット](/other-unit)
+      }}
+
+      後
+    MARKDOWN
+
+    assert_match(/前/, result)
+    assert_match(/後/, result)
+    assert_match(/別ユニット/, result)
+  end
+
+  test '{{member2}}はold_keyが一致するPersonが見つかればmemberプラグインと同様にそのPersonの経歴を出力する' do
+    Person.create!(name: 'のる', key: 'member2-plugin-person',
+                   old_key: URI.encode_www_form_component('のる(ex-ふりぃ)'.encode('EUC-JP')))
+
+    result = markdown(<<~MARKDOWN)
+      {{member2 Vocal,のる,のる(ex-ふりぃ)
+      この行はold_key一致時には使われない
+      }}
+    MARKDOWN
+
+    assert_match(%r{href="/member2-plugin-person"}, result)
+    assert_no_match(/この行はold_key一致時には使われない/, result)
+  end
+
+  test '{{member2}}はold_key省略時、常にdataをメンバー自身の経歴として扱う' do
+    result = markdown(<<~MARKDOWN)
+      {{member2 Guitar,テストギタリスト
+      [別ユニット2](/other-unit2)
+      }}
+    MARKDOWN
+
+    assert_match(/テストギタリスト/, result)
+    assert_match(/別ユニット2/, result)
+  end
+
+  test '{{member2 パート,表示名,old_key}}（1行・dataなし）はmemberプラグイン相当として動作する' do
+    Person.create!(name: 'のる', key: 'member2-plugin-person-inline',
+                   old_key: URI.encode_www_form_component('のる4'.encode('EUC-JP')))
+
+    result = markdown('{{member2 Vocal,のる,のる4}}')
+
+    assert_match(%r{href="/member2-plugin-person-inline"}, result)
+  end
+
+  test '{{member2 パート,表示名,old_key,SNS}}（4番目のパラメータ）はold_keyの一致有無にかかわらずSNSリンクを表示する' do
+    result = markdown(<<~MARKDOWN)
+      {{member2 Bass,泉,泉(ex-蟋蟀),http://ameblo.jp/bass-izumi/
+      → [蟋蟀](/koorogi) → 個人/フリー
+      }}
+    MARKDOWN
+
+    assert_match(%r{href="http://ameblo.jp/bass-izumi/"}, result)
+    assert_match(/蟋蟀/, result)
+  end
+
+  test '{{member2}}のold_keyが"-"（未指定）の場合はPersonを検索せずdataを経歴として扱う' do
+    result = markdown(<<~MARKDOWN)
+      {{member2 Guitar,神谷 英希,-
+      → [くりから。](/kurikara)(一期) → (隠密華撃団) → [くりから。](/kurikara)(二期) →
+      }}
+    MARKDOWN
+
+    assert_match(/神谷 英希/, result)
+    assert_match(/くりから。/, result)
+    assert_match(/隠密華撃団/, result)
+  end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -83,6 +83,35 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert_equal 'Rem.', concurrent[2][:part_and_name]
   end
 
+  test 'parse_old_history parses Markdown形式のリンク[Label](URL)をexternal_urlとして扱う' do
+    # CustomPageDraftGeneratorが旧[[Label|target]]記法から変換した後の経歴テキストを想定
+    history_str = '→ [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}'
+    person = Person.new(old_history: history_str)
+    history = person.parse_old_history
+
+    assert_equal 1, history.size
+    item = history[0][0]
+    assert_equal 'GLAMOROUS HONEY', item[:unit_name]
+    assert_equal '/glamorous-honey', item[:external_url]
+    assert_equal ['2006/05/10加入'], item[:notes]
+  end
+
+  test 'parse_old_history はMarkdown形式のリンクに続く(Part)をpart_and_nameとして扱う' do
+    history_str = '[くりから。](/kurikara)(一期) → (隠密華撃団) → [くりから。](/kurikara)(二期)'
+    person = Person.new(old_history: history_str)
+    history = person.parse_old_history
+
+    assert_equal 3, history.size
+    assert_equal 'くりから。', history[0][0][:unit_name]
+    assert_equal '/kurikara', history[0][0][:external_url]
+    assert_equal '一期', history[0][0][:part_and_name]
+
+    assert_equal '(隠密華撃団)', history[1][0][:unit_name]
+
+    assert_equal 'くりから。', history[2][0][:unit_name]
+    assert_equal '二期', history[2][0][:part_and_name]
+  end
+
   test 'parse_old_history handles parens wrapping correctly' do
     person = Person.new(old_history: '(Solo) → (BandA)')
     history = person.parse_old_history

--- a/test/services/custom_page_draft_generator_test.rb
+++ b/test/services/custom_page_draft_generator_test.rb
@@ -110,6 +110,25 @@ class CustomPageDraftGeneratorTest < ActiveSupport::TestCase
     assert_empty draft.warnings
   end
 
+  test '{{member2 ...}}（複数行）はTODO化せずそのまま残り、内部の{{fn ...}}で途中切断されない（Issue#1123）' do
+    wiki = <<~WIKI
+      {{member Vocal,相馬 ジュン平,-,http://smjp.jugem.jp/}}
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY|/glamorous-honey]{{fn 2006/05/10加入}}
+      }}
+      {{member Drums,和也,和也(ex-VIRULENT),http://ameblo.jp/virulent-kazuya/}}
+    WIKI
+    draft = generate(name: 'test', wiki: wiki)
+
+    assert_includes draft.body, <<~EXPECTED.strip
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+      }}
+    EXPECTED
+    assert_includes draft.body, '{{member Drums,和也,和也(ex-VIRULENT),http://ameblo.jp/virulent-kazuya/}}'
+    assert_empty draft.warnings
+  end
+
   test '{{include unit:ID,セクション名}} は対象のUnitに同名のSectionがあればそのまま残る' do
     unit = Unit.create!(name: 'テストバンド2', key: 'test-band2-for-draft-generator')
     unit.sections.create!(name: '概要', wiki_text: '本文')


### PR DESCRIPTION
## Summary
- `{{member2 パート,表示名,old_key,SNS\nメンバー経歴\n}}` を追加。1行目末尾に閉じの`}}`がない場合は複数行プラグインとみなし、次に現れる**単独の`}}`行**までをdataとして扱う（ブロック内に`{{fn ...}}`のような単行プラグインがネストしていても、それを終端と誤認しない）
- old_keyが一致する`Person`が見つかれば`member`プラグインと同様にそのPersonの経歴を出力し、一致しなければdataをメンバー自身の経歴として出力する。SNS（4番目のパラメータ）はold_keyの一致有無にかかわらず表示する
- `WikiParser#parse_history_string` にMarkdown形式のリンク（`[Label](URL)`）を認識するパターンを追加。`CustomPageDraftGenerator`が旧`[[Label|target]]`記法から変換した後の経歴テキストが実際にこの形式になるため（実データ: `tmp/custom_page_drafts/13992_...md`で確認）
- `CustomPageDraftGenerator`をmember2に対応: `SUPPORTED_PLUGINS`に追加し、複数行ブロックをプレースホルダへ退避してから行内プラグイン判定を行うことで、`{{fn ...}}`等のネストによる誤った記法切断（`未対応プラグイン member2`警告と本文破損）を防止

## Test plan
- [x] `bin/rails test` が全件パスすること（336 runs, 0 failures）
- [x] `bundle exec rubocop` がクリーンであること
- [x] `WIKIPAGE_ID=13992 bundle exec rails custom_page_drafts:generate` を実行し、実データの3件の`{{member2 ...}}`ブロックが警告なし・記法を壊さず出力されることを確認
- [ ] 実際にCustomPageのMarkdownで`{{member2}}`をプレビューし、表示を目視確認する

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)