### PR TITLE
feat: 全ユニット共通のテンポラリsnapshotプールを追加

### DIFF
--- a/app/models/temporary_snapshot_person.rb
+++ b/app/models/temporary_snapshot_person.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: temporary_snapshot_people
+#
+#  id              :bigint           not null, primary key
+#  inline_history  :text
+#  name_alias      :string
+#  old_person_key  :string
+#  part            :integer          default("vocal"), not null
+#  part_alias      :string
+#  person_key      :string
+#  person_name     :string
+#  sns             :json
+#  source          :string           default("career_history_import"), not null
+#  status          :integer          default("active"), not null
+#  support         :boolean          default(FALSE), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  hint_unit_id    :bigint
+#  person_id       :bigint
+#
+# Indexes
+#
+#  index_temporary_snapshot_people_on_hint_unit_id    (hint_unit_id)
+#  index_temporary_snapshot_people_on_old_person_key  (old_person_key)
+#  index_temporary_snapshot_people_on_person_id       (person_id)
+#  index_temporary_snapshot_people_on_person_key      (person_key)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (hint_unit_id => units.id)
+#  fk_rails_...  (person_id => people.id)
+#
+# 全ユニット共通の一時プール。person_importer#parse_career_history など、
+# どのユニットの・どのスナップショットに紐付けるべきか機械的に判定できない
+# メンバー情報を一旦ここに保持し、管理画面から手動で SnapshotPerson へ振り分ける。
+# 詳細: https://github.com/kuwavkdb/vkdby/issues/1167
+class TemporarySnapshotPerson < ApplicationRecord
+  belongs_to :person, optional: true
+  belongs_to :hint_unit, class_name: 'Unit', optional: true
+
+  enum :status, { undefined: 0, active: 1, pending: 2, left: 3, concerned: 4, pre: 5 }
+  enum :part, { vocal: 0, guitar: 1, bass: 2, drums: 3, keyboard: 4, dj: 5, unknown: 99 }
+
+  validates :status, presence: true
+  validates :part, presence: true
+  validate :person_or_name_presence
+
+  before_validation :find_person_by_key, if: -> { person_id.blank? && person_key.present? }
+
+  def name
+    name_alias.presence || person_name.presence || person&.name
+  end
+
+  def key
+    person&.key || person_key
+  end
+
+  private
+
+  def person_or_name_presence
+    return unless person_id.blank? && person_name.blank?
+
+    errors.add(:base, 'Person or Person Name must be present')
+  end
+
+  def find_person_by_key
+    found_person = Person.find_by(key: person_key)
+    return unless found_person
+
+    self.person = found_person
+  end
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -43,6 +43,7 @@ class Unit < ApplicationRecord
   has_many :tag_indices, through: :tag_index_items
   has_many :sections, as: :sectionable, dependent: :destroy
   has_many :unit_snapshots, dependent: :destroy
+  has_many :temporary_snapshot_people, foreign_key: :hint_unit_id, inverse_of: :hint_unit, dependent: :nullify
   enum :unit_type, { band: 0, unit: 1, session: 2, solo: 3, limited: 4, moved: 5, other: 99 }
   enum :status, { pre: 0, active: 1, freeze: 2, disbanded: 3, unknown: 99 }
 

--- a/db/migrate/20260818120000_create_temporary_snapshot_people.rb
+++ b/db/migrate/20260818120000_create_temporary_snapshot_people.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateTemporarySnapshotPeople < ActiveRecord::Migration[8.1]
+  def change
+    create_table :temporary_snapshot_people do |t|
+      t.bigint  :person_id
+      t.string  :person_key
+      t.string  :person_name
+      t.string  :name_alias
+      t.integer :part, null: false, default: 0
+      t.string  :part_alias
+      t.boolean :support, null: false, default: false
+      t.integer :status, null: false, default: 1
+      t.string  :old_person_key
+      t.json    :sns
+      t.text    :inline_history
+      t.bigint  :hint_unit_id
+      t.string  :source, null: false, default: 'career_history_import'
+
+      t.timestamps
+    end
+
+    add_index :temporary_snapshot_people, :person_id
+    add_index :temporary_snapshot_people, :person_key
+    add_index :temporary_snapshot_people, :old_person_key
+    add_index :temporary_snapshot_people, :hint_unit_id
+
+    add_foreign_key :temporary_snapshot_people, :people
+    add_foreign_key :temporary_snapshot_people, :units, column: :hint_unit_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_08_071018) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -262,6 +262,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_071018) do
     t.index ["name"], name: "index_tag_indices_on_name", unique: true
   end
 
