### PR TITLE
fix: Unit編集画面のSnapshotsをcurrent優先＋表示順で並べる

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -54,7 +54,7 @@ module Admin
 
     def edit
       @unit_logs = @unit.unit_logs.order(:log_date)
-      @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(snapshot_date: :desc)
+      @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(current: :desc, snapshot_index: :asc)
       @unit.links.build # Build an empty link for the form
       @wiki_page_imports = @unit.wiki_page_imports.includes(:wikipage).order(updated_at: :desc)
       @update_logs = UpdateLog.for_unit(@unit)
@@ -84,7 +84,7 @@ module Admin
         redirect_to edit_admin_unit_path(@unit), notice: 'Unit updated successfully.'
       else
         @unit_logs = @unit.unit_logs.order(:log_date)
-        @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(snapshot_date: :desc)
+        @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(current: :desc, snapshot_index: :asc)
         @unit.links.build if @unit.links.none?(&:new_record?)
         render :edit, status: :unprocessable_entity
       end

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -320,6 +320,21 @@ module Admin
       assert_equal 'active', @unit.reload.status
     end
 
+    test 'edit shows unit snapshots with current first, then ordered by display order' do
+      third = @unit.unit_snapshots.create!(label: 'Snapshot Third', snapshot_date: '2024-03-01', snapshot_index: 3)
+      first = @unit.unit_snapshots.create!(label: 'Snapshot First', snapshot_date: '2024-01-01', snapshot_index: 1)
+      current = @unit.unit_snapshots.create!(label: 'Snapshot Current', snapshot_date: '2024-02-01', snapshot_index: 2,
+                                             current: true)
+
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      body = response.body
+      positions = [current, first, third].map { |snapshot| body.index(snapshot.label) }
+      assert positions.all?, 'expected all snapshot labels to appear in the response body'
+      assert_equal positions, positions.sort
+    end
+
     private
 
     def login_as_admin


### PR DESCRIPTION
## Summary
- `Admin::UnitsController#edit` / `#update`（バリデーションエラー時の再描画）の Snapshots 一覧のソート順を `snapshot_date desc` から `current desc, snapshot_index asc` に変更
- current のスナップショットを最優先で先頭に表示し、それ以外は表示順（snapshot_index）に並ぶようにした（公開プロフィール画面と同じ並び方針）

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] `bundle exec rubocop` がクリーンであること
- [ ] Unit編集画面でSnapshotsがcurrent優先＋表示順に並んでいることを確認

Closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)