### PR TITLE
feat: テンポラリスナップショットプールの管理画面UIを追加

### DIFF
--- a/app/controllers/admin/temporary_snapshot_people_controller.rb
+++ b/app/controllers/admin/temporary_snapshot_people_controller.rb
@@ -8,6 +8,9 @@ module Admin
       @temporary_snapshot_people = TemporarySnapshotPerson.includes(:person, :hint_unit).order(:created_at)
       @unit = Unit.kept.find_by(id: params[:unit_id])
       @temporary_snapshot_people = @temporary_snapshot_people.where(hint_unit_id: @unit.id) if @unit
+
+      @assigned_unit = Unit.kept.find_by(id: params[:assigned_unit_id])
+      @assigned_unit_snapshot = @assigned_unit&.unit_snapshots&.find_by(id: params[:assigned_unit_snapshot_id])
     end
 
     def assign
@@ -30,8 +33,9 @@ module Admin
       if snapshot_person.save
         record_update_log(snapshot_person, action: 'create')
         @temporary_snapshot_person.destroy
-        redirect_to admin_temporary_snapshot_people_path,
-                    notice: "#{@unit.name} のスナップショットへ振り分けました。"
+        redirect_to admin_temporary_snapshot_people_path(
+          assigned_unit_id: @unit.id, assigned_unit_snapshot_id: unit_snapshot.id
+        ), notice: "#{@unit.name} のスナップショットへ振り分けました。"
       else
         @unit_snapshots = @unit.unit_snapshots.chronological
         flash.now[:alert] = "振り分けに失敗しました: #{snapshot_person.errors.full_messages.join('、')}"

--- a/app/controllers/admin/temporary_snapshot_people_controller.rb
+++ b/app/controllers/admin/temporary_snapshot_people_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Admin
+  class TemporarySnapshotPeopleController < Admin::BaseController
+    before_action :set_temporary_snapshot_person, only: %i[destroy assign]
+
+    def index
+      @temporary_snapshot_people = TemporarySnapshotPerson.includes(:person, :hint_unit).order(:created_at)
+      @unit = Unit.kept.find_by(id: params[:unit_id])
+      @temporary_snapshot_people = @temporary_snapshot_people.where(hint_unit_id: @unit.id) if @unit
+    end
+
+    def assign
+      target_unit_id = params[:unit_id].presence || @temporary_snapshot_person.hint_unit_id
+      @unit = Unit.kept.find_by(id: target_unit_id)
+      @unit_snapshots = @unit ? @unit.unit_snapshots.chronological : UnitSnapshot.none
+
+      return unless request.post?
+
+      if @unit.nil?
+        redirect_to assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person),
+                    alert: 'ユニットを選択してください。'
+        return
+      end
+
+      unit_snapshot = target_unit_snapshot
+
+      snapshot_person = unit_snapshot.snapshot_people.build(snapshot_person_attributes)
+
+      if snapshot_person.save
+        record_update_log(snapshot_person, action: 'create')
+        @temporary_snapshot_person.destroy
+        redirect_to admin_temporary_snapshot_people_path,
+                    notice: "#{@unit.name} のスナップショットへ振り分けました。"
+      else
+        @unit_snapshots = @unit.unit_snapshots.chronological
+        flash.now[:alert] = "振り分けに失敗しました: #{snapshot_person.errors.full_messages.join('、')}"
+        render :assign, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @temporary_snapshot_person.destroy
+      redirect_to admin_temporary_snapshot_people_path, notice: 'プールから削除しました。'
+    end
+
+    private
+
+    def set_temporary_snapshot_person
+      @temporary_snapshot_person = TemporarySnapshotPerson.find(params[:id])
+    end
+
+    def target_unit_snapshot
+      if params[:unit_snapshot_id].present?
+        @unit.unit_snapshots.find(params[:unit_snapshot_id])
+      else
+        @unit.unit_snapshots.create!(current: false, active: false, past: true)
+      end
+    end
+
+    def snapshot_person_attributes
+      {
+        person_id: @temporary_snapshot_person.person_id,
+        person_key: @temporary_snapshot_person.person_key,
+        person_name: @temporary_snapshot_person.person_name,
+        name_alias: params[:name_alias].presence,
+        part: params[:part].presence || @temporary_snapshot_person.part,
+        part_alias: params[:part_alias].presence || @temporary_snapshot_person.part_alias,
+        status: params[:status].presence || @temporary_snapshot_person.status,
+        support: ActiveModel::Type::Boolean.new.cast(params[:support]) || false,
+        sns: @temporary_snapshot_person.sns,
+        inline_history: @temporary_snapshot_person.inline_history
+      }
+    end
+  end
+end

