### PR TITLE
div_beginプラグインのclass="members"対応とMembers表示の統一

### DIFF
--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-slate-800 p-3 md:p-4 border-b border-slate-100 dark:border-slate-700 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-900/40 transition-colors">
+<div class="bg-white dark:bg-slate-800 p-3 border-b border-slate-100 dark:border-slate-700 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-900/40 transition-colors">
   <div>
     <div class="flex items-center justify-between gap-3 md:gap-4 flex-wrap sm:flex-nowrap">
       <div class="flex items-center gap-3 md:gap-4 flex-1">

--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-slate-800 p-5 border-b border-slate-100 dark:border-slate-700 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-900/40 transition-colors">
+<div class="bg-white dark:bg-slate-800 p-3 md:p-4 border-b border-slate-100 dark:border-slate-700 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-900/40 transition-colors">
   <div>
     <div class="flex items-center justify-between gap-3 md:gap-4 flex-wrap sm:flex-nowrap">
       <div class="flex items-center gap-3 md:gap-4 flex-1">

--- a/app/components/member_row_component.html.erb
+++ b/app/components/member_row_component.html.erb
@@ -5,15 +5,17 @@
         <span class="text-xs font-black text-slate-400 dark:text-slate-500 uppercase tracking-widest min-w-[4rem]" title="<%= (@member.part_alias.present? || @member.support?) ? @member.part.upcase : '' %>">
           <%= (@member.support? ? "サポート " : "") + (@member.part_alias.presence || @member.part.upcase) %>
         </span>
-        <h3 class="text-base md:text-lg font-black text-slate-800 dark:text-slate-100">
-
+        <%# role="heading"のdivを使用（<h3>にしない）: {{member}}/{{member2}}/{{snapshot}}
+            プラグイン経由でcustom_pages/show.html.erbの.markdown-content内に
+            埋め込まれる際、グローバルな`.markdown-content h3`スタイル
+            （margin: 1em 0 0.4em）が意図せず適用され、行の余白が大きく崩れるため %>
+        <div role="heading" aria-level="3" class="text-base md:text-lg font-black text-slate-800 dark:text-slate-100">
           <% if @member.person && @member.person.key.present? %>
             <%= link_to @member.name, profile_path(@member.person.key), class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
           <% else %>
-
             <%= @member.name %>
           <% end %>
-        </h3>
+        </div>
       </div>
       <div class="flex items-center gap-2">
         <% if @member.sns.present? && @member.sns.is_a?(Array) %>

--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -5,9 +5,13 @@
         <button type="button" data-action="click->toggle#toggle"
                 class="flex items-center justify-between gap-2 flex-1 min-w-0 -mx-1 px-1 py-0.5 rounded text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400">
           <span class="flex items-center gap-2 min-w-0">
-            <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+            <%# role="heading"のdivを使用（<h2>にしない）: {{snapshot}}プラグイン経由で
+                custom_pages/show.html.erbの.markdown-content内に埋め込まれる際、
+                グローバルな`.markdown-content h2`スタイル（border-bottom）が
+                見出しテキスト幅だけの短い下線として意図せず表示されてしまうため %>
+            <div role="heading" aria-level="2" class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
               <%= snapshot.past? ? 'Related' : 'Members' %>
-            </h2>
+            </div>
             <% if @show_label && snapshot.label.present? %>
               <span class="text-xs font-black px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= snapshot.label %></span>
             <% end %>

--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-12 mb-12">
   <% @snapshots.each do |snapshot| %>
-    <section data-controller="toggle" data-toggle-open-value="<%= snapshot.current? %>">
+    <section data-controller="toggle" data-toggle-open-value="<%= snapshot.current? && @summary_preview %>">
       <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
         <div class="flex items-center gap-2">
           <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">

--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -2,27 +2,26 @@
   <% @snapshots.each do |snapshot| %>
     <section data-controller="toggle" data-toggle-open-value="<%= snapshot.current? && @summary_preview %>">
       <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
-        <div class="flex items-center gap-2">
-          <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-            <%= snapshot.past? ? 'Related' : 'Members' %>
-          </h2>
-          <% if @show_label && snapshot.label.present? %>
-            <span class="text-xs font-black px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= snapshot.label %></span>
-          <% end %>
-          <% if snapshot.current? %>
-            <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">Current</span>
-          <% end %>
-        </div>
-        <div class="flex items-center gap-2">
-          <% if @admin && @unit %>
-            <%= link_to "Edit", edit_admin_unit_unit_snapshot_path(@unit, snapshot), class: "text-xs font-medium text-slate-400 hover:text-indigo-500 transition-colors" %>
-          <% end %>
-          <button type="button" data-action="click->toggle#toggle" class="inline-flex items-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors" title="Toggle history">
-            <svg class="w-4 h-4 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-            </svg>
-          </button>
-        </div>
+        <button type="button" data-action="click->toggle#toggle"
+                class="flex items-center justify-between gap-2 flex-1 min-w-0 -mx-1 px-1 py-0.5 rounded text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400">
+          <span class="flex items-center gap-2 min-w-0">
+            <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+              <%= snapshot.past? ? 'Related' : 'Members' %>
+            </h2>
+            <% if @show_label && snapshot.label.present? %>
+              <span class="text-xs font-black px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400"><%= snapshot.label %></span>
+            <% end %>
+            <% if snapshot.current? %>
+              <span class="text-xs font-black uppercase px-2 py-0.5 rounded-md bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-400">Current</span>
+            <% end %>
+          </span>
+          <svg class="w-4 h-4 shrink-0 text-slate-400 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </button>
+        <% if @admin && @unit %>
+          <%= link_to "Edit", edit_admin_unit_unit_snapshot_path(@unit, snapshot), class: "text-xs font-medium text-slate-400 hover:text-indigo-500 transition-colors ml-2 shrink-0", onclick: "event.stopPropagation()" %>
+        <% end %>
       </div>
       <% if snapshot.current? || !@summary_preview %>
         <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">

--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -24,8 +24,10 @@
           </button>
         </div>
       </div>
