### PR TITLE
fix: {{member}}プラグインでold_key不一致時もリンクなしで表示する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -340,17 +340,16 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   # 例: {{member Vocal,のる,のる(ex-ふりぃ),@noru_xxx}}
   # old_keyをEUC-JPエンコードしてPeopleを検索し、Unitページのメンバー行
   # （MemberRowComponent）と同じ経歴カードを出力する。
-  # old_keyが未指定（省略・"-"）の場合はPersonを検索せず、プロフィールへのリンクなしで
-  # 表示名・リンク（指定があれば）のみのメンバー行を出力する（member2のold_key省略時と同じ扱い）。
-  # old_keyが指定されているのに一致するPersonが見つからない場合は、従来通り何も出力しない
-  # （インポート時の記法ミス等を無言で不完全表示しないため）。
+  # old_keyが未指定（省略・"-"）の場合、または指定されていても一致するPersonが
+  # 見つからない場合は、Personを検索せず（または見つからなかった扱いで）プロフィールへの
+  # リンクなしで表示名・リンク（指定があれば）のみのメンバー行を出力する
+  # （member2のold_key省略・不一致時と同じ扱い。Issue#1152）。
   def expand_member_plugin(args, _sectionable, placeholders, _open_tags)
     part, display_name, raw_old_key, link = args.split(',', 4).map { |v| v&.strip }
     return '' if part.blank? || display_name.blank?
 
     no_old_key = raw_old_key.blank? || raw_old_key == '-'
     person = Person.kept.find_by(old_key: encode_member_old_key(raw_old_key)) unless no_old_key
-    return '' if !no_old_key && !person
 
     person_key = person&.cache_key_with_version || 'noperson'
     html = plugin_cache_fetch('member', person_key, Digest::MD5.hexdigest(args)) do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -482,10 +482,11 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_no_match(/DB上の名前/, result)
   end
 
-  test '{{member}}で一致するPersonが見つからない場合は空文字になる' do
-    result = markdown('前{{member Vocal,のる,存在しないキー}}後')
+  test '{{member}}で一致するPersonが見つからない場合、old_key未指定と同様プロフィールリンクなしで表示される(Issue#1152)' do
+    result = markdown('{{member Vocal,のる,存在しないキー}}')
 
-    assert_match(/前後/, result)
+    assert_match(/のる/, result)
+    assert_no_match(%r{<a[^>]*>のる</a>}, result)
   end
 
   test '{{member}}はold_keyが"-"（未指定）の場合、Personへのリンクなしで表示名・リンクのみ表示する(Issue#1132)' do


### PR DESCRIPTION
## Summary
- `{{member パート,表示名,old_key,リンク}}` プラグインで、old_keyが指定されているのに一致するPersonが見つからない場合、これまでメンバー行が丸ごと出力されていなかった問題を修正
- old_key未指定（省略・`-`）の場合と同様、プロフィールリンクなしで表示名・リンク（あれば）のみを表示するようフォールバックする（`{{member2}}`と同じ挙動に統一）

## Test plan
- [x] `bin/rails test` が全件パスすること（381 runs, 0 failures）
- [x] RuboCop パス
- [x] `{{member}}` 関連テスト（application_helper_test.rb）で old_key不一致時の新しい期待値（リンクなし表示）を確認

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)