--- a/app/views/admin/temporary_snapshot_people/assign.html.erb
+++ b/app/views/admin/temporary_snapshot_people/assign.html.erb
@@ -1,0 +1,109 @@
+<% title = "#{@temporary_snapshot_person.name} を振り分ける" %>
+<% content_for :title, title %>
+<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= title %></h1>
+  <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
+    パート: <%= @temporary_snapshot_person.part.humanize %> / ステータス: <%= @temporary_snapshot_person.status.humanize %>
+    <% if @temporary_snapshot_person.hint_unit %>
+      / 元のヒントユニット: <%= @temporary_snapshot_person.hint_unit.name %>
+    <% end %>
+  </p>
+
+  <% if flash[:alert] %>
+    <div class="mt-4 bg-red-50 dark:bg-red-950 p-4 rounded text-red-700 dark:text-red-300 text-sm"><%= flash[:alert] %></div>
+  <% end %>
+
+  <div class="mt-6 bg-white shadow rounded-lg p-6 dark:bg-gray-900">
+    <h2 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">1. 振り分け先ユニットを選択</h2>
+    <%= form_with url: assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person), method: :get, class: "flex items-end gap-3" do %>
+      <div data-controller="unit-select"
+           data-unit-select-url-value="<%= search_admin_units_path %>"
+           class="relative flex-1">
+        <label for="unit_search" class="block text-sm font-medium text-gray-700 dark:text-gray-300">ユニット</label>
+        <input type="text"
+               id="unit_search"
+               value="<%= @unit&.name %>"
+               placeholder="ユニット名で検索..."
+               autocomplete="off"
+               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+               data-unit-select-target="input"
+               data-action="input->unit-select#search keydown->unit-select#onKeydown">
+        <div data-unit-select-target="results"
+             class="absolute z-50 mt-1 w-full bg-white dark:bg-gray-800 shadow-lg rounded-md border border-gray-200 dark:border-gray-700 hidden max-h-60 overflow-y-auto"></div>
+        <input type="hidden" name="unit_id" value="<%= @unit&.id %>" data-unit-select-target="unitId">
+      </div>
+      <button type="submit" class="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-600 cursor-pointer">表示を切り替え</button>
+    <% end %>
+  </div>
+
+  <% if @unit %>
+    <div class="mt-6 bg-white shadow rounded-lg p-6 dark:bg-gray-900">
+      <h2 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-4">2. <%= @unit.name %> のスナップショットへ振り分け</h2>
+
+      <%= form_with url: assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person), method: :post, class: "space-y-4" do %>
+        <input type="hidden" name="unit_id" value="<%= @unit.id %>">
+
+        <div>
+          <span class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">振り分け先スナップショット</span>
+          <div class="space-y-2">
+            <% @unit_snapshots.each do |snapshot| %>
+              <label class="flex items-start gap-2">
+                <input type="radio" name="unit_snapshot_id" value="<%= snapshot.id %>" class="mt-1 form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:bg-gray-700 dark:border-gray-600">
+                <span class="text-sm text-gray-700 dark:text-gray-300">
+                  <%= snapshot.display_label || "(ラベル・日付未設定)" %>
+                  <span class="text-gray-400 dark:text-gray-500">— <%= snapshot.member_names.presence || "メンバーなし" %></span>
+                </span>
+              </label>
+            <% end %>
+            <label class="flex items-start gap-2">
+              <input type="radio" name="unit_snapshot_id" value="" class="mt-1 form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:bg-gray-700 dark:border-gray-600" <%= 'checked' if @unit_snapshots.empty? %>>
+              <span class="text-sm text-gray-700 dark:text-gray-300">新しいスナップショットを作成する</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <label for="name_alias" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Name Alias</label>
+            <input type="text" name="name_alias" id="name_alias"
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                   placeholder="表示名を上書きする場合に入力">
+          </div>
+          <div>
+            <label for="part" class="block text-sm font-medium text-gray-700 dark:text-gray-300">パート</label>
+            <select name="part" id="part" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+              <% TemporarySnapshotPerson.parts.each_key do |k| %>
+                <option value="<%= k %>" <%= 'selected' if k == @temporary_snapshot_person.part %>><%= k.humanize %></option>
+              <% end %>
+            </select>
+          </div>
+          <div>
+            <label for="part_alias" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Part Alias</label>
+            <input type="text" name="part_alias" id="part_alias" value="<%= @temporary_snapshot_person.part_alias %>"
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+          </div>
+          <div>
+            <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">ステータス</span>
+            <select name="status" id="status" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+              <% TemporarySnapshotPerson.statuses.each_key do |s| %>
+                <option value="<%= s %>" <%= 'selected' if s == @temporary_snapshot_person.status %>><%= s.humanize %></option>
+              <% end %>
+            </select>
+          </div>
+        </div>
+
+        <label class="flex items-center gap-2">
+          <input type="checkbox" name="support" value="1" <%= 'checked' if @temporary_snapshot_person.support? %> class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">サポートメンバー</span>
+        </label>
+
+        <div class="flex justify-end gap-3 pt-2">
+          <%= link_to "キャンセル", admin_temporary_snapshot_people_path, class: "inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-600" %>
+          <button type="submit" class="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 cursor-pointer">この内容で振り分ける</button>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">ユニットを選択すると、振り分け先スナップショットを選べます。</p>
+  <% end %>
+</div>

