### PR TITLE
{{snapshot}}プラグインでsnapshot_id省略時にcurrent=trueのスナップショットを採用する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -283,12 +283,17 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   end
 
   # {{snapshot ユニットkey,snapshot_id}}
+  # snapshot_idを省略した場合（{{snapshot ユニットkey}}）はcurrent: trueのスナップショットを採用する（issue #1136）
   def expand_snapshot_plugin(args, _sectionable, placeholders, _open_tags)
     unit_key, snapshot_id = args.split(',', 2).map(&:strip)
-    return '' if unit_key.blank? || snapshot_id.blank?
+    return '' if unit_key.blank?
 
     unit = Unit.kept.find_by(key: unit_key)
-    snapshot = unit&.unit_snapshots&.active&.find_by(id: snapshot_id)
+    snapshot = if snapshot_id.present?
+                 unit&.unit_snapshots&.active&.find_by(id: snapshot_id)
+               else
+                 unit&.unit_snapshots&.active&.find_by(current: true)
+               end
     return '' unless snapshot
 
     html = plugin_cache_fetch('snapshot', unit.cache_key_with_version, snapshot.cache_key_with_version) do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -168,6 +168,49 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/テストメンバー5/, result)
   end
 
+  test '{{snapshot key}}でsnapshot_idを省略した場合はcurrent: trueのスナップショットが埋め込まれる（issue #1136）' do
+    unit = Unit.create!(key: 'snapshot-plugin-unit-omit-id', name: 'テストユニット', status: 'active')
+    unit.unit_snapshots.create!(snapshot_date: '2019-01-01', current: false, active: true).tap do |s|
+      s.snapshot_people.create!(person_name: '過去メンバー', part: :vocal, status: :active)
+    end
+    current_snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: true, active: true)
+    current_snapshot.snapshot_people.create!(person_name: '現在メンバー', part: :vocal, status: :active)
+
+    result = markdown("{{snapshot #{unit.key}}}")
+
+    assert_match(/現在メンバー/, result)
+    assert_no_match(/過去メンバー/, result)
+  end
+
+  test '{{snapshot key}}でcurrent: trueのスナップショットが存在しない場合は空文字になる' do
+    unit = Unit.create!(key: 'snapshot-plugin-unit-omit-id-none', name: 'テストユニット', status: 'active')
+    unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: false, active: true).tap do |s|
+      s.snapshot_people.create!(person_name: '過去メンバー2', part: :vocal, status: :active)
+    end
+
+    result = markdown("前{{snapshot #{unit.key}}}後")
+
+    assert_match(/前後/, result)
+    assert_no_match(/過去メンバー2/, result)
+  end
+
+  test '{{snapshot key}}でcurrent: trueのスナップショットが非公開(active: false)の場合は空文字になる' do
+    unit = Unit.create!(key: 'snapshot-plugin-unit-omit-id-inactive', name: 'テストユニット', status: 'active')
+    snapshot = unit.unit_snapshots.create!(snapshot_date: '2020-01-01', current: true, active: false)
+    snapshot.snapshot_people.create!(person_name: '非公開メンバー', part: :vocal, status: :active)
+
+    result = markdown("前{{snapshot #{unit.key}}}後")
+
+    assert_match(/前後/, result)
+    assert_no_match(/非公開メンバー/, result)
+  end
+
+  test '{{snapshot key}}でユニットkeyが存在しない場合は空文字になる' do
+    result = markdown('前{{snapshot no-such-unit}}後')
+
+    assert_match(/前後/, result)
+  end
+
   test '{{item ASIN}}でItemカードが埋め込まれる' do
     item = Item.create!(title: 'テストアルバム', release_date: '2020-01-01',
                         link_url: 'https://example.com/item/1', asin: 'B00TESTASIN')


### PR DESCRIPTION
## Summary
- `{{snapshot ユニットkey,snapshot_id}}`プラグインで、`snapshot_id`を省略した`{{snapshot ユニットkey}}`形式でも展開できるようにした
- 省略時は`unit.unit_snapshots.active.find_by(current: true)`にフォールバックする（該当なしなら従来どおり空文字）
- `unit_key,snapshot_id`両方を指定する従来の記法は変更なし

## Test plan
- [x] `bundle exec rails test test/helpers/application_helper_test.rb` が全件パスすること
- [x] 関連する`custom_pages_controller_test.rb`/`snapshot_person_test.rb`/`custom_page_draft_generator_test.rb`もパスすること
- [x] rubocopがクリーンであること
- [ ] カスタムページに`{{snapshot ユニットkey}}`（id省略）を埋め込み、current=trueのメンバー構成が表示されることを確認する

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)