### PR TITLE
論理削除済みのUnit/Personを物理削除可能にする

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -104,13 +104,18 @@ module Admin
     end
 
     def purge
-      unless @person.redirect_source?
-        redirect_to admin_people_path(redirect_source: 'only'), alert: 'リダイレクト元のレコードのみ物理削除できます。'
+      unless @person.discarded?
+        redirect_to admin_people_path(redirect_source: 'only'), alert: '論理削除済みのレコードのみ物理削除できます。'
         return
       end
 
       if Item.by_artist_key(@person.key).exists?
         redirect_to admin_people_path(redirect_source: 'only'), alert: 'このキーはまだ作品から参照されているため物理削除できません。'
+        return
+      end
+
+      if Person.with_discarded.where(destination_key: @person.key).exists?
+        redirect_to admin_people_path(redirect_source: 'only'), alert: 'このキーはリダイレクト先として参照されているため物理削除できません。'
         return
       end
 

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -119,16 +119,30 @@ module Admin
         return
       end
 
+      # Person側から見た unit_people/snapshot_people は必ず person_id が紐づいた実在のメンバー情報なので、
+      # 1件でも残っていれば物理削除しない(Unit側のインライン仮メンバー情報とは異なり道連れ削除はしない)。
+      if @person.unit_people.exists?
+        redirect_to admin_people_path(redirect_source: 'only'), alert: 'ユニットのメンバー情報が残っているため物理削除できません。'
+        return
+      end
+
+      if @person.snapshot_people.exists?
+        redirect_to admin_people_path(redirect_source: 'only'), alert: 'ユニットスナップショットのメンバー情報が残っているため物理削除できません。'
+        return
+      end
+
       key_was = @person.key
       destination_was = @person.destination_key
-      @person.destroy!
-      UpdateLog.create!(
-        user: current_user,
-        action: 'purge',
-        loggable_type: 'Person',
-        loggable_id: @person.id,
-        diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
-      )
+      ActiveRecord::Base.transaction do
+        @person.destroy!
+        UpdateLog.create!(
+          user: current_user,
+          action: 'purge',
+          loggable_type: 'Person',
+          loggable_id: @person.id,
+          diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
+        )
+      end
       redirect_to admin_people_path(redirect_source: 'only'), notice: 'リダイレクト元レコードを物理削除しました。'
     end
 

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -135,16 +135,26 @@ module Admin
         return
       end
 
+      # 実在のPersonに紐づくメンバー情報(unit_people)が残っている場合は物理削除できない。
+      # person_id が nil のインライン仮メンバー情報のみの場合は destroy_all で道連れに削除する。
+      if @unit.unit_people.where.not(person_id: nil).exists?
+        redirect_to admin_units_path(redirect_source: 'only'), alert: '実在のPersonに紐づくメンバー情報が残っているため物理削除できません。'
+        return
+      end
+
       key_was = @unit.key
       destination_was = @unit.destination_key
-      @unit.destroy!
-      UpdateLog.create!(
-        user: current_user,
-        action: 'purge',
-        loggable_type: 'Unit',
-        loggable_id: @unit.id,
-        diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
-      )
+      ActiveRecord::Base.transaction do
+        @unit.unit_people.destroy_all
+        @unit.destroy!
+        UpdateLog.create!(
+          user: current_user,
+          action: 'purge',
+          loggable_type: 'Unit',
+          loggable_id: @unit.id,
+          diff: { 'key' => [key_was, nil], 'destination_key' => [destination_was, nil] }
+        )
+      end
       redirect_to admin_units_path(redirect_source: 'only'), notice: 'リダイレクト元レコードを物理削除しました。'
     end
 

--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -120,13 +120,18 @@ module Admin
     end
 
     def purge
-      unless @unit.redirect_source?
-        redirect_to admin_units_path(redirect_source: 'only'), alert: 'リダイレクト元のレコードのみ物理削除できます。'
+      unless @unit.discarded?
+        redirect_to admin_units_path(redirect_source: 'only'), alert: '論理削除済みのレコードのみ物理削除できます。'
         return
       end
 
       if Item.by_artist_key(@unit.key).exists?
         redirect_to admin_units_path(redirect_source: 'only'), alert: 'このキーはまだ作品から参照されているため物理削除できません。'
+        return
+      end
+
+      if Unit.with_discarded.where(destination_key: @unit.key).exists?
+        redirect_to admin_units_path(redirect_source: 'only'), alert: 'このキーはリダイレクト先として参照されているため物理削除できません。'
         return
       end
 

--- a/app/models/concerns/key_changeable.rb
+++ b/app/models/concerns/key_changeable.rb
@@ -31,8 +31,7 @@ module KeyChangeable
     end
   end
 
-  # discard 済み・destination_key ありのリダイレクト元レコードかどうか(issue #891)。
-  # 物理削除できる対象をこの条件に厳密に限定する。
+  # discard 済み・destination_key ありのリダイレクト元レコードかどうか。
   def redirect_source?
     discarded? && destination_key.present?
   end