+  create_table "temporary_snapshot_people", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "hint_unit_id"
+    t.text "inline_history"
+    t.string "name_alias"
+    t.string "old_person_key"
+    t.integer "part", default: 0, null: false
+    t.string "part_alias"
+    t.bigint "person_id"
+    t.string "person_key"
+    t.string "person_name"
+    t.json "sns"
+    t.string "source", default: "career_history_import", null: false
+    t.integer "status", default: 1, null: false
+    t.boolean "support", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.index ["hint_unit_id"], name: "index_temporary_snapshot_people_on_hint_unit_id"
+    t.index ["old_person_key"], name: "index_temporary_snapshot_people_on_old_person_key"
+    t.index ["person_id"], name: "index_temporary_snapshot_people_on_person_id"
+    t.index ["person_key"], name: "index_temporary_snapshot_people_on_person_key"
+  end
+
   create_table "trends", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.text "content"
@@ -429,6 +451,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_08_071018) do
   add_foreign_key "snapshot_people", "unit_snapshots"
   add_foreign_key "tag_index_items", "tag_indices"
   add_foreign_key "tag_indices", "index_groups"
+  add_foreign_key "temporary_snapshot_people", "people"
+  add_foreign_key "temporary_snapshot_people", "units", column: "hint_unit_id"
   add_foreign_key "unit_logs", "units"
   add_foreign_key "unit_people", "people"
   add_foreign_key "unit_people", "units"

--- a/docs/import/render_transfer.md
+++ b/docs/import/render_transfer.md
@@ -42,3 +42,15 @@ direnv allow .
 実行すると確認プロンプトが表示されます。`y` を入力すると転送が開始されます。
 
 転送対象テーブル: `units`, `unit_people`, `people`, `trends`, `items`, `sections`, `links`, `index_groups`, `tag_index_items`, `tag_indices`, `snapshot_people`, `unit_snapshots`, `users`
+
+## 特定テーブルのみの転送
+
+新規追加したテーブルなど、特定の1テーブルだけをRenderに転送したい場合は個別スクリプトを用意する。
+
+- `temporary_snapshot_people` テーブルのみを転送する場合:
+
+  ```bash
+  ./script/transfer_temporary_snapshot_people_to_render.sh
+  ```
+
+  Render側で対象テーブルのマイグレーションが適用済み（デプロイ済み）であることが前提。

--- a/lib/tasks/temporary_snapshot_people.rake
+++ b/lib/tasks/temporary_snapshot_people.rake
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+namespace :temporary_snapshot_people do
+  desc '既存のギャップ一覧（tmp/unit_people_snapshot_gap.tsv）を temporary_snapshot_people に取り込む（ローカル調査・移行用）'
+  task backfill_from_gap_tsv: :environment do
+    tsv_path = Rails.root.join('tmp', 'unit_people_snapshot_gap.tsv')
+    abort "エラー: #{tsv_path} が見つかりません（ローカルにのみ存在する調査用ファイルです）" unless File.exist?(tsv_path)
+
+    lines = File.readlines(tsv_path, chomp: true)
+    headers = lines.shift.split("\t")
+
+    created = 0
+    already_pooled = 0
+    not_found = []
+
+    lines.each do |line|
+      next if line.blank?
+
+      row = headers.zip(line.split("\t")).to_h
+      unit = Unit.kept.find_by(key: row['unit_key'])
+      person = Person.kept.find_by(key: row['person_key'])
+
+      unit_person = (UnitPerson.find_by(unit: unit, person: person, status: row['status']) if unit && person)
+      unit_person ||= (UnitPerson.find_by(unit: unit, person_key: row['person_key'], status: row['status']) if unit)
+
+      if unit.nil? || unit_person.nil?
+        not_found << "#{row['person_name']}（#{row['person_key']}） / #{row['unit_name']}（#{row['unit_key']}）"
+        next
+      end
+
+      if TemporarySnapshotPerson.where(hint_unit_id: unit.id)
+                                .where(person_id: unit_person.person_id, person_key: unit_person.person_key)
+                                .exists?
+        already_pooled += 1
+        next
+      end
+
+      TemporarySnapshotPerson.create!(
+        person_id: unit_person.person_id,
+        person_key: unit_person.person_key,
+        person_name: unit_person.person_name,
+        part: unit_person.part,
+        part_alias: unit_person.part_alias,
+        support: unit_person.support,
+        status: unit_person.status,
+        old_person_key: unit_person.old_person_key,
+        sns: unit_person.sns,
+        inline_history: unit_person.inline_history,
+        hint_unit_id: unit.id,
+        source: 'unit_people_gap_backfill'
+      )
+      created += 1
+    end
+
+    puts "取り込み完了: #{created}件作成 / #{already_pooled}件は既にプール済みのためスキップ"
+    if not_found.any?
+      puts "対応するUnitPersonが見つからなかった行: #{not_found.size}件"
+      not_found.each { |line| puts "  - #{line}" }
+    end
+  end
+end

