### PR TITLE
member2プラグイン: 手前の単独行member2を巻き込む複数行検出バグを修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -305,20 +305,26 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     register_plugin_placeholder(placeholders, html)
   end
 
-  # {{member パート,表示名,old_key,リンク}}（old_keyは未エンコード。リンクは省略可）
+  # {{member パート,表示名,old_key,リンク}}（old_keyは未エンコード・省略可。old_keyは"-"でも未指定扱い）
   # リンクはURL（http(s)://…）またはXアカウント（@xxxx）を指定する
   # （MemberRowComponentが@始まりをXアカウントとして自動判定しX(Twitter)へのリンクを表示する）。
   # 例: {{member Vocal,のる,のる(ex-ふりぃ),@noru_xxx}}
   # old_keyをEUC-JPエンコードしてPeopleを検索し、Unitページのメンバー行
   # （MemberRowComponent）と同じ経歴カードを出力する。
+  # old_keyが未指定（省略・"-"）の場合はPersonを検索せず、プロフィールへのリンクなしで
+  # 表示名・リンク（指定があれば）のみのメンバー行を出力する（member2のold_key省略時と同じ扱い）。
+  # old_keyが指定されているのに一致するPersonが見つからない場合は、従来通り何も出力しない
+  # （インポート時の記法ミス等を無言で不完全表示しないため）。
   def expand_member_plugin(args, _sectionable, placeholders, _open_tags)
     part, display_name, raw_old_key, link = args.split(',', 4).map { |v| v&.strip }
-    return '' if part.blank? || display_name.blank? || raw_old_key.blank?
+    return '' if part.blank? || display_name.blank?
 
-    person = Person.kept.find_by(old_key: encode_member_old_key(raw_old_key))
-    return '' unless person
+    no_old_key = raw_old_key.blank? || raw_old_key == '-'
+    person = Person.kept.find_by(old_key: encode_member_old_key(raw_old_key)) unless no_old_key
+    return '' if !no_old_key && !person
 
-    html = plugin_cache_fetch('member', person.cache_key_with_version, Digest::MD5.hexdigest(args)) do
+    person_key = person&.cache_key_with_version || 'noperson'
+    html = plugin_cache_fetch('member', person_key, Digest::MD5.hexdigest(args)) do
       member = MemberPluginRow.new(part: part, name: display_name, person: person, sns: link.presence && [link])
       render(MemberRowComponent.new(member: member, hide_status: true)).to_s
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,10 +180,16 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # {{プラグイン名 1行目のパラメータ\n複数行のdata\n}}
   # 1行目末尾に"}}"がない（=閉じていない）場合のみ複数行プラグインとして扱う。
   # 終端は単独で"}}"だけの行。
+  # 1行目パラメータの取り込みは"}}"の直前で止める（(?!\}\})）。素朴に[^\n]*のままだと、
+  # 単独行で閉じている{{member2 ...}}（1行目末尾に"}}"がある）についても「まだ閉じていない
+  # 複数行ブロック」と誤認し、その"}}"ごと1行目パラメータとして飲み込んだ上で、後方の
+  # 無関係な{{member2}}ブロックの終端"}}"行までを丸ごとdataとして誤結合してしまう
+  # （Issue#1133: リンク・old_keyを省略した複数行のmember2が、手前の単独行member2を
+  # 巻き込んで表示が崩れるバグ）。
   def expand_multiline_plugin_macros(text, sectionable, placeholders)
     names = Regexp.union(MULTILINE_PLUGIN_HANDLERS.keys)
 