--- a/app/views/admin/people/index.html.erb
+++ b/app/views/admin/people/index.html.erb
@@ -100,7 +100,7 @@
                       form: { class: "inline-block" },
                       class: "text-green-600 hover:text-green-900 bg-transparent border-0 cursor-pointer p-0" %>
                 <% end %>
-                <% if person.redirect_source? && current_user.admin? %>
+                <% if current_user.admin? %>
                   <%= button_to "物理削除", purge_admin_person_path(person), method: :delete,
                       form: { class: "inline-block ml-4" },
                       onclick: "return confirm('「#{person.key}」を物理削除します。この操作は元に戻せません。よろしいですか？')",

--- a/app/views/admin/units/index.html.erb
+++ b/app/views/admin/units/index.html.erb
@@ -99,7 +99,7 @@
                       form: { class: "inline-block" },
                       class: "text-green-600 hover:text-green-900 bg-transparent border-0 cursor-pointer p-0" %>
                 <% end %>
-                <% if unit.redirect_source? && current_user.admin? %>
+                <% if current_user.admin? %>
                   <%= button_to "物理削除", purge_admin_unit_path(unit), method: :delete,
                       form: { class: "inline-block ml-4" },
                       onclick: "return confirm('「#{unit.key}」を物理削除します。この操作は元に戻せません。よろしいですか？')",

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -107,13 +107,13 @@ module Admin
       assert Person.exists?(id: stub.id)
     end
 
-    test 'purge is rejected for a non redirect-source record' do
+    test 'purge is rejected for a record that is not discarded' do
       login_as_admin
 
       delete purge_admin_person_path(@person)
 
       assert_redirected_to admin_people_path(redirect_source: 'only')
-      assert_equal 'リダイレクト元のレコードのみ物理削除できます。', flash[:alert]
+      assert_equal '論理削除済みのレコードのみ物理削除できます。', flash[:alert]
       assert Person.exists?(id: @person.id)
     end
 
@@ -130,6 +130,18 @@ module Admin
       assert UpdateLog.exists?(loggable_type: 'Person', loggable_id: stub.id, action: 'purge')
     end
 
+    test 'purge deletes a plain discarded record without a destination_key' do
+      login_as_admin
+      @person.discard
+
+      delete purge_admin_person_path(@person)
+
+      assert_redirected_to admin_people_path(redirect_source: 'only')
+      assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
+      assert_not Person.exists?(id: @person.id)
+      assert UpdateLog.exists?(loggable_type: 'Person', loggable_id: @person.id, action: 'purge')
+    end
+
     test 'purge is rejected when the key is still referenced by an item' do
       login_as_admin
       @person.change_key!('new-key-for-purge-item-test')
@@ -142,6 +154,19 @@ module Admin
       assert_redirected_to admin_people_path(redirect_source: 'only')
       assert_equal 'このキーはまだ作品から参照されているため物理削除できません。', flash[:alert]
       assert Person.exists?(id: stub.id)
+    end
+
+    test 'purge is rejected when the key is still used as another redirect destination' do
+      login_as_admin
+      @person.discard
+      Person.create!(name: 'Newer Person', key: 'newer-person-controller-test', status: :active,
+                     destination_key: @person.key).discard
+
+      delete purge_admin_person_path(@person)
+
+      assert_redirected_to admin_people_path(redirect_source: 'only')
+      assert_equal 'このキーはリダイレクト先として参照されているため物理削除できません。', flash[:alert]
+      assert Person.exists?(id: @person.id)
     end
 
     test 'purging a redirect-source stub allows reverting the key' do

--- a/test/controllers/admin/people_controller_test.rb
+++ b/test/controllers/admin/people_controller_test.rb
@@ -169,6 +169,33 @@ module Admin
       assert Person.exists?(id: @person.id)
     end
 
+    test 'purge is rejected when the person is still linked via unit_people' do
+      login_as_admin
+      unit = Unit.create!(name: 'Some Band', key: 'some-band-purge-test', status: :active)
+      unit.unit_people.create!(person: @person, status: :active, part: :vocal)
+      @person.discard
+
+      delete purge_admin_person_path(@person)
+
+      assert_redirected_to admin_people_path(redirect_source: 'only')
+      assert_equal 'ユニットのメンバー情報が残っているため物理削除できません。', flash[:alert]
+      assert Person.exists?(id: @person.id)
+    end
+
+    test 'purge is rejected when the person is still linked via snapshot_people' do
+      login_as_admin
+      unit = Unit.create!(name: 'Some Band', key: 'some-band-snapshot-purge-test', status: :active)
+      unit_snapshot = unit.unit_snapshots.create!(snapshot_date: Date.current)
+      unit_snapshot.snapshot_people.create!(person: @person, status: :active, part: :vocal)
+      @person.discard
+
+      delete purge_admin_person_path(@person)
+
+      assert_redirected_to admin_people_path(redirect_source: 'only')
+      assert_equal 'ユニットスナップショットのメンバー情報が残っているため物理削除できません。', flash[:alert]
+      assert Person.exists?(id: @person.id)
+    end
+
     test 'purging a redirect-source stub allows reverting the key' do
       login_as_admin
       @person.change_key!('new-key-for-purge-revert-test')

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -81,13 +81,13 @@ module Admin
       assert Unit.exists?(id: stub.id)
     end
 
