### PR TITLE
Official Link に X(Twitter) の個別ツイートURLをembed表示する

### DIFF
--- a/app/components/twitter_embed_component.html.erb
+++ b/app/components/twitter_embed_component.html.erb
@@ -1,0 +1,15 @@
+<% if render? %>
+  <section class="mt-8 mb-6">
+    <h2 class="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-4 border-b border-slate-200 dark:border-slate-700 pb-2">
+      X (Twitter)
+    </h2>
+    <div class="grid gap-4">
+      <% @twitter_links.each do |link| %>
+        <blockquote class="twitter-tweet">
+          <a href="<%= link.url %>"></a>
+        </blockquote>
+      <% end %>
+    </div>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  </section>
+<% end %>

--- a/app/components/twitter_embed_component.rb
+++ b/app/components/twitter_embed_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class TwitterEmbedComponent < ViewComponent::Base
+  def initialize(links:)
+    super()
+    @twitter_links = links
+  end
+
+  def render?
+    @twitter_links.present?
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -19,7 +19,8 @@ class ProfilesController < ApplicationController
     unless @unpublished
       @links = @resource.links.where(active: true).order(:sort_order)
       @youtube_links = @links.select { |l| l.youtube_video_id.present? }
-      @links_for_list = @links - @youtube_links
+      @twitter_links = @links.select(&:twitter_status_url?)
+      @links_for_list = @links - @youtube_links - @twitter_links
 
       @resource.is_a?(Person) ? load_person_data : load_unit_data
       load_items

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -14,7 +14,7 @@ module TrendsHelper
   def twitter_url?(url)
     return false if url.blank?
 