--- a/app/views/admin/temporary_snapshot_people/assign.html.erb
+++ b/app/views/admin/temporary_snapshot_people/assign.html.erb
@@ -51,6 +51,9 @@
                 <input type="radio" name="unit_snapshot_id" value="<%= snapshot.id %>" class="mt-1 form-radio text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:bg-gray-700 dark:border-gray-600">
                 <span class="text-sm text-gray-700 dark:text-gray-300">
                   <%= snapshot.display_label || "(ラベル・日付未設定)" %>
+                  <% if snapshot.current? %>
+                    <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">Current</span>
+                  <% end %>
                   <span class="text-gray-400 dark:text-gray-500">— <%= snapshot.member_names.presence || "メンバーなし" %></span>
                 </span>
               </label>

--- a/app/views/admin/temporary_snapshot_people/assign.html.erb
+++ b/app/views/admin/temporary_snapshot_people/assign.html.erb
@@ -5,7 +5,7 @@
   <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
     パート: <%= @temporary_snapshot_person.part.humanize %> / ステータス: <%= @temporary_snapshot_person.status.humanize %>
     <% if @temporary_snapshot_person.hint_unit %>
-      / 元のヒントユニット: <%= @temporary_snapshot_person.hint_unit.name %>
+      / 元のヒントユニット: <%= link_to @temporary_snapshot_person.hint_unit.name, edit_admin_unit_path(@temporary_snapshot_person.hint_unit), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     <% end %>
   </p>
 

--- a/app/views/admin/temporary_snapshot_people/index.html.erb
+++ b/app/views/admin/temporary_snapshot_people/index.html.erb
@@ -8,6 +8,14 @@
     どのユニット・スナップショットに紐付けるべきか判定できなかったメンバー情報の一時置き場です。内容を確認のうえ、適切なユニットのスナップショットへ振り分けてください。
   </p>
 