-      <% if snapshot.current? %>
-        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
+      <% if snapshot.current? || !@summary_preview %>
+        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm"
+             data-toggle-target="<%= snapshot.current? ? 'area' : 'content area' %>"
+             data-action="click->toggle#expand">
           <%= render MemberRowComponent.with_collection(snapshot.snapshot_people.sort_by(&:sort_order), hide_active: true, hide_status: snapshot.past?) %>
         </div>
       <% else %>

--- a/app/components/unit_snapshots_component.html.erb
+++ b/app/components/unit_snapshots_component.html.erb
@@ -25,9 +25,7 @@
         </div>
       </div>
       <% if snapshot.current? || !@summary_preview %>
-        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm"
-             data-toggle-target="<%= snapshot.current? ? 'area' : 'content area' %>"
-             data-action="click->toggle#expand">
+        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
           <%= render MemberRowComponent.with_collection(snapshot.snapshot_people.sort_by(&:sort_order), hide_active: true, hide_status: snapshot.past?) %>
         </div>
       <% else %>

--- a/app/components/unit_snapshots_component.rb
+++ b/app/components/unit_snapshots_component.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class UnitSnapshotsComponent < ViewComponent::Base
-  # summary_preview: 過去(current: false)スナップショットの初期表示方法。
-  # true（デフォルト。ユニットページ本体での表示）  → メンバー名の1行プレビュー＋
-  #   クリック時にhx-getで遅延取得（読み込みコストを抑えるための本番向け最適化）。
-  # false（{{snapshot}}プラグイン。カスタムページでの埋め込み表示）             → 1行プレビューを
-  #   出さず、「現メンバー」表示と同じくメンバー一覧をその場で常時表示する
-  #   （{{div_begin class="members"}}と同じ見た目。開閉トグルはメンバーごとの経歴
-  #   表示のみを対象にする）。1件のsnapshotのみを表示する用途のためデータ量が
-  #   小さく、遅延取得のコストは不要。
+  # summary_preview: ユニットページ本体での表示か、{{snapshot}}プラグイン
+  # （カスタムページでの埋め込み表示）かを区別するフラグ。
+  # true（デフォルト。ユニットページ本体）    → 過去(current: false)スナップショットは
+  #   メンバー名の1行プレビュー＋クリック時にhx-getで遅延取得（読み込みコストを
+  #   抑えるための本番向け最適化）。current: trueのスナップショットは初期状態から展開。
+  # false（{{snapshot}}プラグイン）           → 1行プレビューを出さず、「現メンバー」表示
+  #   と同じくメンバー一覧をその場で常時表示する（{{div_begin class="members"}}と同じ
+  #   見た目。開閉トグルはメンバーごとの経歴表示のみを対象にする）。1件のsnapshotのみを
+  #   表示する用途のためデータ量が小さく、遅延取得のコストは不要。また、current: trueの
+  #   スナップショットであっても常に折りたたんだ状態（経歴非表示）から始める
+  #   （ユニットページ本体の「現メンバー」自動展開は、プラグイン埋め込みでは行わない）。
   def initialize(snapshots:, unit: nil, admin: false, show_label: true, summary_preview: true)
     super()
     @snapshots = snapshots

--- a/app/components/unit_snapshots_component.rb
+++ b/app/components/unit_snapshots_component.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
 class UnitSnapshotsComponent < ViewComponent::Base
-  def initialize(snapshots:, unit: nil, admin: false, show_label: true)
+  # summary_preview: 過去(current: false)スナップショットの初期表示方法。
+  # true（デフォルト。ユニットページ本体での表示）  → メンバー名の1行プレビュー＋
+  #   クリック時にhx-getで遅延取得（読み込みコストを抑えるための本番向け最適化）。
+  # false（{{snapshot}}プラグイン。カスタムページでの埋め込み表示）             → 1行プレビューを
+  #   出さず、{{div_begin class="members"}}と同じ「カード全体を折りたたむ」表示にする。
+  #   1件のsnapshotのみを表示する用途のためデータ量が小さく、遅延取得のコストは不要。
+  def initialize(snapshots:, unit: nil, admin: false, show_label: true, summary_preview: true)
     super()
     @snapshots = snapshots
     @unit = unit
     @admin = admin
     @show_label = show_label
+    @summary_preview = summary_preview
   end
 
   def render?

--- a/app/components/unit_snapshots_component.rb
+++ b/app/components/unit_snapshots_component.rb
@@ -5,8 +5,10 @@ class UnitSnapshotsComponent < ViewComponent::Base
   # true（デフォルト。ユニットページ本体での表示）  → メンバー名の1行プレビュー＋
   #   クリック時にhx-getで遅延取得（読み込みコストを抑えるための本番向け最適化）。
   # false（{{snapshot}}プラグイン。カスタムページでの埋め込み表示）             → 1行プレビューを
-  #   出さず、{{div_begin class="members"}}と同じ「カード全体を折りたたむ」表示にする。
-  #   1件のsnapshotのみを表示する用途のためデータ量が小さく、遅延取得のコストは不要。
+  #   出さず、「現メンバー」表示と同じくメンバー一覧をその場で常時表示する
+  #   （{{div_begin class="members"}}と同じ見た目。開閉トグルはメンバーごとの経歴
+  #   表示のみを対象にする）。1件のsnapshotのみを表示する用途のためデータ量が
+  #   小さく、遅延取得のコストは不要。
   def initialize(snapshots:, unit: nil, admin: false, show_label: true, summary_preview: true)
     super()
     @snapshots = snapshots

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # 変わらない限りキャッシュキーが変化せず古いHTMLが返り続けるため、このバージョンを
   # 上げてキャッシュを一括無効化すること。
   # v2: {{snapshot}}の初期表示をsummary_preview: false化（issue #1130、1行プレビュー廃止）
-  PLUGIN_CACHE_VERSION = 'v2'
+  # v3: UnitSnapshotsComponentの見出しクリック領域を拡大（issue #1130）
+  PLUGIN_CACHE_VERSION = 'v3'
   PLUGIN_CACHE_TTL = 7.days
 
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -141,7 +141,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # v3: UnitSnapshotsComponentの見出しクリック領域を拡大（issue #1130）
   # v4: UnitSnapshotsComponentの見出しを<h2>からrole="heading"のdivに変更
   #     （.markdown-content内での意図しない下線対策、issue #1130）