-    url.match?(%r{^https?://(?:www\.)?(?:twitter\.com|x\.com)/[^/]+/status/\d+})
+    url.match?(Link::TWITTER_STATUS_URL_PATTERN)
   end
 
   def twitter_embed(_url, quote)

--- a/app/javascript/controllers/link_title_suggest_controller.js
+++ b/app/javascript/controllers/link_title_suggest_controller.js
@@ -25,7 +25,10 @@ export default class extends Controller {
         const host = url.hostname.replace(/^www\./i, "").toLowerCase()
         const path = url.pathname
 
-        if (host === "x.com" || host === "twitter.com") return "X"
+        if (host === "x.com" || host === "twitter.com") {
+            if (/^\/[^/]+\/status\/\d+/.test(path)) return "X Post"
+            return "X"
+        }
         if (host === "open.spotify.com") return "Spotify"
         if (host === "youtube.com" || host === "m.youtube.com") {
             if (/^\/(?:watch|shorts\/)/.test(path)) return "YouTube Movie"

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -19,9 +19,16 @@
 #  index_links_on_linkable  (linkable_type,linkable_id)
 #
 class Link < ApplicationRecord
+  # X(Twitter) の個別ツイートURL（twitter.com / x.com どちらも対象）
+  TWITTER_STATUS_URL_PATTERN = %r{^https?://(?:www\.)?(?:twitter\.com|x\.com)/[^/]+/status/\d+}
+
   belongs_to :linkable, polymorphic: true
 
   validates :url, presence: true
+
+  def twitter_status_url?
+    url.present? && url.match?(TWITTER_STATUS_URL_PATTERN)
+  end
 
   def youtube_video_id
     return nil unless url.present?

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -54,6 +54,7 @@
           <div class="hidden md:block">
             <%= render LinksComponent.new(links: @links_for_list) %>
             <%= render SpotifyEmbedComponent.new(links: @links) %>
+            <%= render TwitterEmbedComponent.new(links: @twitter_links) %>
           </div>
           <div class="mt-4">
             <%= render 'layouts/google_adsense_square' %>
@@ -208,6 +209,7 @@
       <div id="links" class="md:hidden">
         <%= render LinksComponent.new(links: @links_for_list) %>
         <%= render SpotifyEmbedComponent.new(links: @links) %>
+        <%= render TwitterEmbedComponent.new(links: @twitter_links) %>
       </div>
 
       <section id="update-log" class="mt-8">

--- a/test/components/previews/twitter_embed_component_preview.rb
+++ b/test/components/previews/twitter_embed_component_preview.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class TwitterEmbedComponentPreview < ViewComponent::Preview
+  layout 'component_preview'
+  def default
+    links = [mock_link('https://x.com/nonameactorsjp/status/892008297930268674')]
+    render(TwitterEmbedComponent.new(links: links))
+  end
+
+  def multiple_tweets
+    links = [
+      mock_link('https://x.com/nonameactorsjp/status/892008297930268674'),
+      mock_link('https://twitter.com/nonameactorsjp/status/892008297930268674')
+    ]
+    render(TwitterEmbedComponent.new(links: links))
+  end
+
+  def no_links
+    render(TwitterEmbedComponent.new(links: []))
+  end
+
+  private
+
+  def mock_link(url)
+    Link.new(
+      url: url,
+      linkable: Person.new
+    )
+  end
+end

--- a/test/components/twitter_embed_component_test.rb
+++ b/test/components/twitter_embed_component_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TwitterEmbedComponentTest < ActiveSupport::TestCase
+  test 'render? is true when a twitter status link is present' do
+    link = OpenStruct.new(url: 'https://x.com/nonameactorsjp/status/892008297930268674')
+
+    component = TwitterEmbedComponent.new(links: [link])
+
+    assert component.render?
+  end
+
+  test 'render? is false when no links are present' do
+    component = TwitterEmbedComponent.new(links: [])
+
+    refute component.render?
+  end
+end

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -21,7 +21,27 @@
 require 'test_helper'
 
 class LinkTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'twitter_status_url? is true for a twitter.com status URL' do
+    link = Link.new(url: 'https://twitter.com/nonameactorsjp/status/892008297930268674')
+
+    assert link.twitter_status_url?
+  end
+
+  test 'twitter_status_url? is true for an x.com status URL' do
+    link = Link.new(url: 'https://x.com/nonameactorsjp/status/892008297930268674')
+
+    assert link.twitter_status_url?
+  end
+
+  test 'twitter_status_url? is false for a plain twitter.com profile URL' do
+    link = Link.new(url: 'https://twitter.com/nonameactorsjp')
+
+    refute link.twitter_status_url?
+  end
+
+  test 'twitter_status_url? is false for a blank URL' do
+    link = Link.new(url: nil)
+
+    refute link.twitter_status_url?
+  end
 end


### PR DESCRIPTION
## Summary
- Official Link（Unit/Personプロフィール）にX(Twitter)の個別ツイートURL（`twitter.com`/`x.com` の `/status/\d+` 形式）が登録されている場合、YouTube/Spotifyと同様に埋め込み表示するようにした
- `Link#twitter_status_url?` を追加し、`TrendsHelper#twitter_url?` の正規表現を `Link::TWITTER_STATUS_URL_PATTERN` に共通化
- `ProfilesController#show` で twitter リンクを抽出し、プレーンリンク表示用の一覧から除外
- 新規 `TwitterEmbedComponent` で `platform.twitter.com/widgets.js` による埋め込みを表示
- Link登録フォームのタイトル自動挿入（`link_title_suggest_controller.js`）で、個別ツイートURLの場合は「X Post」、それ以外（プロフィール等）は従来通り「X」を挿入するよう修正

## Test plan
- [x] `bundle exec rails test` が全件パスすること
- [x] `bundle exec rubocop` がクリーンであること
- [ ] 管理画面でUnit/PersonにXの個別ツイートURLを登録し、プロフィール画面で埋め込み表示されることを確認
- [ ] Link登録フォームでURLを入力しblurした際、個別ツイートURLは「X Post」、プロフィールURLは「X」がタイトルに自動挿入されることを確認

Closes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)