-    text.gsub(/\{\{(#{names})(?:[ \t]+([^\n]*))?\n(.*?)\n[ \t]*\}\}[ \t]*$/m) do
+    text.gsub(/\{\{(#{names})(?:[ \t]+((?:(?!\}\})[^\n])*))?\n(.*?)\n[ \t]*\}\}[ \t]*$/m) do
       plugin_name = Regexp.last_match(1)
       args = Regexp.last_match(2)&.strip
       data = Regexp.last_match(3)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,6 +93,13 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   def markdown(text, sectionable: nil)
     return '' if text.blank?
 
+    # CRLF/CR改行（Windows由来の貼り付け等）が混じっていると、複数行プラグインの
+    # 終端検出（expand_multiline_plugin_macrosの"\n[ \t]*\}\}[ \t]*$"）等、本文中の
+    # \n・行末($)を前提にした正規表現が軒並みマッチしなくなり表示が崩れる
+    # （Issue#1132: CRLFの場合"}}"の直後が\rになり$にマッチしない）ため、
+    # 以降の処理はすべてLF改行に統一されている前提で行う。
+    text = text.gsub(/\r\n?/, "\n")
+
     placeholders = {}
     text = protect_html_comments(text, placeholders)
     text = expand_plugin_macros(text, sectionable:, placeholders:)

--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -220,9 +220,12 @@ class CustomPageDraftGenerator # rubocop:disable Metrics/ClassLength
   # {{member2 ...}}のような複数行プラグイン記法を丸ごとプレースホルダに退避する。
   # 終端は単独で"}}"だけの行（ブロック内に{{fn ...}}等がネストしていても、
   # それ単体を終端と誤認しない）。
+  # 1行目パラメータの取り込みは"}}"の直前で止める（(?!\}\})）。ApplicationHelper#expand_multiline_plugin_macros
+  # と同じ理由（Issue#1133）で、単独行で閉じた{{member2 ...}}を後方の無関係な
+  # member2ブロックの終端まで誤って巻き込まないようにするための対策。
   def protect_multiline_plugin_blocks(text, blocks)
     names = Regexp.union(MULTILINE_SUPPORTED_PLUGINS)
-    text.gsub(/\{\{(?:#{names})(?:[ \t]+[^\n]*)?\n.*?\n[ \t]*\}\}[ \t]*$/m) do |block|
+    text.gsub(/\{\{(?:#{names})(?:[ \t]+(?:(?!\}\})[^\n])*)?\n.*?\n[ \t]*\}\}[ \t]*$/m) do |block|
       token = "⟦MULTILINE_PLUGIN_#{blocks.length}⟧"
       blocks << block
       token

--- a/app/services/custom_page_draft_generator.rb
+++ b/app/services/custom_page_draft_generator.rb
@@ -100,6 +100,10 @@ class CustomPageDraftGenerator # rubocop:disable Metrics/ClassLength
 
   def generate
     body = @wikipage.wiki.to_s.dup
+    # CRLF/CR改行が混じっていると複数行プラグインの終端検出等、\n・行末($)前提の
+    # 正規表現が軒並みマッチしなくなるため、以降の処理の前にLF改行へ統一する
+    # （ApplicationHelper#markdownと同様。Issue#1132）。
+    body = body.gsub(/\r\n?/, "\n")
     body = strip_hidden_blocks(body)
     body = strip_comment_lines(body)
     body = convert_headings(body)

--- a/app/views/admin/custom_pages/_markdown_help.html.erb
+++ b/app/views/admin/custom_pages/_markdown_help.html.erb
@@ -62,7 +62,7 @@
         <dd class="mt-1 text-xs text-gray-600 dark:text-gray-400 space-y-1">
           <p>
             old_key（旧サイトのページ名。未エンコードでよい）が一致する人物を検索し、ユニットページと同じ経歴カードを埋め込みます（例: <code>{{member Vocal,のる,のる(ex-ふりぃ)}}</code>）。
-            old_keyが不明・不要な場合は <code>-</code> を指定します。
+            old_keyが不明・不要な場合は省略するか <code>-</code> を指定します（その場合、人物プロフィールへのリンクなしで表示名・リンクのみのメンバー行になります）。
           </p>
           <p>
             リンク（4番目のパラメータ、省略可）は <code>http(s)://…</code> のURL、または <code>@xxxx</code> のXアカウントを指定できます（例: <code>{{member Vocal,のる,のる(ex-ふりぃ),@noru_xxx}}</code>）。

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -534,6 +534,24 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/隠密華撃団/, result)
   end
 
+  test '{{member2}}はold_key・リンクを省略した複数行ブロックの手前に単独行の{{member2}}があっても巻き込まない(Issue#1133)' do
+    Person.create!(name: 'K.', key: 'member2-regression-guitar',
+                   old_key: URI.encode_www_form_component('K.'.encode('EUC-JP')))
+
+    result = markdown(<<~MARKDOWN)
+      {{member2 Guitar,K.,K.}}
+
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+      }}
+    MARKDOWN
+
+    assert_match(%r{href="/member2-regression-guitar"}, result)
+    assert_match(/森川泰敬/, result)
+    assert_match(/GLAMOROUS HONEY/, result)
+    assert_no_match(/\}\}/, result)
+  end
+
   # 以下、issue #1115（プラグインのcache対応）関連のテスト。
   # test環境のデフォルトcache_storeは:null_store（常にブロックを実行し何もキャッシュしない）
   # のため、キャッシュの有無を検証するテストのみ一時的にMemoryStoreへ差し替える。

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -464,6 +464,18 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(%r{2006/05/10加入}, result)
   end
 
+  test '{{member2}}はCRLF改行の本文でも複数行ブロックとして正しく終端を検出する(Issue#1132)' do
+    # Windows由来の貼り付け等でCRLFが混じると、"}}"直後が\rになり$にマッチしなくなり、
+    # 複数行ブロックの終端を見失って表示が崩れていた（実際のCustomPage本文で発覚）。
+    md = "{{member2 Bass,森川泰敬\r\n→ [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}\r\n}}\r\n"
+    result = markdown(md)
+
+    assert_match(/森川泰敬/, result)
+    assert_match(/GLAMOROUS HONEY/, result)
+    assert_match(%r{2006/05/10加入}, result)
+    assert_no_match(/\}\}/, result)
+  end
+
   test '{{member2}}はブロック内にネストした{{fn ...}}を終端の"}}"と誤認しない' do
     result = markdown(<<~MARKDOWN)
       前

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -410,6 +410,20 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/前後/, result)
   end
 
+  test '{{member}}はold_keyが"-"（未指定）の場合、Personへのリンクなしで表示名・リンクのみ表示する(Issue#1132)' do
+    result = markdown('{{member Vocal,相馬 ジュン平,-,http://smjp.jugem.jp/}}')
+
+    assert_match(/相馬 ジュン平/, result)
+    assert_match(%r{href="http://smjp.jugem.jp/"}, result)
+    assert_no_match(%r{<a[^>]*>相馬 ジュン平</a>}, result)
+  end
+
+  test '{{member}}はold_key自体を省略した場合も同様にPersonへのリンクなしで表示される(Issue#1132)' do
+    result = markdown('{{member Vocal,相馬 ジュン平}}')
+
+    assert_match(/相馬 ジュン平/, result)
+  end
+
   test '{{member}}はステータスバッジを表示しない' do
     Person.create!(name: 'のる', key: 'member-plugin-person3',
                    old_key: URI.encode_www_form_component('のる3'.encode('EUC-JP')))

--- a/test/services/custom_page_draft_generator_test.rb
+++ b/test/services/custom_page_draft_generator_test.rb
@@ -129,6 +129,18 @@ class CustomPageDraftGeneratorTest < ActiveSupport::TestCase
     assert_empty draft.warnings
   end
 
+  test 'CRLF改行のwikiでも{{member2 ...}}（複数行）の終端を見失わない（Issue#1132）' do
+    wiki = "{{member2 Bass,森川泰敬\r\n→ [GLAMOROUS HONEY|/glamorous-honey]{{fn 2006/05/10加入}}\r\n}}\r\n"
+    draft = generate(name: 'test', wiki: wiki)
+
+    assert_includes draft.body, <<~EXPECTED.strip
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+      }}
+    EXPECTED
+    assert_empty draft.warnings
+  end
+
   test '単独行の{{member2 ...}}の後に複数行の{{member2 ...}}があっても巻き込まれない（Issue#1133）' do
     wiki = <<~WIKI
       {{member2 Guitar,K.,K.}}

--- a/test/services/custom_page_draft_generator_test.rb
+++ b/test/services/custom_page_draft_generator_test.rb
@@ -129,6 +129,24 @@ class CustomPageDraftGeneratorTest < ActiveSupport::TestCase
     assert_empty draft.warnings
   end
 
+  test '単独行の{{member2 ...}}の後に複数行の{{member2 ...}}があっても巻き込まれない（Issue#1133）' do
+    wiki = <<~WIKI
+      {{member2 Guitar,K.,K.}}
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY|/glamorous-honey]{{fn 2006/05/10加入}}
+      }}
+    WIKI
+    draft = generate(name: 'test', wiki: wiki)
+
+    assert_includes draft.body, '{{member2 Guitar,K.,K.}}'
+    assert_includes draft.body, <<~EXPECTED.strip
+      {{member2 Bass,森川泰敬
+      → [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}
+      }}
+    EXPECTED
+    assert_empty draft.warnings
+  end
+
   test '{{include unit:ID,セクション名}} は対象のUnitに同名のSectionがあればそのまま残る' do
     unit = Unit.create!(name: 'テストバンド2', key: 'test-band2-for-draft-generator')
     unit.sections.create!(name: '概要', wiki_text: '本文')


### PR DESCRIPTION
## 概要
Fixes #1132

Rehabilitation Maniaxページの実データを使って調査したところ、3つの独立したバグ・不備が見つかったため、まとめて修正しました。

### 1. member2の複数行検出が手前の単独行member2を巻き込むバグ（当初想定していたもの）
`{{member2}}` で手前に単独行の `{{member2 ...}}` があると、複数行検出の正規表現が貪欲に `}}` を飲み込み、後方の無関係なブロックまで誤結合する。1行目パラメータの取り込みを `}}` の直前で止めるよう修正（実データではこのパターンには該当しなかったが、既存の潜在バグとして修正）。

### 2. {{member}}でold_key省略時にメンバー行が丸ごと消える
`{{member Vocal,相馬 ジュン平,-,http://smjp.jugem.jp/}}` のようにold_keyが `-`（不明・不要）でもPerson検索に失敗すると行全体が空文字になっていた（member2は対応済みだったがmemberは未対応）。old_key未指定・`-`の場合はPerson検索をスキップし、プロフィールへのリンクなしで表示名・リンクのみのメンバー行を出力するよう修正。

### 3. 【真因】CRLF改行で複数行member2ブロックの終端検出が失敗する（実際にスクリーンショットで再現していたもの）
実際のCustomPage本文のバイト列を確認したところ、Windows由来のCRLF（`\r\n`）改行が混在していた。複数行プラグインの終端判定 `\n[ \t]*\}\}[ \t]*$` は `}}` の直後が `\r` だと `$` にマッチせず終端を見失う。終端を見失うと未展開のブロックが単独行用の緩い正規表現（改行をまたいで最初の `}}` まで貪欲マッチ）に拾われ、ネストした `{{fn ...}}` の閉じ括弧で誤って途中終了し、経歴データがそのままメンバー名として表示される形で崩れていた。

`ApplicationHelper#markdown` / `CustomPageDraftGenerator#generate` の冒頭でCRLF/CRをLFに正規化することで解決。

## テスト
- `test/helpers/application_helper_test.rb` / `test/services/custom_page_draft_generator_test.rb` に3件それぞれの再現・回帰テストを追加
- 実際のRehabilitation Maniaxページの本文（本番相当データ、CRLF含む）をそのまま使って再現・修正確認済み（VOCAL/GUITAR/BASS/DRUMSすべて正しく表示されることを確認）
- pre-push hook（rubocop + 全テスト369件）: 全て成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)