-  PLUGIN_CACHE_VERSION = 'v4'
+  # v5: MemberRowComponentの行paddingを縮小（閉状態の余白対策、issue #1130）
+  PLUGIN_CACHE_VERSION = 'v5'
   PLUGIN_CACHE_TTL = 7.days
 
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -362,12 +362,23 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # それ以外の記述（例: {{div_begin onclick="..."}}）は無視する。
   DIV_BEGIN_ALLOWED_ATTRS = %w[class subject].freeze
 
+  # ユニットページのMembersセクション（UnitSnapshotsComponentの「現メンバー」表示、
+  # {{snapshot}}プラグインと共通の見た目）と同じ、角丸カード＋シェブロン開閉トグルの
+  # 外枠を出力するためのラベル。トグルの開閉自体はStimulusのtoggleコントローラが行い、
+  # 対応するのはこの外枠内にある{{member}}/{{member2}}の経歴表示
+  # （MemberRowComponentが出力するdata-toggle-target="content"）。
+  DIV_BEGIN_MEMBERS_DEFAULT_LABEL = 'Members'
+
   # {{div_begin class="value"}}                     → <div class="value">
   # {{div_begin}}                                    → <div>
   # {{div_begin class="closable" subject="見出し"}} → 折りたたみ表示（初期状態は閉じている）。
   #   <details class="closable"><summary>見出し</summary> を出力し、
   #   ラベルのクリックで開閉する（class="closable" と subject の両方が揃った場合のみ）。
   #   開閉マーカーは<summary>のブラウザ標準表示に任せる。
+  # {{div_begin class="members"}}                    → ユニットページのMembersセクションと
+  #   同じ見た目（角丸カード＋シェブロン開閉トグル）で{{member}}/{{member2}}の並びを囲む
+  #   （初期状態は閉じている＝経歴非表示）。subjectを指定すると見出しラベルを変更できる
+  #   （省略時は"Members"）。
   def expand_div_begin_plugin(args, _sectionable, placeholders, open_tags)
     attrs = parse_allowed_attrs(args, DIV_BEGIN_ALLOWED_ATTRS)
     class_value = attrs['class']
@@ -376,6 +387,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     html = if class_value == 'closable' && subject_value.present?
              open_tags.push(:details)
              "<details class=\"closable\"><summary>#{CGI.escapeHTML(subject_value)}</summary>"
+           elsif class_value == 'members'
+             open_tags.push(:members)
+             render_div_begin_members_html(subject_value)
            else
              open_tags.push(:div)
              class_value.present? ? %(<div class="#{CGI.escapeHTML(class_value)}">) : '<div>'
@@ -383,9 +397,38 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     register_plugin_placeholder(placeholders, html)
   end
 
-  # {{div_end}} → 対応する{{div_begin}}の種類に応じて </div> または </details> を出力する
+  # {{div_begin class="members"}}が出力する外枠のHTML。
+  # ユニットページのMembersセクション（UnitSnapshotsComponentの「現メンバー」表示）と
+  # 同一のマークアップ・クラスを用いることで、同じStimulus toggleコントローラ・
+  # 同じ見た目で開閉できるようにしている。
+  def render_div_begin_members_html(subject_value)
+    label = CGI.escapeHTML(subject_value.presence || DIV_BEGIN_MEMBERS_DEFAULT_LABEL)
+    <<~HTML.chomp
+      <section data-controller="toggle" data-toggle-open-value="false">
+        <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
+          <div class="flex items-center gap-2">
+            <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">#{label}</h2>
+          </div>
+          <div class="flex items-center gap-2">
+            <button type="button" data-action="click->toggle#toggle" class="inline-flex items-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors" title="Toggle history">
+              <svg class="w-4 h-4 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+              </svg>
+              <span class="sr-only">#{label}の開閉</span>
+            </button>
+          </div>
+        </div>
+        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
+    HTML
+  end
+
+  # {{div_end}} → 対応する{{div_begin}}の種類に応じて </div> / </details> / </div></section> を出力する
   def expand_div_end_plugin(_args, _sectionable, placeholders, open_tags)
-    html = open_tags.pop == :details ? '</details>' : '</div>'
+    html = case open_tags.pop
+           when :details then '</details>'
+           when :members then "</div>\n</section>"
+           else '</div>'
+           end
     register_plugin_placeholder(placeholders, html)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,7 +143,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   #     （.markdown-content内での意図しない下線対策、issue #1130）
   # v5: MemberRowComponentの行paddingを縮小（閉状態の余白対策、issue #1130）
   # v6: MemberRowComponentのデスクトップ行paddingをさらに縮小（issue #1130）
-  PLUGIN_CACHE_VERSION = 'v6'
+  # v7: MemberRowComponentのメンバー名を<h3>からrole="heading"のdivに変更
+  #     （.markdown-content内での意図しない余白対策、issue #1130）
+  PLUGIN_CACHE_VERSION = 'v7'
   PLUGIN_CACHE_TTL = 7.days
 
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,8 +133,12 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # （例: {{div_end}}）も許可するプラグイン
   PLUGINS_WITHOUT_REQUIRED_ARGS = %w[div_begin div_end].freeze
 
-  # コンポーネントレンダリングを伴うプラグインのキャッシュ設定（plugin_cache_fetch参照）
-  PLUGIN_CACHE_VERSION = 'v1'
+  # コンポーネントレンダリングを伴うプラグインのキャッシュ設定（plugin_cache_fetch参照）。
+  # レンダリング結果（HTML構造）を変更した場合は、レコード側のcache_key_with_versionが
+  # 変わらない限りキャッシュキーが変化せず古いHTMLが返り続けるため、このバージョンを
+  # 上げてキャッシュを一括無効化すること。
+  # v2: {{snapshot}}の初期表示をsummary_preview: false化（issue #1130、1行プレビュー廃止）
+  PLUGIN_CACHE_VERSION = 'v2'
   PLUGIN_CACHE_TTL = 7.days
 
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -142,7 +142,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # v4: UnitSnapshotsComponentの見出しを<h2>からrole="heading"のdivに変更
   #     （.markdown-content内での意図しない下線対策、issue #1130）
   # v5: MemberRowComponentの行paddingを縮小（閉状態の余白対策、issue #1130）