+  <% if @assigned_unit && @assigned_unit_snapshot %>
+    <div class="mt-4 rounded-md bg-green-50 dark:bg-green-950 p-4 text-sm text-green-800 dark:text-green-200">
+      <%= link_to "#{@assigned_unit.name} のスナップショットを管理画面で確認する →",
+            edit_admin_unit_unit_snapshot_path(@assigned_unit, @assigned_unit_snapshot),
+            class: "font-medium underline hover:no-underline" %>
+    </div>
+  <% end %>
+
   <% if @unit %>
     <div class="mt-4 flex items-center gap-2 text-sm">
       <span class="text-gray-700 dark:text-gray-300">絞り込み中: <strong><%= @unit.name %></strong></span>

--- a/app/views/admin/temporary_snapshot_people/index.html.erb
+++ b/app/views/admin/temporary_snapshot_people/index.html.erb
@@ -1,0 +1,66 @@
+<% title = "テンポラリスナップショットプール" %>
+<% content_for :title, title %>
+<div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="flex items-center justify-between mb-4">
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= title %></h1>
+  </div>
+  <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
+    どのユニット・スナップショットに紐付けるべきか判定できなかったメンバー情報の一時置き場です。内容を確認のうえ、適切なユニットのスナップショットへ振り分けてください。
+  </p>
+
+  <% if @unit %>
+    <div class="mt-4 flex items-center gap-2 text-sm">
+      <span class="text-gray-700 dark:text-gray-300">絞り込み中: <strong><%= @unit.name %></strong></span>
+      <%= link_to "絞り込みを解除", admin_temporary_snapshot_people_path, class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+    </div>
+  <% end %>
+
+  <div class="mt-6 overflow-x-auto bg-white shadow rounded-lg dark:bg-gray-900">
+    <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
+      <thead class="bg-gray-50 dark:bg-gray-800">
+        <tr>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">名前</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">ヒントユニット</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">パート</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">ステータス</th>
+          <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">出所</th>
+          <th scope="col" class="relative py-2 pl-3 pr-4 sm:pr-6"><span class="sr-only">操作</span></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-700">
+        <% @temporary_snapshot_people.each do |tsp| %>
+          <tr>
+            <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-900 dark:text-gray-200">
+              <%= tsp.name %>
+              <% if tsp.person %>
+                <%= link_to "(Person)", edit_admin_person_path(tsp.person), class: "text-xs text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+              <% end %>
+            </td>
+            <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400">
+              <% if tsp.hint_unit %>
+                <%= link_to tsp.hint_unit.name, edit_admin_unit_path(tsp.hint_unit), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+              <% else %>
+                <span class="text-gray-400 dark:text-gray-500">なし</span>
+              <% end %>
+            </td>
+            <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400"><%= tsp.part.humanize %></td>
+            <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400"><%= tsp.status.humanize %></td>
+            <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400"><%= tsp.source %></td>
+            <td class="relative whitespace-nowrap py-3 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+              <%= link_to "振り分ける", assign_admin_temporary_snapshot_person_path(tsp), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 mr-4" %>
+              <%= button_to "削除", admin_temporary_snapshot_person_path(tsp), method: :delete,
+                    class: "text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 bg-transparent border-0 p-0 cursor-pointer inline",
+                    form: { style: "display:inline" },
+                    onclick: "return confirm('プールから削除します。よろしいですか？')" %>
+            </td>
+          </tr>
+        <% end %>
+        <% if @temporary_snapshot_people.empty? %>
+          <tr>
+            <td colspan="6" class="px-3 py-6 text-center text-sm text-gray-500 dark:text-gray-400">プールは空です。</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/admin/units/_snapshots_list.html.erb
+++ b/app/views/admin/units/_snapshots_list.html.erb
@@ -8,6 +8,16 @@
             class: "text-sm text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
   </div>
