### PR TITLE
Markdownプラグイン(item/member/member2/snapshot)の描画結果をキャッシュ

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
+require 'digest'
 
 module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   class ExternalAwareHtmlRenderer < Redcarpet::Render::HTML
@@ -131,6 +132,10 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # （例: {{div_end}}）も許可するプラグイン
   PLUGINS_WITHOUT_REQUIRED_ARGS = %w[div_begin div_end].freeze
 
+  # コンポーネントレンダリングを伴うプラグインのキャッシュ設定（plugin_cache_fetch参照）
+  PLUGIN_CACHE_VERSION = 'v1'
+  PLUGIN_CACHE_TTL = 7.days
+
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。
   # 1行目に閉じの"}}"がなければ複数行プラグインとみなし、次に現れる
   # "}}"のみの行までをdataとして扱う（本文中に{{fn ...}}のような単行プラグインが
@@ -193,6 +198,16 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     html
   end
 
+  # {{item}} / {{member}} / {{member2}} / {{snapshot}} はコンポーネントのレンダリングを
+  # 伴いコストが高いため、結果のHTML断片をRails.cacheに保存して再利用する（issue #1115）。
+  # key_partsには参照先レコードの cache_key_with_version（id + updated_at）を含めることで、
+  # レコードが更新されるたびにキーが変わり、明示的な無効化なしに自動でキャッシュが切り替わる。
+  # expires_in は更新のないレコードのキャッシュがRedis上に無期限に残り続けないための保険。
+  def plugin_cache_fetch(*key_parts, &)
+    key = (['markdown_plugin', PLUGIN_CACHE_VERSION] + key_parts).join('/')
+    Rails.cache.fetch(key, expires_in: PLUGIN_CACHE_TTL, &)
+  end
+
   # {{include key,セクション名}}       → CustomPage (key指定)
   # {{include unit:ID,セクション名}}   → Unit (ID指定)
   # {{include person:ID,セクション名}} → Person (ID指定)
@@ -226,7 +241,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     snapshot = unit&.unit_snapshots&.active&.find_by(id: snapshot_id)
     return '' unless snapshot
 
-    html = render(UnitSnapshotsComponent.new(snapshots: [snapshot], unit: unit, admin: false, show_label: false)).to_s
+    html = plugin_cache_fetch('snapshot', unit.cache_key_with_version, snapshot.cache_key_with_version) do
+      render(UnitSnapshotsComponent.new(snapshots: [snapshot], unit: unit, admin: false, show_label: false)).to_s
+    end
     register_plugin_placeholder(placeholders, html)
   end
 
@@ -238,7 +255,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     item = Item.find_by(asin: asin)
     return '' unless item
 
-    html = render(ItemCardComponent.new(item_card: item)).to_s
+    html = plugin_cache_fetch('item', item.cache_key_with_version) do
+      render(ItemCardComponent.new(item_card: item)).to_s
+    end
     register_plugin_placeholder(placeholders, html)
   end
 
@@ -255,8 +274,10 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     person = Person.kept.find_by(old_key: encode_member_old_key(raw_old_key))
     return '' unless person
 
-    member = MemberPluginRow.new(part: part, name: display_name, person: person, sns: link.presence && [link])
-    html = render(MemberRowComponent.new(member: member, hide_status: true))
+    html = plugin_cache_fetch('member', person.cache_key_with_version, Digest::MD5.hexdigest(args)) do
+      member = MemberPluginRow.new(part: part, name: display_name, person: person, sns: link.presence && [link])
+      render(MemberRowComponent.new(member: member, hide_status: true)).to_s
+    end
     register_plugin_placeholder(placeholders, html)
   end
 
@@ -306,15 +327,21 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     raw_old_key = nil if raw_old_key.blank? || raw_old_key == '-'
     person = raw_old_key && Person.kept.find_by(old_key: encode_member_old_key(raw_old_key))
 
-    member = MemberPluginRow.new(
-      part: part,
-      name: display_name,
-      person: person,
-      sns: link.presence && [link],
-      inline_history: person ? nil : data.to_s.strip.presence
-    )
+    # personが見つかった場合dataは経歴として使われない（下記inline_history参照）ため、
+    # その場合はキャッシュキーからdataを除外しヒット率を上げる。
+    fingerprint = person ? args.to_s : "#{args}\n#{data}"
+    person_key = person&.cache_key_with_version || 'noperson'
 