-  PLUGIN_CACHE_VERSION = 'v5'
+  # v6: MemberRowComponentのデスクトップ行paddingをさらに縮小（issue #1130）
+  PLUGIN_CACHE_VERSION = 'v6'
   PLUGIN_CACHE_TTL = 7.days
 
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -198,6 +198,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     text.gsub(/<!--.*?-->/m) { register_plugin_placeholder(placeholders, Regexp.last_match(0)) }
   end
 
+  PLUGIN_PLACEHOLDER_TOKEN = /⟦PLUGIN_PLACEHOLDER_[0-9a-f]+⟧/
+
   # レンダリング済みHTMLをMarkdown解析後に復元するためのプレースホルダーを発行する。
   # コンポーネントの生成するHTML（複数行タグ・Stimulus/htmx属性等）はRedcarpetの
   # 生HTMLブロック認識に乗らず壊れることがあるため、Markdown解析を経由させない。
@@ -208,8 +210,19 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   def restore_plugin_placeholders(html, placeholders)
+    # {{member}}等のブロックレベルなプラグインを空行で区切らず連続して書いた場合
+    # （実際の移行ドラフトでのメンバー一覧の書き方）、Redcarpetはhard_wrapにより
+    # それらを1つの<p>...</p>にまとめ、プレースホルダー間に<br>を挿入する。
+    # その状態のまま各トークンをブロック要素（<div>等）に単純置換すると、<p>の
+    # 中に<div>が入れ子になった不正なHTMLになり、ブラウザ側の自動修復で余計な
+    # 空<p>（既定の上下マージン分の余白）が挿入されてしまう（Issue#1130）。
+    # <p>の中身がプレースホルダーのみ（<br>区切り可）の場合は、そのp/brごと
+    # 取り除いてから個々のトークンを復元することでこれを防ぐ。
+    html = html.gsub(%r{<p>((?:#{PLUGIN_PLACEHOLDER_TOKEN}(?:<br>\s*)?)+)</p>}o) do
+      Regexp.last_match(1).gsub(/<br>\s*/, "\n")
+    end
+
     placeholders.each do |token, raw_html|
-      html = html.sub("<p>#{token}</p>", raw_html)
       html = html.sub(token, raw_html)
     end
     html

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -374,12 +374,14 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   #   <details class="closable"><summary>見出し</summary> を出力し、
   #   ラベルのクリックで開閉する（class="closable" と subject の両方が揃った場合のみ）。
   #   開閉マーカーは<summary>のブラウザ標準表示に任せる。
-  # {{div_begin class="members"}}                    → ユニットページのMembersセクションと
-  #   同じ見た目（角丸カード＋シェブロン開閉トグル）で{{member}}/{{member2}}の並びを囲む。
-  #   初期状態は閉じており、カード全体（メンバー一覧すべて）が非表示になる
-  #   （{{snapshot}}プラグインのsummary_preview: falseと同じ「カード全体を折りたたむ」方式。
-  #   ユニットページ本体のMembersセクションのようなメンバー名1行プレビューは出さない）。
-  #   subjectを指定すると見出しラベルを変更できる（省略時は"Members"）。
+  # {{div_begin class="members"}}                    → ユニットページのMembersセクション
+  #   （UnitSnapshotsComponentの「現メンバー」表示）と同じ見た目（角丸カード＋シェブロン
+  #   開閉トグル）で{{member}}/{{member2}}の並びを囲む。メンバー一覧自体は常に表示され、
+  #   開閉トグルが対応するのは各メンバーの経歴表示（{{member2}}のdata等、
+  #   MemberRowComponentが出力するdata-toggle-target="content"）のみ
+  #   （初期状態は閉じている＝経歴非表示。ユニットページのMembersセクションを
+  #   折りたたんだ状態と同じ）。subjectを指定すると見出しラベルを変更できる
+  #   （省略時は"Members"）。
   def expand_div_begin_plugin(args, _sectionable, placeholders, open_tags)
     attrs = parse_allowed_attrs(args, DIV_BEGIN_ALLOWED_ATTRS)
     class_value = attrs['class']
@@ -399,11 +401,11 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # {{div_begin class="members"}}が出力する外枠のHTML。
-  # UnitSnapshotsComponentの角丸カード＋シェブロン開閉トグルと同一のマークアップ・
-  # クラスを用いることで、同じStimulus toggleコントローラ・同じ見た目で開閉できる
-  # ようにしている。data-toggle-target="content area"により、開閉トグルはカード全体
-  # （中の{{member}}/{{member2}}すべて）を対象にする
-  # （{{snapshot}}プラグイン＝summary_preview: falseの場合と同じ挙動）。
+  # UnitSnapshotsComponentの「現メンバー」表示（角丸カード＋シェブロン開閉トグル）と
+  # 同一のマークアップ・クラスを用いることで、同じStimulus toggleコントローラ・
+  # 同じ見た目で開閉できるようにしている。data-toggle-target="area"のみを持たせ、
+  # メンバー一覧自体は開閉に関わらず常に表示する（{{snapshot}}プラグイン・
+  # summary_preview: falseの場合と同じ挙動）。
   def render_div_begin_members_html(subject_value)
     label = CGI.escapeHTML(subject_value.presence || DIV_BEGIN_MEMBERS_DEFAULT_LABEL)
     <<~HTML.chomp
@@ -421,7 +423,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
             </button>
           </div>
         </div>
-        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="content area" data-action="click->toggle#expand">
+        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
     HTML
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -422,23 +422,19 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # 同一のマークアップ・クラスを用いることで、同じStimulus toggleコントローラ・
   # 同じ見た目で開閉できるようにしている。data-toggle-target="area"のみを持たせ、
   # メンバー一覧自体は開閉に関わらず常に表示する（{{snapshot}}プラグイン・
-  # summary_preview: falseの場合と同じ挙動）。
+  # summary_preview: falseの場合と同じ挙動）。開閉のクリック領域は見出し全体
+  # （ラベル＋シェブロン）とする。
   def render_div_begin_members_html(subject_value)
     label = CGI.escapeHTML(subject_value.presence || DIV_BEGIN_MEMBERS_DEFAULT_LABEL)
     <<~HTML.chomp
       <section data-controller="toggle" data-toggle-open-value="false">
         <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
-          <div class="flex items-center gap-2">
+          <button type="button" data-action="click->toggle#toggle" class="flex items-center justify-between gap-2 flex-1 min-w-0 -mx-1 px-1 py-0.5 rounded text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400">
             <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">#{label}</h2>
-          </div>
-          <div class="flex items-center gap-2">
-            <button type="button" data-action="click->toggle#toggle" class="inline-flex items-center text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors" title="Toggle history">
-              <svg class="w-4 h-4 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-              </svg>
-              <span class="sr-only">#{label}の開閉</span>
-            </button>
-          </div>
+            <svg class="w-4 h-4 shrink-0 text-slate-400 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            </svg>
+          </button>
         </div>
         <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
     HTML

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -139,7 +139,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # 上げてキャッシュを一括無効化すること。
   # v2: {{snapshot}}の初期表示をsummary_preview: false化（issue #1130、1行プレビュー廃止）
   # v3: UnitSnapshotsComponentの見出しクリック領域を拡大（issue #1130）
-  PLUGIN_CACHE_VERSION = 'v3'
+  # v4: UnitSnapshotsComponentの見出しを<h2>からrole="heading"のdivに変更
+  #     （.markdown-content内での意図しない下線対策、issue #1130）
+  PLUGIN_CACHE_VERSION = 'v4'
   PLUGIN_CACHE_TTL = 7.days
 
   # 複数行にわたるプラグイン記法（例: {{member2 ...}}）のディスパッチ先。
@@ -425,13 +427,17 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # メンバー一覧自体は開閉に関わらず常に表示する（{{snapshot}}プラグイン・
   # summary_preview: falseの場合と同じ挙動）。開閉のクリック領域は見出し全体
   # （ラベル＋シェブロン）とする。
+  # 見出しは<h2>ではなくrole="heading"のdivを使用する: このHTMLは常にカスタム
+  # ページの.markdown-content内に埋め込まれるため、<h2>にするとグローバルな
+  # `.markdown-content h2`スタイル（border-bottom）が見出しテキスト幅だけの
+  # 短い下線として意図せず表示されてしまう。
   def render_div_begin_members_html(subject_value)
     label = CGI.escapeHTML(subject_value.presence || DIV_BEGIN_MEMBERS_DEFAULT_LABEL)
     <<~HTML.chomp
       <section data-controller="toggle" data-toggle-open-value="false">
         <div class="flex items-center justify-between mb-6 border-b border-slate-200 dark:border-slate-700 pb-2">
           <button type="button" data-action="click->toggle#toggle" class="flex items-center justify-between gap-2 flex-1 min-w-0 -mx-1 px-1 py-0.5 rounded text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-400">
-            <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">#{label}</h2>
+            <div role="heading" aria-level="2" class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">#{label}</div>
             <svg class="w-4 h-4 shrink-0 text-slate-400 transition-transform duration-200" data-toggle-target="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
             </svg>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -255,7 +255,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     return '' unless snapshot
 
     html = plugin_cache_fetch('snapshot', unit.cache_key_with_version, snapshot.cache_key_with_version) do
-      render(UnitSnapshotsComponent.new(snapshots: [snapshot], unit: unit, admin: false, show_label: false)).to_s
+      render(UnitSnapshotsComponent.new(snapshots: [snapshot], unit: unit, admin: false, show_label: false,
+                                        summary_preview: false)).to_s
     end
     register_plugin_placeholder(placeholders, html)
   end
@@ -362,11 +363,9 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # それ以外の記述（例: {{div_begin onclick="..."}}）は無視する。
   DIV_BEGIN_ALLOWED_ATTRS = %w[class subject].freeze
 
-  # ユニットページのMembersセクション（UnitSnapshotsComponentの「現メンバー」表示、
-  # {{snapshot}}プラグインと共通の見た目）と同じ、角丸カード＋シェブロン開閉トグルの
-  # 外枠を出力するためのラベル。トグルの開閉自体はStimulusのtoggleコントローラが行い、
-  # 対応するのはこの外枠内にある{{member}}/{{member2}}の経歴表示
-  # （MemberRowComponentが出力するdata-toggle-target="content"）。
+  # ユニットページのMembersセクション（UnitSnapshotsComponent）・{{snapshot}}プラグイン
+  # （summary_preview: false指定時）と同じ、角丸カード＋シェブロン開閉トグルの
+  # 外枠を出力するためのデフォルト見出しラベル。
   DIV_BEGIN_MEMBERS_DEFAULT_LABEL = 'Members'
 
   # {{div_begin class="value"}}                     → <div class="value">
@@ -376,9 +375,11 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   #   ラベルのクリックで開閉する（class="closable" と subject の両方が揃った場合のみ）。
   #   開閉マーカーは<summary>のブラウザ標準表示に任せる。
   # {{div_begin class="members"}}                    → ユニットページのMembersセクションと
-  #   同じ見た目（角丸カード＋シェブロン開閉トグル）で{{member}}/{{member2}}の並びを囲む
-  #   （初期状態は閉じている＝経歴非表示）。subjectを指定すると見出しラベルを変更できる
-  #   （省略時は"Members"）。
+  #   同じ見た目（角丸カード＋シェブロン開閉トグル）で{{member}}/{{member2}}の並びを囲む。
+  #   初期状態は閉じており、カード全体（メンバー一覧すべて）が非表示になる
+  #   （{{snapshot}}プラグインのsummary_preview: falseと同じ「カード全体を折りたたむ」方式。
+  #   ユニットページ本体のMembersセクションのようなメンバー名1行プレビューは出さない）。
+  #   subjectを指定すると見出しラベルを変更できる（省略時は"Members"）。
   def expand_div_begin_plugin(args, _sectionable, placeholders, open_tags)
     attrs = parse_allowed_attrs(args, DIV_BEGIN_ALLOWED_ATTRS)
     class_value = attrs['class']
@@ -398,9 +399,11 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # {{div_begin class="members"}}が出力する外枠のHTML。
-  # ユニットページのMembersセクション（UnitSnapshotsComponentの「現メンバー」表示）と
-  # 同一のマークアップ・クラスを用いることで、同じStimulus toggleコントローラ・
-  # 同じ見た目で開閉できるようにしている。
+  # UnitSnapshotsComponentの角丸カード＋シェブロン開閉トグルと同一のマークアップ・
+  # クラスを用いることで、同じStimulus toggleコントローラ・同じ見た目で開閉できる
+  # ようにしている。data-toggle-target="content area"により、開閉トグルはカード全体
+  # （中の{{member}}/{{member2}}すべて）を対象にする
+  # （{{snapshot}}プラグイン＝summary_preview: falseの場合と同じ挙動）。
   def render_div_begin_members_html(subject_value)
     label = CGI.escapeHTML(subject_value.presence || DIV_BEGIN_MEMBERS_DEFAULT_LABEL)
     <<~HTML.chomp
@@ -418,7 +421,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
             </button>
           </div>
         </div>
-        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area" data-action="click->toggle#expand">
+        <div class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="content area" data-action="click->toggle#expand">
     HTML
   end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -316,6 +316,27 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/森川泰敬/, result)
   end
 
+  test '空行区切りなしで連続する{{member}}は<p>や<br>で余分に囲まれない(Issue#1130の余白崩れ対策)' do
+    Person.create!(name: 'のる', key: 'members-gap-person-1',
+                   old_key: URI.encode_www_form_component('のる(ex-ふりぃ)'.encode('EUC-JP')))
+    Person.create!(name: 'Kyoki', key: 'members-gap-person-2',
+                   old_key: URI.encode_www_form_component('叶唏'.encode('EUC-JP')))
+
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="members"}}
+      {{member Vocal,のる,のる(ex-ふりぃ)}}
+      {{member Guitar,Kyoki,叶唏}}
+      {{div_end}}
+    MARKDOWN
+
+    # 各メンバー行(ブロック要素)が<p>で囲まれたり、行間に<br>が挟まったりしていないこと
+    assert_no_match(/<p>\s*<(?:section|div)/, result)
+    assert_no_match(%r{</div>\s*<br>}, result)
+    assert_no_match(%r{</div>\s*</p>}, result)
+    assert_match(/のる/, result)
+    assert_match(/Kyoki/, result)
+  end
+
   test '{{div_begin class="members" subject="..."}}は見出しラベルを上書きできる' do
     result = markdown('{{div_begin class="members" subject="旧メンバー"}}本文{{div_end}}')
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
   include ActiveSupport::Testing::TimeHelpers
+  include ViewComponent::TestHelpers
 
   test '{{include key,section}}で指定したCustomPageのセクション本文が展開される' do
     page = CustomPage.create!(key: 'target-page', title: 'Target', active: true)
@@ -72,6 +73,26 @@ class ApplicationHelperTest < ActionView::TestCase
     result = markdown("{{snapshot #{unit.key},#{snapshot.id}}}")
 
     assert_match(/テストメンバー/, result)
+  end
+
+  test '{{snapshot}}はcurrent: trueのスナップショットでも、ユニットページ本体と違い初期状態は折りたたまれている' do
+    unit = Unit.create!(key: 'snapshot-plugin-unit-current-fold', name: 'テストユニット', status: 'active')
+    snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: true, active: true)
+    snapshot.snapshot_people.create!(person_name: 'テストメンバー', part: :vocal, status: :active)
+
+    result = markdown("{{snapshot #{unit.key},#{snapshot.id}}}")
+
+    assert_match(/data-toggle-open-value="false"/, result)
+  end
+
+  test 'ユニットページ本体(summary_preview: true)では従来どおりcurrent: trueのスナップショットが初期展開される' do
+    unit = Unit.create!(key: 'unit-page-current-open', name: 'テストユニット', status: 'active')
+    snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: true, active: true)
+    snapshot.snapshot_people.create!(person_name: 'テストメンバー', part: :vocal, status: :active)
+
+    result = render_inline(UnitSnapshotsComponent.new(snapshots: [snapshot], unit: unit)).to_html
+
+    assert_match(/data-toggle-open-value="true"/, result)
   end
 
   test '{{snapshot key,id}}で埋め込んだ場合はバンドページと違いラベルが表示されない' do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -384,6 +384,16 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(%r{href="/member-plugin-person"}, result)
   end
 
