### PR TITLE
経歴の外部リンク[Label|URL]が(Part)付きだと誤ってMarkdown形式と解釈される不具合を修正

### DIFF
--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -74,7 +74,8 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
           }
         # Pattern 1b: [Label](target) or [Label](target)(Part) - Markdown形式のリンク
         # （CustomPageDraftGeneratorが旧[[Label|target]]記法から変換した経歴テキストなどで使用される）
-        when /\[([^\]]+)\]\(([^)]+)\)(?:\(([^)]+)\))?/
+        # Label に | を含む場合はPattern 2（旧wikiのパイプ外部リンク）を優先させるため除外する
+        when /\[([^\]|]+)\]\(([^)]+)\)(?:\(([^)]+)\))?/
           link_text = ::Regexp.last_match(1)
           target = ::Regexp.last_match(2)
           part_and_name = ::Regexp.last_match(3)

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -112,6 +112,32 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert_equal '二期', history[2][0][:part_and_name]
   end
 
+  test 'parse_old_history parses旧wiki形式の外部リンク[LinkText|URL]をexternal_urlとして扱う' do
+    history_str = '[Yahoo|http://www.yahoo.co.jp]'
+    person = Person.new(old_history: history_str)
+    history = person.parse_old_history
+
+    assert_equal 1, history.size
+    item = history[0][0]
+    assert_equal 'Yahoo', item[:unit_name]
+    assert_equal 'http://www.yahoo.co.jp', item[:external_url]
+    assert_nil item[:part_and_name]
+  end
+
+  test 'parse_old_history は外部リンク[LinkText|URL]に続く(Part)をURLと混同しない' do
+    # 修正前は Markdown形式パターンが先にマッチし、"三角形の時間|https://3kkj.jp/" が
+    # unit_name に、"Vo.&Dr.Flan" が external_url に誤って入ってしまう不具合があった
+    history_str = '[三角形の時間|https://3kkj.jp/](Vo.&Dr.Flan)'
+    person = Person.new(old_history: history_str)
+    history = person.parse_old_history
+
+    assert_equal 1, history.size
+    item = history[0][0]
+    assert_equal '三角形の時間', item[:unit_name]
+    assert_equal 'https://3kkj.jp/', item[:external_url]
+    assert_equal 'Vo.&Dr.Flan', item[:part_and_name]
+  end
+
   test 'parse_old_history handles parens wrapping correctly' do
     person = Person.new(old_history: '(Solo) → (BandA)')
     history = person.parse_old_history


### PR DESCRIPTION
## Summary
- 経歴（`old_history`）のパーサ `WikiParser#parse_history_string` で、旧wiki形式の外部リンク `[Label|URL]` の直後に `(Part)` が続く場合（例: `[三角形の時間|https://3kkj.jp/](Vo.&Dr.Flan)`）、本来マッチすべきパイプ形式の外部リンクパターンより先に、Markdown形式リンクパターン `[Label](URL)` が誤ってマッチしてしまい、リンクテキストに `|URL` が丸ごと含まれ、`(Part)` の中身がURLとして扱われてしまう不具合を修正
- Markdown形式リンクパターンの文字クラスから `|` を除外し、`|` を含む場合は確実にパイプ外部リンクパターン側に処理を譲るよう修正
- 併せて issue #1143 の例（`[Yahoo|http://www.yahoo.co.jp]`）と、上記のバグ再現ケースを検証するテストを追加

## Test plan
- [x] `bundle exec rails test` が全件パスすること（380 runs, 0 failures）
- [x] `bundle exec rubocop` で指摘なし
- [x] `[Yahoo|http://www.yahoo.co.jp]` が正しく外部リンクとしてパースされることを確認
- [x] `[三角形の時間|https://3kkj.jp/](Vo.&Dr.Flan)` がリンクテキスト/URL/Partに正しく分離されることを確認
- [x] 既存のMarkdown形式リンク `[Label](URL)` の挙動に影響がないことを確認（regressionなし）

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)