### PR TITLE
fix: 経歴のMarkdown内部リンクを外部リンク扱いしないようにする

### DIFF
--- a/app/components/history_row_component.html.erb
+++ b/app/components/history_row_component.html.erb
@@ -13,6 +13,8 @@
             </svg>
             <span class="sr-only">(外部サイト)</span>
           <% end %>
+        <% elsif item[:internal_url].present? %>
+          <%= link_to helpers.sanitize_with_ruby(item[:unit_name]), item[:internal_url], class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
         <% elsif item[:old_key].present? %>
           <%= link_to helpers.sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
         <% else %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     private
 
     def external_url?(url)
-      return false if url.blank? || url.start_with?('/', '#', 'mailto:')
+      return false if url.blank? || SiteLinkClassifier.relative_or_safe_link?(url)
       return true unless url.match?(%r{\Ahttps?://})
 
       URI.parse(url).host != @site_host
@@ -117,7 +117,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
   private
 
   def external_url?(url)
-    return false if url.blank? || url.start_with?('/', '#', 'mailto:')
+    return false if url.blank? || SiteLinkClassifier.relative_or_safe_link?(url)
     return true unless url.match?(%r{\Ahttps?://})
 
     URI.parse(url).host != request.host

--- a/app/models/concerns/wiki_parser.rb
+++ b/app/models/concerns/wiki_parser.rb
@@ -7,7 +7,8 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
   # 戻り値: [
   #   [
   #     { unit_name: "ユニット名", part_and_name: "Part" or "Part+PersonName" or "PersonName",
-  #       old_key: "EUC-JPエンコードされたユニット名", external_url: "外部URL", note: "備考(日付など)" },
+  #       old_key: "EUC-JPエンコードされたユニット名", external_url: "外部URL",
+  #       internal_url: "サイト内相対パス", note: "備考(日付など)" },
   #     ... (同時期の活動)
   #   ],
   #   ...
@@ -73,11 +74,12 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
             notes: metadata[:notes]
           }
         # Pattern 1b: [Label](target) or [Label](target)(Part) - Markdown形式のリンク
-        # （CustomPageDraftGeneratorが旧[[Label|target]]記法から変換した経歴テキストなどで使用される）
+        # （CustomPageDraftGeneratorが旧[[Label|target]]記法から変換した経歴テキストなどで使用される。
+        # targetが"/xxx"のようなサイト内相対パスの場合はinternal_url、それ以外はexternal_urlとして扱う）
         # Label に | を含む場合はPattern 2（旧wikiのパイプ外部リンク）を優先させるため除外する
         when /\[([^\]|]+)\]\(([^)]+)\)(?:\(([^)]+)\))?/
           link_text = ::Regexp.last_match(1)
-          target = ::Regexp.last_match(2)
+          target = ::Regexp.last_match(2).strip
           part_and_name = ::Regexp.last_match(3)
 
           display_link_text = wrapped_in_parens ? "(#{link_text.strip})" : link_text.strip
@@ -85,13 +87,14 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
           concurrent_items << {
             unit_name: display_link_text,
             part_and_name: part_and_name&.strip,
-            external_url: target.strip,
+            **link_url_attribute(target),
             notes: metadata[:notes]
           }
         # Pattern 2: [LinkText|URL] or [LinkText|URL](Part) - External link
+        # （URLがサイト内相対パスの場合はinternal_urlとして扱う）
         when /\[([^\]|]+)\|([^\]]+)\](?:\(([^)]+)\))?/
           link_text = ::Regexp.last_match(1)
-          url = ::Regexp.last_match(2)
+          url = ::Regexp.last_match(2).strip
           part_and_name = ::Regexp.last_match(3)
 
           # If wrapped in parentheses, add them to display
@@ -100,7 +103,7 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
           concurrent_items << {
             unit_name: display_link_text,
             part_and_name: part_and_name&.strip,
-            external_url: url.strip,
+            **link_url_attribute(url),
             notes: metadata[:notes]
           }
         # Pattern 3: Plain text - No link, display as-is (including parentheses)
@@ -120,6 +123,13 @@ module WikiParser # rubocop:disable Metrics/ModuleLength
   end
 
   private
+
+  # リンク先がサイト内の相対パスならinternal_url、それ以外（外部URL）ならexternal_urlとして
+  # ハッシュを組み立てる。表示側（profiles/show.html.erb, history_row_component.html.erb）は
+  # internal_urlの場合は外部リンクアイコン・target="_blank"を付けずにサイト内リンクとして描画する
+  def link_url_attribute(url)
+    SiteLinkClassifier.relative_or_safe_link?(url) ? { internal_url: url } : { external_url: url }
+  end
 
   def process_plugins(text, metadata = {})
     text.gsub(/\{\{([^}]+)\}\}/) do |match|

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -108,7 +108,8 @@ class Person < ApplicationRecord
   # old_historyをパースして履歴アイテムの配列を返す
   # 戻り値: [
   #   [
-  #     { unit_name: "ユニット名", part_and_name: "Part" or "Part+PersonName" or "PersonName", old_key: "EUC-JPエンコードされたユニット名", external_url: "外部URL" },
+  #     { unit_name: "ユニット名", part_and_name: "Part" or "Part+PersonName" or "PersonName",
+  #       old_key: "EUC-JPエンコードされたユニット名", external_url: "外部URL", internal_url: "サイト内相対パス" },
   #     ... (同時期の活動)
   #   ],
   #   ...