+  test '{{member}}のメンバー名は<h3>ではなくrole="heading"のdivを使う(markdown-content内の意図しない余白対策)' do
+    Person.create!(name: 'のる', key: 'member-plugin-person-noh3',
+                   old_key: URI.encode_www_form_component('のる(ex-ふりぃ)'.encode('EUC-JP')))
+
+    result = markdown('{{member Vocal,のる,のる(ex-ふりぃ)}}')
+
+    assert_no_match(/<h3/, result)
+    assert_match(/role="heading" aria-level="3"/, result)
+  end
+
   test '{{member}}は表示名(第2引数)をそのまま表示し、Personのnameとは独立している' do
     Person.create!(name: 'DB上の名前', key: 'member-plugin-person2',
                    old_key: URI.encode_www_form_component('旧名'.encode('EUC-JP')))

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -127,10 +127,26 @@ class ApplicationHelperTest < ActionView::TestCase
     result = markdown("前\n\n{{snapshot #{unit.key},#{snapshot.id}}}\n\n後")
 
     # UnitSnapshotsComponentの複数行タグの属性がRedcarpetに解析されテキストとして
-    # 露出していないこと（<p>の中にhx-get等の属性テキストが漏れていないこと）を確認する
-    assert_no_match(/<p>[^<]*(?:data-toggle-target|hx-get|hx-trigger)/, result)
-    assert_match(%r{hx-get="[^"]*snapshots/#{snapshot.id}/members"}, result)
+    # 露出していないこと（<p>の中にdata-toggle-target等の属性テキストが漏れていないこと）を確認する
+    assert_no_match(/<p>[^<]*data-toggle-target/, result)
     assert_match(/テストメンバー4/, result)
+  end
+
+  test '{{snapshot}}で埋め込んだ過去スナップショットはユニットページ本体と異なり、1行プレビュー(summary)ではなくカード全体折りたたみになる' do
+    unit = Unit.create!(key: 'snapshot-plugin-unit5', name: 'テストユニット5', status: 'active')
+    snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: false, active: true)
+    snapshot.snapshot_people.create!(person_name: 'テストメンバー5', part: :vocal, status: :active)
+
+    result = markdown("{{snapshot #{unit.key},#{snapshot.id}}}")
+
+    # 1行プレビュー(summary)・hx-get遅延取得は使われない
+    assert_no_match(/data-toggle-target="summary/, result)
+    assert_no_match(/hx-get/, result)
+    # {{div_begin class="members"}}と同じ「カード全体折りたたみ」のマークアップ
+    assert_match(/data-toggle-target="content area"/, result)
+    assert_match(/data-toggle-open-value="false"/, result)
+    # 遅延取得ではなくその場でメンバー行が描画される
+    assert_match(/テストメンバー5/, result)
   end
 
   test '{{item ASIN}}でItemカードが埋め込まれる' do
@@ -258,11 +274,17 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/<section data-controller="toggle" data-toggle-open-value="false">/, result)
     assert_match(%r{<h2[^>]*>Members</h2>}, result)
     assert_match(/data-action="click->toggle#toggle"/, result)