-    test 'purge is rejected for a non redirect-source record' do
+    test 'purge is rejected for a record that is not discarded' do
       login_as_admin
 
       delete purge_admin_unit_path(@unit)
 
       assert_redirected_to admin_units_path(redirect_source: 'only')
-      assert_equal 'リダイレクト元のレコードのみ物理削除できます。', flash[:alert]
+      assert_equal '論理削除済みのレコードのみ物理削除できます。', flash[:alert]
       assert Unit.exists?(id: @unit.id)
     end
 
@@ -104,6 +104,18 @@ module Admin
       assert UpdateLog.exists?(loggable_type: 'Unit', loggable_id: stub.id, action: 'purge')
     end
 
+    test 'purge deletes a plain discarded record without a destination_key' do
+      login_as_admin
+      @unit.discard
+
+      delete purge_admin_unit_path(@unit)
+
+      assert_redirected_to admin_units_path(redirect_source: 'only')
+      assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
+      assert_not Unit.exists?(id: @unit.id)
+      assert UpdateLog.exists?(loggable_type: 'Unit', loggable_id: @unit.id, action: 'purge')
+    end
+
     test 'purge is rejected when the key is still referenced by an item' do
       login_as_admin
       @unit.change_key!('new-key-for-purge-item-test')
@@ -116,6 +128,19 @@ module Admin
       assert_redirected_to admin_units_path(redirect_source: 'only')
       assert_equal 'このキーはまだ作品から参照されているため物理削除できません。', flash[:alert]
       assert Unit.exists?(id: stub.id)
+    end
+
+    test 'purge is rejected when the key is still used as another redirect destination' do
+      login_as_admin
+      @unit.discard
+      Unit.create!(name: 'Newer Unit', key: 'newer-unit-controller-test', status: :active,
+                   destination_key: @unit.key).discard
+
+      delete purge_admin_unit_path(@unit)
+
+      assert_redirected_to admin_units_path(redirect_source: 'only')
+      assert_equal 'このキーはリダイレクト先として参照されているため物理削除できません。', flash[:alert]
+      assert Unit.exists?(id: @unit.id)
     end
 
     test 'purging a redirect-source stub allows reverting the key' do

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -143,6 +143,32 @@ module Admin
       assert Unit.exists?(id: @unit.id)
     end
 
+    test 'purge is rejected when a unit_people row still references a real person' do
+      login_as_admin
+      person = Person.create!(name: 'Real Member', key: 'real-member-purge-test', status: :active)
+      @unit.unit_people.create!(person: person, status: :active, part: :vocal)
+      @unit.discard
+
+      delete purge_admin_unit_path(@unit)
+
+      assert_redirected_to admin_units_path(redirect_source: 'only')
+      assert_equal '実在のPersonに紐づくメンバー情報が残っているため物理削除できません。', flash[:alert]
+      assert Unit.exists?(id: @unit.id)
+    end
+
+    test 'purge destroys unit_people rows that only hold inline placeholder data' do
+      login_as_admin
+      unit_person = @unit.unit_people.create!(person_name: 'Inline Member', status: :active, part: :vocal)
+      @unit.discard
+
+      delete purge_admin_unit_path(@unit)
+
+      assert_redirected_to admin_units_path(redirect_source: 'only')
+      assert_equal 'リダイレクト元レコードを物理削除しました。', flash[:notice]
+      assert_not Unit.exists?(id: @unit.id)
+      assert_not UnitPerson.exists?(id: unit_person.id)
+    end
+
     test 'purging a redirect-source stub allows reverting the key' do
       login_as_admin
       @unit.change_key!('new-key-for-purge-revert-test')


### PR DESCRIPTION
## Summary
- 物理削除ボタンの表示・実行条件を `redirect_source?`（destination_key あり限定）から `discarded?` に変更し、通常の論理削除レコードも物理削除できるようにした
- 既存の作品参照チェック（Item.by_artist_key）に加え、キーが他レコードのリダイレクト先（destination_key）として参照されている場合は物理削除を拒否するガードを追加
- 物理削除時に unit_people/snapshot_people の外部キー違反が発生する不具合を修正
  - Unit: 実Person（person_id あり）に紐づく unit_people が残っていれば拒否。person_id が nil のインライン仮メンバー情報のみなら道連れ削除してから物理削除
  - Person: unit_people／snapshot_people が1件でも残っていれば拒否（実データのため道連れ削除はしない）

## Test plan
- [x] `bundle exec rails test test/controllers/admin/units_controller_test.rb test/controllers/admin/people_controller_test.rb` が全件パス
- [x] `bundle exec rubocop` オフェンスなし
- [x] pre-push hook（全テスト389件・RuboCop）パス

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)