### PR TITLE
カスタムページのフッターに Management Information を設置する

### DIFF
--- a/app/components/management_information_component.html.erb
+++ b/app/components/management_information_component.html.erb
@@ -27,7 +27,7 @@
         </dd>
       </div>
     <% end %>
-    <% if @resource.old_wiki_id.present? %>
+    <% if @resource.respond_to?(:old_wiki_id) && @resource.old_wiki_id.present? %>
       <div class="flex justify-between items-center">
         <dt class="font-bold text-slate-400 dark:text-slate-500 italic">Old Wiki ID</dt>
         <dd><code class="bg-white dark:bg-slate-800 px-2 py-0.5 rounded border border-slate-200 dark:border-slate-700 font-mono text-slate-500 dark:text-slate-400"><%= @resource.old_wiki_id %></code></dd>

--- a/app/models/custom_page.rb
+++ b/app/models/custom_page.rb
@@ -57,6 +57,12 @@ class CustomPage < ApplicationRecord
     SYSTEM_KEYS.include?(key)
   end
 
+  def vkdb_url
+    return nil if old_key.blank?
+
+    "#{Rails.application.config.old_key_url_base}/#{old_key}.html"
+  end
+
   def expire_cache
     # 現時点ではページ固有のキャッシュはないが、将来的な拡張に備えたフック
     # サイドバーキャッシュも念のため削除

--- a/app/views/custom_pages/show.html.erb
+++ b/app/views/custom_pages/show.html.erb
@@ -23,6 +23,15 @@
             <div class="markdown-content max-w-none">
               <%= markdown(@page.body, sectionable: @page) %>
             </div>
+
+            <%= render ManagementInformationComponent.new(resource: @page) %>
+
+            <footer class="mt-12 pt-8 border-t border-slate-100 dark:border-slate-700 text-center">
+              <p class="text-[0.65rem] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest leading-loose">
+                Last updated<br>
+                <span class="text-slate-300 dark:text-slate-600 font-black"><%= @page.updated_at.strftime("%Y-%m-%d %H:%M:%S") %></span>
+              </p>
+            </footer>
           </div>
         </div>
 

--- a/test/controllers/custom_pages_controller_test.rb
+++ b/test/controllers/custom_pages_controller_test.rb
@@ -93,4 +93,29 @@ class CustomPagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, 'Snapshot Embed Member'
   end
+
+  test 'Management Information is hidden from a logged-out visitor' do
+    page = CustomPage.create!(key: 'management-info-hidden-test-page', title: 'Management Info Hidden Test',
+                              active: true, body: 'body')
+
+    get custom_page_path(key: page.key)
+
+    assert_response :success
+    assert_not_includes response.body, 'Management Information'
+  end
+
+  test 'Management Information shows ID, Key and a link to old_key on the old wiki for a super_operator' do
+    post login_path, params: { email: users(:one).email, password: 'password' }
+    page = CustomPage.create!(key: 'management-info-visible-test-page', title: 'Management Info Visible Test',
+                              active: true, body: 'body', old_key: 'management-info-visible-old-key')
+
+    get custom_page_path(key: page.key)
+
+    assert_response :success
+    assert_includes response.body, 'Management Information'
+    assert_includes response.body, page.id.to_s
+    assert_includes response.body, page.key
+    assert_includes response.body,
+                    "#{Rails.application.config.old_key_url_base}/#{page.old_key}.html"
+  end
 end


### PR DESCRIPTION
## Summary
- カスタムページ（`custom_pages/show.html.erb`）のフッターに、ユニット/人物ページと同様の `ManagementInformationComponent`（ID・Key・Old Key）を設置
- `CustomPage` に `vkdb_url` を追加し、Old Key を旧wikiへのリンクとして表示（Unit/Person と同じ実装パターン）
- `CustomPage` には `old_wiki_id` が存在しないため、コンポーネント側に `respond_to?` ガードを追加
- 表示権限はユニット/人物ページと同様（ログイン済み super_operator 以上のみ表示）、コンポーネントの `render?` をそのまま利用

## Test plan
- [x] `bin/rails test` が全件パスすること（378 runs, 0 failures）
- [x] 未ログイン時は Management Information が表示されないこと
- [x] super_operator でログイン時に ID・Key・Old Key（旧wikiリンク）が表示されること

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)