-    assert_match(/class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area"/,
-                 result)
+    assert_match(/rounded-2xl overflow-hidden shadow-sm" data-toggle-target="content area"/, result)
     assert_match(%r{</section>}, result)
     assert_match(/森川泰敬/, result)
     assert_match(/GLAMOROUS HONEY/, result)
+  end
+
+  test '{{div_begin class="members"}}は初期状態でカード全体が折りたたまれ(閉じた状態)、メンバー名の1行プレビューは出さない' do
+    result = markdown('{{div_begin class="members"}}本文{{div_end}}')
+
+    assert_match(/data-toggle-open-value="false"/, result)
+    assert_no_match(/data-toggle-target="summary/, result)
   end
 
   test '{{div_begin class="members" subject="..."}}は見出しラベルを上書きできる' do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -244,6 +244,58 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(%r{</details>}, result)
   end
 
+  test '{{div_begin class="members"}}はユニットページのMembersセクションと同じ外枠(toggleコントローラ・角丸カード)で出力される' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="members"}}
+
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey)
+      }}
+
+      {{div_end}}
+    MARKDOWN
+
+    assert_match(/<section data-controller="toggle" data-toggle-open-value="false">/, result)
+    assert_match(%r{<h2[^>]*>Members</h2>}, result)
+    assert_match(/data-action="click->toggle#toggle"/, result)
+    assert_match(/class="flex flex-col border border-slate-200 dark:border-slate-700 rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area"/,
+                 result)
+    assert_match(%r{</section>}, result)
+    assert_match(/森川泰敬/, result)
+    assert_match(/GLAMOROUS HONEY/, result)
+  end
+
+  test '{{div_begin class="members" subject="..."}}は見出しラベルを上書きできる' do
+    result = markdown('{{div_begin class="members" subject="旧メンバー"}}本文{{div_end}}')
+
+    assert_match(%r{<h2[^>]*>旧メンバー</h2>}, result)
+    assert_no_match(%r{<h2[^>]*>Members</h2>}, result)
+  end
+
+  test '{{div_begin class="members"}}のsubject値はHTMLエスケープされる' do
+    result = markdown('{{div_begin class="members" subject="a&b"}}本文{{div_end}}')
+
+    assert_match(%r{<h2[^>]*>a&amp;b</h2>}, result)
+  end
+
+  test '{{div_begin class="members"}}のネストで対応する{{div_end}}が</div></section>を出力する' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="members"}}
+
+      {{div_begin class="inner"}}
+
+      本文
+
+      {{div_end}}
+
+      {{div_end}}
+    MARKDOWN
+
+    assert_match(/<section data-controller="toggle"/, result)
+    assert_match(/<div class="inner">/, result)
+    assert_match(%r{</section>}, result)
+  end
+
   test '{{member パート,表示名,old_key}}でold_keyに一致するPersonの経歴カードが埋め込まれる' do
     Person.create!(name: 'のる', key: 'member-plugin-person',
                    old_key: URI.encode_www_form_component('のる(ex-ふりぃ)'.encode('EUC-JP')))

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -291,7 +291,7 @@ class ApplicationHelperTest < ActionView::TestCase
     MARKDOWN
 
     assert_match(/<section data-controller="toggle" data-toggle-open-value="false">/, result)