-    html = render(MemberRowComponent.new(member: member, hide_status: true))
+    html = plugin_cache_fetch('member2', person_key, Digest::MD5.hexdigest(fingerprint)) do
+      member = MemberPluginRow.new(
+        part: part,
+        name: display_name,
+        person: person,
+        sns: link.presence && [link],
+        inline_history: person ? nil : data.to_s.strip.presence
+      )
+      render(MemberRowComponent.new(member: member, hide_status: true)).to_s
+    end
     register_plugin_placeholder(placeholders, html)
   end
 

--- a/app/models/snapshot_person.rb
+++ b/app/models/snapshot_person.rb
@@ -40,7 +40,11 @@ class SnapshotPerson < ApplicationRecord
 
   default_scope { kept }
 
-  belongs_to :unit_snapshot
+  # touch: true は {{snapshot}}プラグイン（application_helper.rb）のキャッシュキーが
+  # UnitSnapshot#updated_at を参照しているための対応。SnapshotPerson単体の
+  # 作成・更新・削除・discard/undiscardのたびに親UnitSnapshotのupdated_atも更新され、
+  # キャッシュが自動的に無効化される。
+  belongs_to :unit_snapshot, touch: true
   belongs_to :person, optional: true
 
   enum :status, { undefined: 0, active: 1, pending: 2, left: 3, concerned: 4, pre: 5 }

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
+  include ActiveSupport::Testing::TimeHelpers
 
   test '{{include key,section}}で指定したCustomPageのセクション本文が展開される' do
     page = CustomPage.create!(key: 'target-page', title: 'Target', active: true)
@@ -363,5 +364,79 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/神谷 英希/, result)
     assert_match(/くりから。/, result)
     assert_match(/隠密華撃団/, result)
+  end
+
+  # 以下、issue #1115（プラグインのcache対応）関連のテスト。
+  # test環境のデフォルトcache_storeは:null_store（常にブロックを実行し何もキャッシュしない）
+  # のため、キャッシュの有無を検証するテストのみ一時的にMemoryStoreへ差し替える。
+  def with_memory_cache_store
+    original = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = original
+  end
+
+  test '{{item}}はキャッシュされ、updated_atが変わらない更新には反応しない' do
+    with_memory_cache_store do
+      item = Item.create!(title: '初期タイトル', release_date: '2020-01-01',
+                          link_url: 'https://example.com/item/cache1', asin: 'B00CACHEITEM1')
+
+      first = markdown("{{item #{item.asin}}}")
+      assert_match(/初期タイトル/, first)
+
+      # updated_atを変えずにDBだけ書き換える（キャッシュキーは変化しないはず）
+      item.update_column(:title, '書き換え後タイトル')
+
+      second = markdown("{{item #{item.asin}}}")
+      assert_match(/初期タイトル/, second, 'キャッシュキーが同じなら初回レンダリング結果が再利用されるはず')
+    end
+  end
+
+  test '{{item}}はItemが更新されるとキャッシュが自動的に切り替わる' do
+    with_memory_cache_store do
+      item = Item.create!(title: '初期タイトル2', release_date: '2020-01-01',
+                          link_url: 'https://example.com/item/cache2', asin: 'B00CACHEITEM2')
+      markdown("{{item #{item.asin}}}")
+
+      travel(1.second) { item.update!(title: '更新後タイトル2') }
+
+      result = markdown("{{item #{item.asin}}}")
+      assert_match(/更新後タイトル2/, result)
+    end
+  end
+
+  test '{{member}}はPersonが更新されるとキャッシュが自動的に切り替わる' do
+    with_memory_cache_store do
+      person = Person.create!(name: 'のる', key: 'member-cache-person',
+                              old_key: URI.encode_www_form_component('cache-key-1'.encode('EUC-JP')),
+                              old_history: '旧履歴テキスト')
+
+      first = markdown('{{member Vocal,のる,cache-key-1}}')
+      assert_match(/旧履歴テキスト/, first)
+
+      travel(1.second) { person.update!(old_history: '新履歴テキスト') }
+
+      second = markdown('{{member Vocal,のる,cache-key-1}}')
+      assert_match(/新履歴テキスト/, second)
+      assert_no_match(/旧履歴テキスト/, second)
+    end
+  end
+
+  test '{{snapshot}}はsnapshot_peopleの編集で親unit_snapshotがtouchされキャッシュが切り替わる' do
+    with_memory_cache_store do
+      unit = Unit.create!(key: 'snapshot-cache-unit', name: 'キャッシュテストユニット', status: 'active')
+      snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: true, active: true)
+      sp = snapshot.snapshot_people.create!(person_name: '旧メンバー名', part: :vocal, status: :active)
+
+      first = markdown("{{snapshot #{unit.key},#{snapshot.id}}}")
+      assert_match(/旧メンバー名/, first)
+
+      travel(1.second) { sp.update!(person_name: '新メンバー名') }
+
+      second = markdown("{{snapshot #{unit.key},#{snapshot.id}}}")
+      assert_match(/新メンバー名/, second)
+      assert_no_match(/旧メンバー名/, second)
+    end
   end
 end