+
+  <% temporary_count = TemporarySnapshotPerson.where(hint_unit_id: unit.id).count %>
+  <% if temporary_count.positive? %>
+    <div class="mb-4">
+      <%= link_to admin_temporary_snapshot_people_path(unit_id: unit.id),
+            class: "inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-200 dark:bg-amber-900 dark:text-amber-200 dark:hover:bg-amber-800" do %>
+        テンポラリプールに<%= temporary_count %>件あります →
+      <% end %>
+    </div>
+  <% end %>
   <% if unit_snapshots.any? %>
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -137,6 +137,15 @@
                       </svg>
                       Units
                     <% end %>
+                    <%= link_to admin_temporary_snapshot_people_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-indigo-600 dark:text-zinc-500 dark:group-hover:text-indigo-400">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                      </svg>
+                      Temporary Pool
+                      <% if (count = TemporarySnapshotPerson.count).positive? %>
+                        <span class="ml-1.5 inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200"><%= count %></span>
+                      <% end %>
+                    <% end %>
                     <%= link_to admin_people_path, class: "group flex items-center px-4 py-2 text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 whitespace-nowrap" do %>
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2 text-zinc-400 group-hover:text-indigo-600 dark:text-zinc-500 dark:group-hover:text-indigo-400">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
@@ -334,6 +343,9 @@
                       <!-- Mobile Admin Links -->
                       <%= link_to admin_units_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: Units
+                      <% end %>
+                      <%= link_to admin_temporary_snapshot_people_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
+                        Settings: Temporary Pool
                       <% end %>
                       <%= link_to admin_people_path, class: "block px-4 py-2 text-base font-medium text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:text-zinc-100 dark:hover:bg-zinc-900 transition-colors" do %>
                         Settings: People

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,12 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         end
       end
     end
+    resources :temporary_snapshot_people, only: %i[index destroy] do
+      member do
+        get :assign
+        post :assign
+      end
+    end
     resources :people do
       collection do
         get :search

--- a/test/controllers/admin/temporary_snapshot_people_controller_test.rb
+++ b/test/controllers/admin/temporary_snapshot_people_controller_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class TemporarySnapshotPeopleControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      post login_path, params: { email: users(:one).email, password: 'password' }
+      @unit = units(:one)
+      @snapshot = unit_snapshots(:one)
+      @temporary_snapshot_person = TemporarySnapshotPerson.create!(
+        person_name: 'テスト太郎',
+        part: :vocal,
+        status: :left,
+        hint_unit: @unit
+      )
+    end
+
+    test 'should get index' do
+      get admin_temporary_snapshot_people_path
+      assert_response :success
+    end
+
+    test 'should get index filtered by unit' do
+      get admin_temporary_snapshot_people_path(unit_id: @unit.id)
+      assert_response :success
+      assert_match @temporary_snapshot_person.name, response.body
+    end
+
+    test 'should get assign form defaulting to hint unit' do
+      get assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person)
+      assert_response :success
+      assert_match @unit.name, response.body
+    end
+
+    test 'should assign to an existing snapshot and remove from pool' do
+      assert_difference('SnapshotPerson.count', 1) do
+        assert_difference('TemporarySnapshotPerson.count', -1) do
+          post assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person), params: {
+            unit_id: @unit.id,
+            unit_snapshot_id: @snapshot.id,
+            part: 'vocal',
+            status: 'left'
+          }
+        end
+      end
+
+      assert_redirected_to admin_temporary_snapshot_people_path
+      assert_equal 'テスト太郎', @snapshot.reload.snapshot_people.last.person_name
+    end
+
+    test 'should assign to a newly created snapshot when none selected' do
+      assert_difference('UnitSnapshot.count', 1) do
+        post assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person), params: {
+          unit_id: @unit.id,
+          unit_snapshot_id: '',
+          part: 'vocal',
+          status: 'left'
+        }
+      end
+
+      assert_redirected_to admin_temporary_snapshot_people_path
+    end
+
+    test 'should not assign without a target unit' do
+      unhinted = TemporarySnapshotPerson.create!(person_name: 'ヒントなし', part: :vocal, status: :left)
+
+      assert_no_difference('SnapshotPerson.count') do
+        post assign_admin_temporary_snapshot_person_path(unhinted), params: { unit_id: '' }
+      end
+      assert_redirected_to assign_admin_temporary_snapshot_person_path(unhinted)
+    end
+
+    test 'should destroy pooled entry' do
+      assert_difference('TemporarySnapshotPerson.count', -1) do
+        delete admin_temporary_snapshot_person_path(@temporary_snapshot_person)
+      end
+      assert_redirected_to admin_temporary_snapshot_people_path
+    end
+
+    test 'should redirect to login when not authenticated' do
+      delete logout_path
+      get admin_temporary_snapshot_people_path
+      assert_redirected_to login_path
+    end
+  end
+end

