### PR TITLE
feat: カスタムページMarkdownに左右配置用の{{div_begin class="columns"}}を追加

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -60,6 +60,27 @@
       border-radius: 0.25em;
     }
     details.closable[open] summary { margin-bottom: 0.25em; }
+
+    /* {{div_begin class="columns"}} プラグイン（画像・{{youtube}}埋め込み等の左右配置）。
+       モバイル幅では縦積み、md幅以上で2カラムに並べる（issue #1146）。
+       直下の各要素（<p><img></p>や{{youtube}}のプレースホルダー等）がそのままグリッドの
+       各カラムになるため、1カラムに複数要素をまとめたい場合は{{div_begin}}（無属性）で
+       さらに内側を1つの<div>にまとめる。 */
+    .columns {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1rem;
+      align-items: center;
+      margin: 1em 0;
+    }
+    .columns > *:first-child { margin-top: 0; }
+    .columns > *:last-child { margin-bottom: 0; }
+  }
+
+  @media (min-width: 768px) {
+    .markdown-content .columns {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
 
   @variant dark {

--- a/app/views/admin/custom_pages/_form.html.erb
+++ b/app/views/admin/custom_pages/_form.html.erb
@@ -43,28 +43,7 @@
       <%= form.label :body, "本文", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <p class="text-xs text-gray-500 dark:text-gray-400">Markdown形式で記述できます（<code>{{include}}</code>/<code>{{snapshot}}</code>/<code>{{item}}</code> は「プレビュー」を押すと確認できます）</p>
     </div>
-    <% if custom_page.persisted? && current_user.admin? %>
-      <div class="mt-1 mb-2 flex items-center gap-3">
-        <input type="file"
-               accept="image/*"
-               class="hidden"
-               aria-hidden="true"
-               data-markdown-preview-target="imageInput"
-               data-action="change->markdown-preview#uploadImage">
-        <button type="button"
-                class="inline-flex items-center gap-1 px-3 py-1 text-sm border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
-                data-action="click->markdown-preview#selectImage"
-                aria-label="画像をアップロードしてMarkdownに挿入">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
-          画像をアップロード
-        </button>
-        <span class="text-xs text-gray-500 dark:text-gray-400"
-              data-markdown-preview-target="uploadStatus"
-              aria-live="polite"></span>
-      </div>
-    <% else %>
+    <% unless custom_page.persisted? && current_user.admin? %>
       <p class="mt-1 mb-2 text-xs text-gray-400 dark:text-gray-500">画像のアップロードは保存後に利用できます</p>
     <% end %>
     <div class="mt-1 grid grid-cols-2 gap-4">
@@ -86,18 +65,42 @@
     <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">公開する（チェックなしは下書き）</span>
   </div>
 
-  <div class="sticky bottom-0 z-10 -mx-6 -mb-6 flex items-center justify-end gap-x-4 rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
-    <span class="text-xs text-gray-500 dark:text-gray-400"
-          data-markdown-preview-target="previewStatus"
-          aria-live="polite"></span>
-    <%= link_to "キャンセル", admin_custom_pages_path,
-        class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
-    <button type="button"
-            class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium border border-gray-300 rounded-md text-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:text-gray-100 dark:hover:bg-gray-700"
-            data-action="click->markdown-preview#serverPreview">
-      プレビュー
-    </button>
-    <%= form.submit custom_page.persisted? ? "更新" : "作成",
-        class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
+  <div class="sticky bottom-0 z-10 -mx-6 -mb-6 flex items-center justify-between gap-x-4 rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
+    <div class="flex items-center gap-3">
+      <% if custom_page.persisted? && current_user.admin? %>
+        <input type="file"
+               accept="image/*"
+               class="hidden"
+               aria-hidden="true"
+               data-markdown-preview-target="imageInput"
+               data-action="change->markdown-preview#uploadImage">
+        <button type="button"
+                class="inline-flex items-center gap-1 px-3 py-1 text-sm border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                data-action="click->markdown-preview#selectImage"
+                aria-label="画像をアップロードしてMarkdownに挿入">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          画像をアップロード
+        </button>
+        <span class="text-xs text-gray-500 dark:text-gray-400"
+              data-markdown-preview-target="uploadStatus"
+              aria-live="polite"></span>
+      <% end %>
+    </div>
+    <div class="flex items-center gap-x-4">
+      <span class="text-xs text-gray-500 dark:text-gray-400"
+            data-markdown-preview-target="previewStatus"
+            aria-live="polite"></span>
+      <%= link_to "キャンセル", admin_custom_pages_path,
+          class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
+      <button type="button"
+              class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium border border-gray-300 rounded-md text-gray-900 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:text-gray-100 dark:hover:bg-gray-700"
+              data-action="click->markdown-preview#serverPreview">
+        プレビュー
+      </button>
+      <%= form.submit custom_page.persisted? ? "更新" : "作成",
+          class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/admin/custom_pages/_markdown_help.html.erb
+++ b/app/views/admin/custom_pages/_markdown_help.html.erb
@@ -60,7 +60,23 @@
             <li><code>{{div_begin}}</code> … 属性なしの<code>&lt;div&gt;</code></li>
             <li><code>{{div_begin class="値"}}</code> … <code>class</code>付きの<code>&lt;div&gt;</code></li>
             <li><code>{{div_begin class="closable" subject="見出し"}}</code> … 折りたたみ表示（初期状態は閉じている）</li>
+            <li><code>{{div_begin class="columns"}}</code> … 囲んだ範囲を左右に並べて表示（下記参照）</li>
           </ul>
+        </dd>
+      </div>
+
+      <div>
+        <dt class="font-mono text-xs bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 rounded px-2 py-1 inline-block">
+          {{div_begin class="columns"}} … {{div_end}}
+        </dt>
+        <dd class="mt-1 text-xs text-gray-600 dark:text-gray-400 space-y-1">
+          <p>画像や<code>{{youtube}}</code>埋め込みなどを左右2カラムに並べて表示します（スマホ幅では縦積みになります）。</p>
+          <p>囲んだ範囲の直下にある要素（画像1枚・<code>{{youtube}}</code>1つなど）がそれぞれ1つのカラムになります。1つのカラムに複数の要素をまとめたい場合は、内側をさらに<code>{{div_begin}}</code>（属性なし）で1つの<code>&lt;div&gt;</code>にまとめてください。</p>
+          <pre class="mt-1 font-mono text-xs bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 rounded px-2 py-1 overflow-x-auto">{{div_begin class="columns"}}
+![説明](画像URL)
+
+{{youtube C-PqwPsrDd0}}
+{{div_end}}</pre>
         </dd>
       </div>
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -438,6 +438,20 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_match(%r{</section>}, result)
   end
 
+  test '{{div_begin class="columns"}}は画像や{{youtube}}埋め込みを左右に並べるための<div class="columns">を出力する' do
+    result = markdown(<<~MARKDOWN)
+      {{div_begin class="columns"}}
+      ![説明](https://example.com/image.jpg)
+
+      {{youtube C-PqwPsrDd0}}
+      {{div_end}}
+    MARKDOWN
+
+    assert_match(/<div class="columns">/, result)
+    assert_match(%r{<img[^>]+src="https://example.com/image.jpg"}, result)
+    assert_match(%r{<iframe src="https://www.youtube.com/embed/C-PqwPsrDd0"}, result)
+  end
+
   test '{{member パート,表示名,old_key}}でold_keyに一致するPersonの経歴カードが埋め込まれる' do
     Person.create!(name: 'のる', key: 'member-plugin-person',
                    old_key: URI.encode_www_form_component('のる(ex-ふりぃ)'.encode('EUC-JP')))


### PR DESCRIPTION
## Summary
- カスタムページMarkdownの`{{div_begin}}`プラグインに、画像や`{{youtube}}`埋め込みなどを左右2カラムに並べるための専用クラス`{{div_begin class="columns"}}`を追加（モバイル幅は縦積み、md幅以上で2カラム、縦中央揃え）
- Ruby側（`expand_div_begin_plugin`）は既にclass属性をそのまま`<div class="...">`として出力する仕組みのため、CSS（`.markdown-content .columns`）とドキュメントの追加のみで対応
- 管理画面のMarkdownヘルプ（`_markdown_help.html.erb`）に使い方と記法例を追記
- スクロールで見えなくなっていたカスタムページ編集フォームの画像アップロードボタンを、フッターの既存sticky枠の左端に移動

## Test plan
- [x] `bin/rails test` が全件パスすること（381 runs, 0 failures）
- [x] `bundle exec rubocop` で新規オフェンスがないこと
- [ ] 管理画面でカスタムページを編集し、`{{div_begin class="columns"}}`で画像とYouTube埋め込みを並べてプレビューが崩れないことを目視確認
- [ ] 編集フォームで本文を下にスクロールしても画像アップロードボタンがフッターsticky枠内に表示され続けることを確認

Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)