--- a/test/models/snapshot_person_test.rb
+++ b/test/models/snapshot_person_test.rb
@@ -27,6 +27,8 @@
 require 'test_helper'
 
 class SnapshotPersonTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
   test 'valid snapshot_person with person' do
     sp = snapshot_people(:one)
     assert sp.valid?
@@ -57,5 +59,43 @@ class SnapshotPersonTest < ActiveSupport::TestCase
   test 'name returns person.name when person_name is blank' do
     sp = snapshot_people(:one)
     assert_equal people(:one).name, sp.name
+  end
+
+  # {{snapshot}}プラグイン（application_helper.rb）のキャッシュキーは
+  # UnitSnapshot#updated_at を参照しているため、SnapshotPersonの作成・更新・削除で
+  # 親UnitSnapshotのupdated_atも更新される（touch: true）必要がある。
+  test '作成時に親unit_snapshotのupdated_atをtouchする' do
+    snapshot = unit_snapshots(:one)
+    original_updated_at = snapshot.updated_at
+
+    travel_to(original_updated_at + 1.minute) do
+      snapshot.snapshot_people.create!(person_name: 'タッチテスト', part: :vocal, status: :active)
+    end
+
+    assert_not_equal original_updated_at, snapshot.reload.updated_at
+  end
+
+  test '更新時に親unit_snapshotのupdated_atをtouchする' do
+    sp = snapshot_people(:one)
+    snapshot = sp.unit_snapshot
+    original_updated_at = snapshot.updated_at
+
+    travel_to(original_updated_at + 1.minute) do
+      sp.update!(person_name: '更新後の名前')
+    end
+
+    assert_not_equal original_updated_at, snapshot.reload.updated_at
+  end
+
+  test '削除時に親unit_snapshotのupdated_atをtouchする' do
+    sp = snapshot_people(:one)
+    snapshot = sp.unit_snapshot
+    original_updated_at = snapshot.updated_at
+
+    travel_to(original_updated_at + 1.minute) do
+      sp.destroy!
+    end
+
+    assert_not_equal original_updated_at, snapshot.reload.updated_at
   end
 end


### PR DESCRIPTION
## Summary
- `{{item}}` `{{member}}` `{{member2}}` `{{snapshot}}` プラグインのレンダリング結果（ItemCardComponent / MemberRowComponent / UnitSnapshotsComponent）をRails.cacheに保存し再利用するようにした
- キャッシュキーには参照先レコードの `cache_key_with_version`（id + updated_at）を含め、レコード更新時に自動的にキーが変わり無効化される設計（明示的なキャッシュ削除処理は不要）。expires_inは7日間（更新のないレコードのキャッシュが無期限に残り続けないための保険）
- `{{include}}` はindexed findのみで元々軽量なため対象外とした
- `SnapshotPerson`に`belongs_to :unit_snapshot, touch: true`を追加。メンバー行(snapshot_people)の編集は元々親UnitSnapshotのupdated_atをtouchしていなかったため、{{snapshot}}のキャッシュキーが更新後も変わらず古い内容が残ってしまう問題があった

## Test plan
- [x] `bin/rails test` が全件（348件）パスすること
- [x] `bundle exec rubocop` で新規オフェンスがないこと
- [x] item/member/snapshot各プラグインについて「参照先レコードが更新されるとキャッシュが自動的に切り替わる」「updated_atが変わらない書き換えではキャッシュキーが変わらず初回レンダリング結果が再利用される」ことをテストで確認
- [x] SnapshotPersonの作成・更新・削除で親UnitSnapshotのupdated_atがtouchされることをテストで確認

Closes #1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)