--- a/app/services/site_link_classifier.rb
+++ b/app/services/site_link_classifier.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# リンク先がサイト内の相対パス／アンカー／mailto:かどうかを判定する共通ロジック。
+# 通常のMarkdownレンダラー（ApplicationHelper::ExternalAwareHtmlRenderer、Section本文等）と
+# 経歴専用パーサー（WikiParser、Person#old_history / UnitPerson・SnapshotPerson#inline_history）の
+# 両方で、外部リンクアイコン・target="_blank"付与の要否判定に使う。
+module SiteLinkClassifier
+  module_function
+
+  # "/xxx"（"//"始まりのプロトコル相対URLを除く）・"#xxx"・"mailto:xxx" は
+  # 常にサイト内／安全なリンクとして扱う
+  def relative_or_safe_link?(url)
+    return false if url.blank?
+
+    url.start_with?('/', '#', 'mailto:') && !url.start_with?('//')
+  end
+end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -123,6 +123,8 @@
                                   </svg>
                                   <span class="sr-only">(外部サイト)</span>
                                 <% end %>
+                              <% elsif item[:internal_url].present? %>
+                                <%= link_to sanitize_with_ruby(item[:unit_name]), item[:internal_url], class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
                               <% elsif item[:old_key].present? %>
                                 <%= link_to sanitize_with_ruby(item[:unit_name]), "/#{item[:old_key]}.html", class: "text-unit dark:text-blue-400 underline decoration-unit/25 dark:decoration-blue-400/40 underline-offset-2 hover:decoration-unit dark:hover:decoration-blue-400 transition-colors" %>
                               <% else %>

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -83,8 +83,9 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert_equal 'Rem.', concurrent[2][:part_and_name]
   end
 
-  test 'parse_old_history parses Markdown形式のリンク[Label](URL)をexternal_urlとして扱う' do
+  test 'parse_old_history はMarkdown形式のリンク[Label](target)のtargetがサイト内相対パスの場合internal_urlとして扱う' do
     # CustomPageDraftGeneratorが旧[[Label|target]]記法から変換した後の経歴テキストを想定
+    # （issue #1190: 以前はサイト内リンクもexternal_url扱いになり外部リンクアイコンが付いてしまっていた）
     history_str = '→ [GLAMOROUS HONEY](/glamorous-honey){{fn 2006/05/10加入}}'
     person = Person.new(old_history: history_str)
     history = person.parse_old_history
@@ -92,7 +93,8 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
     assert_equal 1, history.size
     item = history[0][0]
     assert_equal 'GLAMOROUS HONEY', item[:unit_name]
-    assert_equal '/glamorous-honey', item[:external_url]
+    assert_equal '/glamorous-honey', item[:internal_url]
+    assert_nil item[:external_url]
     assert_equal ['2006/05/10加入'], item[:notes]
   end
 
@@ -103,13 +105,34 @@ class PersonTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
 
     assert_equal 3, history.size
     assert_equal 'くりから。', history[0][0][:unit_name]
-    assert_equal '/kurikara', history[0][0][:external_url]
+    assert_equal '/kurikara', history[0][0][:internal_url]
+    assert_nil history[0][0][:external_url]
     assert_equal '一期', history[0][0][:part_and_name]
 
     assert_equal '(隠密華撃団)', history[1][0][:unit_name]
 
     assert_equal 'くりから。', history[2][0][:unit_name]
     assert_equal '二期', history[2][0][:part_and_name]
+  end
+
+  test 'parse_old_history はMarkdown形式のリンク[Label](URL)のURLが絶対URLの場合はexternal_urlのまま扱う' do
+    history_str = '[公式サイト](https://example.com/)'
+    person = Person.new(old_history: history_str)
+    history = person.parse_old_history
+
+    item = history[0][0]
+    assert_equal 'https://example.com/', item[:external_url]
+    assert_nil item[:internal_url]
+  end
+
+  test 'parse_old_history は旧wiki形式の外部リンク[LinkText|URL]のURLがサイト内相対パスの場合internal_urlとして扱う' do
+    history_str = '[くりから。|/kurikara]'
+    person = Person.new(old_history: history_str)
+    history = person.parse_old_history
+
+    item = history[0][0]
+    assert_equal '/kurikara', item[:internal_url]
+    assert_nil item[:external_url]
   end
 
   test 'parse_old_history parses旧wiki形式の外部リンク[LinkText|URL]をexternal_urlとして扱う' do


### PR DESCRIPTION
## Summary
- `Person#old_history` / `UnitPerson`・`SnapshotPerson#inline_history` をパースする `WikiParser#parse_history_string` が、`[Label](target)` / `[Label|URL]` 形式のリンク先を判定せず常に `external_url` 扱いしていたため、サイト内相対パス（例: `CustomPageDraftGenerator` が生成する `[Label](/unit-key)` 形式）を書いても外部リンクアイコン・`target="_blank"` が付与されてしまう不具合を修正
- リンク先が `/` 始まり等のサイト内相対パスの場合は新設の `internal_url` として区別し、`old_key` 同様アイコンなしのサイト内リンクとして描画するよう `profiles/show.html.erb` / `history_row_component.html.erb` を修正
- サイト内パス判定ロジックの重複を `SiteLinkClassifier` に切り出し、`ApplicationHelper` 側でも共通利用するように整理

## Test plan
- [x] `bundle exec rails test` が全420件パスすること
- [x] `bundle exec rubocop` で対象ファイルがクリーンであること
- [ ] 管理画面でPersonのOld Historyに `[テキスト](/unit-key)` のようなサイト内相対パスを記載し、個人ページ・ユニットページのHistoryで外部リンクアイコンが付かず通常のサイト内リンクとして表示されることを確認

Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)