### PR TITLE
Person/Unit編集画面のヘッダーと保存ボタンをsticky固定

### DIFF
--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -187,7 +187,7 @@
     </div>
   </div>
 
-  <div class="flex justify-end gap-x-4 pt-6 mt-6 border-t border-gray-200 dark:border-gray-700">
+  <div class="sticky bottom-0 z-10 -mx-6 -mb-6 flex justify-end gap-x-4 rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
     <%= link_to "Cancel", admin_people_path, class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
     <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
   </div>

--- a/app/views/admin/people/_tags_form.html.erb
+++ b/app/views/admin/people/_tags_form.html.erb
@@ -4,7 +4,7 @@
   <%= form_with(model: [:admin, person]) do |form| %>
     <%= render 'admin/shared/tag_selection', form: form, record: person %>
 
-    <div class="mt-4 flex justify-end">
+    <div class="sticky bottom-0 z-30 -mx-6 -mb-6 mt-4 flex justify-end rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
       <%= form.submit "タグを保存", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
     </div>
   <% end %>

--- a/app/views/admin/people/edit.html.erb
+++ b/app/views/admin/people/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, title %>
 <div class="container mx-auto px-2 py-4">
   <div class="max-w-7xl mx-auto">
-    <div class="flex justify-between items-center mb-6">
+    <div class="sticky top-0 z-30 -mx-2 px-2 py-4 mb-6 flex justify-between items-center bg-zinc-50/95 dark:bg-zinc-950/95 backdrop-blur-sm border-b border-zinc-200 dark:border-zinc-800">
       <h1 class="text-2xl font-bold dark:text-white"><%= title %></h1>
       <%= link_to "Back to Public Page", profile_path(@person.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>

--- a/app/views/admin/shared/_tag_selection.html.erb
+++ b/app/views/admin/shared/_tag_selection.html.erb
@@ -21,7 +21,7 @@
         <% tags_in_group = grouped[group]&.sort_by { |t| t.order_in_group || Float::INFINITY } %>
         <% next if tags_in_group.blank? %>
         <div>
-          <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1"><%= group.name %></p>
+          <p class="sticky top-0 z-20 bg-white dark:bg-gray-800 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1"><%= group.name %></p>
           <div class="flex flex-wrap gap-3">
             <% tags_in_group.each do |tag| %>
               <label class="inline-flex items-center gap-1.5 cursor-pointer">
@@ -41,7 +41,7 @@
       <% ungrouped = grouped[nil]&.sort_by { |t| t.order_in_group || Float::INFINITY } %>
       <% if ungrouped.present? %>
         <div>
-          <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">グループなし</p>
+          <p class="sticky top-0 z-20 bg-white dark:bg-gray-800 py-1 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">グループなし</p>
           <div class="flex flex-wrap gap-3">
             <% ungrouped.each do |tag| %>
               <label class="inline-flex items-center gap-1.5 cursor-pointer">

--- a/app/views/admin/units/_form.html.erb
+++ b/app/views/admin/units/_form.html.erb
@@ -159,7 +159,7 @@
 
 
 
-  <div class="flex justify-end gap-x-4">
+  <div class="sticky bottom-0 z-10 -mx-6 -mb-6 flex justify-end gap-x-4 rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
     <%= link_to "Cancel", admin_units_path, class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
     <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
   </div>

--- a/app/views/admin/units/_tags_form.html.erb
+++ b/app/views/admin/units/_tags_form.html.erb
@@ -4,7 +4,7 @@
   <%= form_with(model: [:admin, unit]) do |form| %>
     <%= render 'admin/shared/tag_selection', form: form, record: unit %>
 
-    <div class="mt-4 flex justify-end">
+    <div class="sticky bottom-0 z-30 -mx-6 -mb-6 mt-4 flex justify-end rounded-b-lg border-t border-gray-200 bg-white/95 px-6 py-4 backdrop-blur-sm dark:border-gray-700 dark:bg-gray-800/95">
       <%= form.submit "タグを保存", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
     </div>
   <% end %>

--- a/app/views/admin/units/edit.html.erb
+++ b/app/views/admin/units/edit.html.erb
@@ -2,13 +2,13 @@
 <% content_for :title, title %>
 <div class="container mx-auto px-2 py-4">
   <div class="max-w-7xl mx-auto">
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold"><%= title %></h1>
+    <div class="sticky top-0 z-30 -mx-2 px-2 py-4 mb-6 flex justify-between items-center bg-zinc-50/95 dark:bg-zinc-950/95 backdrop-blur-sm border-b border-zinc-200 dark:border-zinc-800">
+      <h1 class="text-2xl font-bold dark:text-white"><%= title %></h1>
       <%= link_to "Back to Public Page", profile_path(@unit.key), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
     </div>
     <div class="md:grid md:grid-cols-5 md:gap-8">
       <div class="md:col-span-2">
-        <div class="bg-white shadow rounded-lg p-6 mb-6">
+        <div class="bg-white shadow rounded-lg p-6 mb-6 dark:bg-gray-800">
           <%= render "form", unit: @unit %>
         </div>
         <%= render "admin/shared/change_key_form", change_key_path: change_key_admin_unit_path(@unit), form_id: "change_key_form" %>


### PR DESCRIPTION
## Summary
- Person/Unit編集画面のヘッダー（タイトル + Back to Public Page）を画面上部にsticky固定
- Update Person/Unit ボタンを画面下部にsticky固定
- タグ保存ボタンも同様に画面下部にsticky固定
- タグ選択のグループ名ラベルを画面上部にsticky固定し、スクロール中も所属グループがわかるように
- タグ保存ボタンのsticky領域のz-indexを引き上げ、グループ名ラベルとの重なりを解消

## Test plan
- [x] `bin/rails test` が全件パスすること（pre-push hookで確認済み: 421 runs, 0 failures）
- [ ] `/admin/people/:id/edit` `/admin/units/:id/edit` を開き、ヘッダー・保存ボタン・タグ保存ボタンがスクロール時に固定されることを確認
- [ ] タグ一覧をスクロールし、グループ名ラベルとタグ保存ボタンが重なる位置でも保存ボタンが手前に表示されクリックできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)