### PR TITLE
HTMLコメントが行頭以外にあるとエスケープされ可視文字になる不具合を修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -94,6 +94,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     return '' if text.blank?
 
     placeholders = {}
+    text = protect_html_comments(text, placeholders)
     text = expand_plugin_macros(text, sectionable:, placeholders:)
 
     renderer = ExternalAwareHtmlRenderer.new(site_host: request.host, hard_wrap: true)
@@ -179,6 +180,18 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
 
       send(handler, args, sectionable, placeholders, [], data)
     end
+  end
+
+  # <!-- ... --> はRedcarpetが行頭からの生HTMLブロックとして認識した場合のみ
+  # そのまま出力されるが、リスト項目中や文中など行頭以外に書かれた場合は通常の
+  # テキストとしてHTMLエスケープされ、コメント記法がそのまま可視文字として
+  # 出力されてしまう（Issue#1116）。CustomPageDraftGenerator（下書き自動生成）が
+  # 「要手動対応」の目印として `- <!-- TODO: ... -->` のようにリスト項目中へ
+  # コメントを挿入するケースがあり、これが本文としてそのまま表示されていた。
+  # 出現位置によらずコメントは常に非表示になるべきなので、Markdown解析前に
+  # プレースホルダーへ退避し、解析後に生のHTMLコメントとして復元する。
+  def protect_html_comments(text, placeholders)
+    text.gsub(/<!--.*?-->/m) { register_plugin_placeholder(placeholders, Regexp.last_match(0)) }
   end
 
   # レンダリング済みHTMLをMarkdown解析後に復元するためのプレースホルダーを発行する。

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -36,6 +36,34 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/\{\{unknown foo,bar\}\}/, result)
   end
 
+  test 'リスト項目中のHTMLコメントはエスケープされず生のHTMLコメントとして出力される（Issue#1116）' do
+    result = markdown("- 通常の項目\n- <!-- TODO: 要手動対応 元記法: {{category イベント}} -->\n- 別の項目")
+
+    assert_no_match(/&lt;!--/, result)
+    assert_match(/<!-- TODO: 要手動対応 元記法: \{\{category イベント\}\} -->/, result)
+    assert_match(/通常の項目/, result)
+    assert_match(/別の項目/, result)
+  end
+
+  test '文中のHTMLコメントはエスケープされず生のHTMLコメントとして出力される（Issue#1116）' do
+    result = markdown('前の文<!-- 隠しコメント -->後の文')
+
+    assert_no_match(/&lt;!--/, result)
+    assert_match(/前の文<!-- 隠しコメント -->後の文/, result)
+  end
+
+  test '行頭単独のHTMLコメントは従来どおり生HTMLコメントとして出力される' do
+    result = markdown("本文\n\n<!-- 行頭コメント -->\n\n続き")
+
+    assert_match(/<!-- 行頭コメント -->/, result)
+  end
+
+  test 'HTMLコメント内のプラグイン記法は展開されずコメントごとそのまま残る（Issue#1116）' do
+    result = markdown('<!-- {{unknown foo,bar}} -->')
+
+    assert_match(/<!-- \{\{unknown foo,bar\}\} -->/, result)
+  end
+
   test '{{snapshot key,id}}で公開スナップショットのメンバーが埋め込まれる' do
     unit = Unit.create!(key: 'snapshot-plugin-unit', name: 'テストユニット', status: 'active')
     snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: true, active: true)


### PR DESCRIPTION
## Summary
- Redcarpetは行頭からの生HTMLブロックとして認識したコメント（`<!-- ... -->`だけの行）のみそのまま出力し、リスト項目中や文中など行頭以外にあるコメントは通常のテキストとしてHTMLエスケープしてしまっていた
- `CustomPageDraftGenerator`が「要手動対応」の目印として `- <!-- TODO: ... -->` のようにリスト項目中へコメントを挿入するケースがあり、これがエスケープされて可視テキストとしてページに表示されていた
- `ApplicationHelper#markdown` でMarkdown解析前にHTMLコメントをプレースホルダーへ退避し、解析後に生のHTMLコメントとして復元することで、出現位置によらず常に非表示になるよう修正した
- 副次効果として、コメント内に書かれた `{{...}}` 記法が誤ってプラグインとして展開されることも防げる

## Test plan
- [x] `bin/rails test` が全件パスすること（352 runs, 0 failures）
- [x] `test/helpers/application_helper_test.rb` にリスト項目中・文中・行頭単独・コメント内プラグイン記法の4パターンのテストを追加
- [x] 実際の下書きファイル（HTMLコメントを含むもの）を `markdown` ヘルパーに通し、エスケープされたコメントが出力に含まれないことを確認
- [x] `bundle exec rubocop` クリーン

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)