-    assert_match(%r{<h2[^>]*>Members</h2>}, result)
+    assert_match(/role="heading" aria-level="2"[^>]*>Members</, result)
     assert_match(/data-action="click->toggle#toggle"/, result)
     assert_match(/rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area"/, result)
     assert_match(%r{</section>}, result)
@@ -340,14 +340,20 @@ class ApplicationHelperTest < ActionView::TestCase
   test '{{div_begin class="members" subject="..."}}は見出しラベルを上書きできる' do
     result = markdown('{{div_begin class="members" subject="旧メンバー"}}本文{{div_end}}')
 
-    assert_match(%r{<h2[^>]*>旧メンバー</h2>}, result)
-    assert_no_match(%r{<h2[^>]*>Members</h2>}, result)
+    assert_match(/role="heading" aria-level="2"[^>]*>旧メンバー</, result)
+    assert_no_match(/role="heading" aria-level="2"[^>]*>Members</, result)
   end
 
   test '{{div_begin class="members"}}のsubject値はHTMLエスケープされる' do
     result = markdown('{{div_begin class="members" subject="a&b"}}本文{{div_end}}')
 
-    assert_match(%r{<h2[^>]*>a&amp;b</h2>}, result)
+    assert_match(/role="heading" aria-level="2"[^>]*>a&amp;b</, result)
+  end
+
+  test '{{div_begin class="members"}}の見出しは<h2>ではなくrole="heading"のdivを使う(markdown-content内の意図しない下線対策)' do
+    result = markdown('{{div_begin class="members"}}本文{{div_end}}')
+
+    assert_no_match(/<h2/, result)
   end
 
   test '{{div_begin class="members"}}のネストで対応する{{div_end}}が</div></section>を出力する' do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -132,7 +132,7 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/テストメンバー4/, result)
   end
 
