### PR TITLE
カスタムページに{{youtube 動画ID}}プラグインを追加する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,7 +133,8 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     'div_begin' => :expand_div_begin_plugin,
     'div_end' => :expand_div_end_plugin,
     'member' => :expand_member_plugin,
-    'member2' => :expand_member2_plugin
+    'member2' => :expand_member2_plugin,
+    'youtube' => :expand_youtube_plugin
   }.freeze
 
   # パラメータ（{{プラグイン名 ...}} の "..." 部分）を省略した記法
@@ -309,6 +310,22 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     html = plugin_cache_fetch('item', item.cache_key_with_version) do
       render(ItemCardComponent.new(item_card: item)).to_s
     end
+    register_plugin_placeholder(placeholders, html)
+  end
+
+  # {{youtube 動画ID}}
+  # YouTube動画IDを指定して埋め込みプレーヤーを表示する（例: {{youtube C-PqwPsrDd0}}）。
+  # 動画IDはYouTube仕様上、英数字・"-"・"_"の11文字固定。それ以外の入力（URL丸ごと等）は
+  # iframeのsrc属性に渡す値として想定外のため、埋め込まず何も出力しない。
+  def expand_youtube_plugin(args, _sectionable, placeholders, _open_tags)
+    video_id = args.strip
+    return '' unless video_id.match?(/\A[\w-]{11}\z/)
+
+    html = <<~HTML.chomp
+      <div class="relative pb-[56.25%] h-0 overflow-hidden rounded-xl my-4">
+        <iframe src="https://www.youtube.com/embed/#{video_id}" title="YouTube動画" loading="lazy" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen class="absolute top-0 left-0 w-full h-full border-0"></iframe>
+      </div>
+    HTML
     register_plugin_placeholder(placeholders, html)
   end
 

--- a/app/views/admin/custom_pages/_markdown_help.html.erb
+++ b/app/views/admin/custom_pages/_markdown_help.html.erb
@@ -43,6 +43,15 @@
 
       <div>
         <dt class="font-mono text-xs bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 rounded px-2 py-1 inline-block">
+          {{youtube 動画ID}}
+        </dt>
+        <dd class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+          指定したYouTube動画（英数字・"-"・"_"の11文字の動画ID）を埋め込みプレーヤーとして表示します（例: <code>{{youtube C-PqwPsrDd0}}</code>）。動画IDはYouTubeの動画URLの<code>v=</code>以降の部分です。
+        </dd>
+      </div>
+
+      <div>
+        <dt class="font-mono text-xs bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 rounded px-2 py-1 inline-block">
           {{div_begin class="値" subject="見出し"}} … {{div_end}}
         </dt>
         <dd class="mt-1 text-xs text-gray-600 dark:text-gray-400 space-y-1">

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -196,6 +196,27 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(/前後/, result)
   end
 
+  test '{{youtube 動画ID}}でYouTube動画が埋め込まれる' do
+    result = markdown('{{youtube C-PqwPsrDd0}}')
+
+    assert_match(%r{https://www\.youtube\.com/embed/C-PqwPsrDd0}, result)
+    assert_match(/<iframe/, result)
+  end
+
+  test '{{youtube 動画ID}}で複数行タグが崩れずに埋め込まれる' do
+    result = markdown("前\n\n{{youtube C-PqwPsrDd0}}\n\n後")
+
+    assert_no_match(/<p>[^<]*<iframe/, result)
+    assert_match(/<iframe/, result)
+  end
+
+  test '{{youtube 動画ID}}で動画IDの形式が不正な場合は空文字になる' do
+    result = markdown('前{{youtube ../../etc}}後')
+
+    assert_match(/前後/, result)
+    assert_no_match(/<iframe/, result)
+  end
+
   test '{{div_begin class="..."}}と{{div_end}}でdivタグが出力される' do
     result = markdown(<<~MARKDOWN)
       {{div_begin class="closable"}}


### PR DESCRIPTION
## Summary
- カスタムページのMarkdown本文で `{{youtube 動画ID}}` と書くとYouTube動画の埋め込みプレーヤーを表示できるプラグインを追加
- 動画ID（英数字・`-`・`_`の11文字固定）を正規表現で検証し、不正な値はiframeのsrc属性に渡さず何も出力しない
- 管理画面のMarkdownプラグイン一覧ヘルプ（`_markdown_help.html.erb`）に記法の説明を追加

## Test plan
- [x] `bin/rails test` が全件パスすること（372 runs, 0 failures）
- [x] `{{youtube C-PqwPsrDd0}}` で埋め込みiframeが出力される
- [x] 複数行の前後にテキストがあってもタグが崩れない
- [x] 不正な動画ID（11文字の`[\w-]`以外）を指定した場合は何も出力されない
- [ ] 実際の管理画面でカスタムページに `{{youtube C-PqwPsrDd0}}` を記述し、表示確認

Closes #1138

🤖 Generated with [Claude Code](https://claude.com/claude-code)