--- a/script/transfer_temporary_snapshot_people_to_render.sh
+++ b/script/transfer_temporary_snapshot_people_to_render.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# temporary_snapshot_people テーブルのみをRenderの本番DBに転送するスクリプト
+# 事前に .envrc の DB_CONNECTION が設定されていること（direnv 等で読み込む）
+# 事前にRender側で temporary_snapshot_people テーブルのマイグレーションが
+# 適用済みであること（通常はデプロイ時の `rails db:migrate` で自動適用される）
+
+set -e
+
+if [ -z "$DB_CONNECTION" ]; then
+  echo "エラー: DB_CONNECTION が設定されていません"
+  echo "  .envrc に export DB_CONNECTION=... を設定し、direnv allow を実行してください"
+  exit 1
+fi
+
+TABLE="temporary_snapshot_people"
+DB_NAME="vkdby_development"
+
+echo "=== ${TABLE} テーブルのみをRenderへ転送します ==="
+echo "警告: Renderの本番DBの ${TABLE} テーブルのデータが上書きされます。続行しますか？ [y/N]"
+read -r answer
+if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+  echo "中止しました"
+  exit 0
+fi
+
+echo "--- データ転送中 ---"
+(echo "TRUNCATE ${TABLE} RESTART IDENTITY CASCADE;" && pg_dump -t "$TABLE" -a "$DB_NAME") | psql "$DB_CONNECTION"
+
+echo ""
+echo "=== 転送完了 ==="


### PR DESCRIPTION
## Summary
- `temporary_snapshot_people` テーブルを新設（#1167 の設計案・候補A）。ユニットに従属しないフラットなプールとして、`hint_unit_id`（振り分け先候補ユニット）を持たせた
- `TemporarySnapshotPerson` モデルを追加し、`Unit` 側に逆参照（`has_many :temporary_snapshot_people`, `dependent: :nullify`）を追加
- 既存ギャップ（`tmp/unit_people_snapshot_gap.tsv`、184件）を `temporary_snapshot_people` に取り込むローカル用rakeタスク `temporary_snapshot_people:backfill_from_gap_tsv` を追加
  - 汎用的な再算出ロジックだと `unit_people` の `status: left` 全体（2,491件、ノイズ含む）を拾ってしまうため、既存tsvの184件のみを対象にする方式にした
- `temporary_snapshot_people` テーブルのみをRenderの本番DBへ転送するスクリプト `script/transfer_temporary_snapshot_people_to_render.sh` を追加し、`docs/import/render_transfer.md` に手順を追記

## Test plan
- [x] `bundle exec rails test` が全件パスすること（395 runs, 0 failures）
- [x] `bundle exec rubocop` がクリーンであること
- [x] `bundle exec rails temporary_snapshot_people:backfill_from_gap_tsv` をローカルで実行し、184件作成・再実行で0件（冪等）を確認

## 未実施（本PRのスコープ外）
- 管理画面UI（プール表示・振り分け機能）は未実装。#1167 本体で別途対応予定
- `person_importer.rb#parse_career_history` の恒常的な書き込み先変更は未対応
- Renderへの実データ転送は未実施（Render側にテーブルがデプロイされてから実行する）

Related: #1167（本PRではテーブル・バックフィル・転送スクリプトのみ対応。issueは管理画面UI実装まで残す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)