-  test '{{snapshot}}で埋め込んだ過去スナップショットはユニットページ本体と異なり、1行プレビュー(summary)ではなくカード全体折りたたみになる' do
+  test '{{snapshot}}で埋め込んだ過去スナップショットはユニットページ本体と異なり、1行プレビュー(summary)を出さずメンバー一覧をその場で表示する' do
     unit = Unit.create!(key: 'snapshot-plugin-unit5', name: 'テストユニット5', status: 'active')
     snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: false, active: true)
     snapshot.snapshot_people.create!(person_name: 'テストメンバー5', part: :vocal, status: :active)
@@ -142,10 +142,8 @@ class ApplicationHelperTest < ActionView::TestCase
     # 1行プレビュー(summary)・hx-get遅延取得は使われない
     assert_no_match(/data-toggle-target="summary/, result)
     assert_no_match(/hx-get/, result)
-    # {{div_begin class="members"}}と同じ「カード全体折りたたみ」のマークアップ
-    assert_match(/data-toggle-target="content area"/, result)
-    assert_match(/data-toggle-open-value="false"/, result)
-    # 遅延取得ではなくその場でメンバー行が描画される
+    # {{div_begin class="members"}}と同じく、メンバー一覧は開閉に関わらず常に表示される
+    assert_match(/data-toggle-target="area"/, result)
     assert_match(/テストメンバー5/, result)
   end
 
@@ -274,17 +272,27 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/<section data-controller="toggle" data-toggle-open-value="false">/, result)
     assert_match(%r{<h2[^>]*>Members</h2>}, result)
     assert_match(/data-action="click->toggle#toggle"/, result)
-    assert_match(/rounded-2xl overflow-hidden shadow-sm" data-toggle-target="content area"/, result)
+    assert_match(/rounded-2xl overflow-hidden shadow-sm" data-toggle-target="area"/, result)
     assert_match(%r{</section>}, result)
     assert_match(/森川泰敬/, result)
     assert_match(/GLAMOROUS HONEY/, result)
   end
 
-  test '{{div_begin class="members"}}は初期状態でカード全体が折りたたまれ(閉じた状態)、メンバー名の1行プレビューは出さない' do
-    result = markdown('{{div_begin class="members"}}本文{{div_end}}')
+  test '{{div_begin class="members"}}はユニットページのMembersセクションと同様、メンバー一覧自体は開閉に関わらず常に表示される' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="members"}}
 
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey)
+      }}
+
+      {{div_end}}
+    MARKDOWN
+
+    # 初期状態(閉)はメンバーごとの経歴表示のみが非表示になり、メンバー一覧自体は表示される
     assert_match(/data-toggle-open-value="false"/, result)
     assert_no_match(/data-toggle-target="summary/, result)
+    assert_match(/森川泰敬/, result)
   end
 
   test '{{div_begin class="members" subject="..."}}は見出しラベルを上書きできる' do


### PR DESCRIPTION
## Summary
- `{{div_begin class="members"}}...{{div_end}}` を追加。ユニットページのMembersセクション（角丸カード＋シェブロン開閉トグル）と同じ見た目・挙動で`{{member}}`/`{{member2}}`の並びを囲めるようにした
- 開閉トグルはメンバー一覧自体ではなく、各メンバーの経歴表示（{{member2}}のdata等）のみを対象にする（ユニットページ本体の「現メンバー」表示と同じ挙動）
- `UnitSnapshotsComponent`に`summary_preview:`オプションを追加し、`{{snapshot}}`プラグイン埋め込み時（カスタムページ）は1行プレビュー＋hx-get遅延取得をやめ、`{{div_begin class="members"}}`と同じ「現メンバー」スタイルに統一。current: trueのスナップショットでも初期状態は折りたたみにした（ユニットページ本体側の表示は変更なし）
- 開閉のクリック領域を、小さいシェブロンアイコンのみから見出し（ラベル＋バッジ）全体に拡大。フォーカス時のアウトラインも付与
- Members見出し（`<h2>`）・メンバー名（`<h3>`）を、`role="heading"`の`<div>`に変更。カスタムページの`.markdown-content`向けグローバルCSS（`h2`のborder-bottom、`h3`のmargin）が意図せず適用され、下線や余白崩れが起きていたのを解消（見出しとしてのアクセシビリティは維持）
- `MemberRowComponent`の行paddingを`p-5`→`p-3`に縮小し、閉状態の見た目をよりコンパクトに
- `PLUGIN_CACHE_VERSION`を`v7`まで順次更新し、既存のプラグインレンダリングキャッシュを無効化
- 空行区切りなしで`{{member}}`等のブロックレベルプラグインを連続して書いた場合に、Redcarpetが`<p>`+`<br>`でまとめてしまい不正なネストHTML（ブラウザの自動修復で余計な空`<p>`が挿入され余白が崩れる）になる不具合を修正

## Test plan
- [x] `bin/rails test` が全件パスすること（363件）
- [x] `bundle exec rubocop` オフェンスなし
- [x] `{{div_begin class="members"}}`と`{{snapshot}}`のレンダリング結果を目視確認し、余白崩れ・不正なHTML・意図しない下線がないことを確認

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)