--- a/test/controllers/admin/temporary_snapshot_people_controller_test.rb
+++ b/test/controllers/admin/temporary_snapshot_people_controller_test.rb
@@ -45,8 +45,23 @@ module Admin
         end
       end
 
-      assert_redirected_to admin_temporary_snapshot_people_path
+      assert_redirected_to admin_temporary_snapshot_people_path(
+        assigned_unit_id: @unit.id, assigned_unit_snapshot_id: @snapshot.id
+      )
       assert_equal 'テスト太郎', @snapshot.reload.snapshot_people.last.person_name
+    end
+
+    test 'should show a link to the assigned unit snapshot after assigning' do
+      post assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person), params: {
+        unit_id: @unit.id,
+        unit_snapshot_id: @snapshot.id,
+        part: 'vocal',
+        status: 'left'
+      }
+      follow_redirect!
+
+      assert_response :success
+      assert_select "a[href='#{edit_admin_unit_unit_snapshot_path(@unit, @snapshot)}']"
     end
 
     test 'should assign to a newly created snapshot when none selected' do
@@ -59,7 +74,9 @@ module Admin
         }
       end
 
-      assert_redirected_to admin_temporary_snapshot_people_path
+      assert_redirected_to admin_temporary_snapshot_people_path(
+        assigned_unit_id: @unit.id, assigned_unit_snapshot_id: UnitSnapshot.last.id
+      )
     end
 
     test 'should not assign without a target unit' do


### PR DESCRIPTION
## Summary
- `Admin::TemporarySnapshotPeopleController` を追加
  - `index`: プール全件（`unit_id` パラメータで絞り込み可）を一覧表示
  - `assign`: 振り分け先ユニットを検索・選択 → そのユニットの既存スナップショット（または新規作成）を選び、`name_alias`/`part`/`part_alias`/`status`/`support` を編集した上で `SnapshotPerson` を作成し、元の `TemporarySnapshotPerson` を削除
  - `destroy`: 誤検出などをプールから単純に削除
- ユニット編集画面のスナップショット一覧（`_snapshots_list.html.erb`）に、そのユニットを `hint_unit` とするプール件数バッジ・リンクを追加
- 管理画面ナビ（デスクトップドロップダウン/モバイルメニュー）に「Temporary Pool」導線を追加（全体件数バッジ付き）

## 補足・既知の制約
- 新規スナップショットを作成して振り分ける場合、`active: false` / `past: true` で作成する（未公開かつ「過去の在籍」表示になる）。`past` は通常の編集フォームからは変更できないため、`past` の扱いを変えたい場合は別途対応が必要
- `person_importer.rb#parse_career_history` 側の恒常的な書き込み先変更は本PRでは未対応（#1167 の残タスク）

## Test plan
- [x] `bundle exec rails test` が全件パスすること（403 runs, 0 failures）
- [x] `bundle exec rubocop` がクリーンであること
- [x] `Admin::TemporarySnapshotPeopleController` の index/assign(GET/POST)/destroy を統合テストで確認（既存スナップショットへの振り分け・新規スナップショット作成・ユニット未選択時のガード・プールからの削除・未認証時のリダイレクト）

Related: #1167（本PRで管理画面UIを実装。issueはPersonImporter側の恒常対応まで残す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)