### PR TITLE
アイテム新規作成のArtistサジェストにkeyを表示する

### DIFF
--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -218,6 +218,7 @@ export default class extends Controller {
            data-destination-key="${this.escapeHtml(item.destination_key || "")}">
         <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
         ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ""}
+        ${item.key ? `<div class="text-xs text-gray-500 dark:text-gray-400">key: ${this.escapeHtml(item.key)}</div>` : ""}
         ${item.history_summary ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.history_summary)}</div>` : ""}
         ${item.destination_key ? `<div class="text-xs text-amber-600 dark:text-amber-400">→ ${this.escapeHtml(item.destination_key)}</div>` : ""}
       </div>

--- a/app/javascript/controllers/artist_rows_controller.js
+++ b/app/javascript/controllers/artist_rows_controller.js
@@ -218,9 +218,13 @@ export default class extends Controller {
            data-destination-key="${this.escapeHtml(item.destination_key || "")}">
         <div class="font-medium text-gray-900 dark:text-gray-100">${this.escapeHtml(item.name)}</div>
         ${item.name_kana ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.name_kana)}</div>` : ""}
-        ${item.key ? `<div class="text-xs text-gray-500 dark:text-gray-400">key: ${this.escapeHtml(item.key)}</div>` : ""}
+        ${item.key || item.destination_key ? `
+          <div class="flex items-center gap-2 text-xs">
+            ${item.key ? `<span class="text-gray-500 dark:text-gray-400">key: ${this.escapeHtml(item.key)}</span>` : ""}
+            ${item.destination_key ? `<span class="text-amber-600 dark:text-amber-400">→ ${this.escapeHtml(item.destination_key)}</span>` : ""}
+          </div>
+        ` : ""}
         ${item.history_summary ? `<div class="text-xs text-gray-500 dark:text-gray-400">${this.escapeHtml(item.history_summary)}</div>` : ""}
-        ${item.destination_key ? `<div class="text-xs text-amber-600 dark:text-amber-400">→ ${this.escapeHtml(item.destination_key)}</div>` : ""}
       </div>
     `).join("") + freeTextHtml
 


### PR DESCRIPTION
## Summary
- 管理画面のアイテム新規作成ページで、Artist（Unit/Person）選択のサジェスト候補一覧に `key` を表示するようにした
- 同じバンド名/個人名が複数存在する場合でも `key` を見て正しい対象を判別・選択できるようにするための対応

## Test plan
- [x] `bin/rails test` が全件パスすること（pre-push hookで確認済み: 412 runs, 0 failures）
- [ ] 管理画面のアイテム新規作成ページで、既存のArtist名と重複する候補を検索し、サジェスト一覧に各候補のkeyが表示されることを確認する

Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)