### PR TITLE
fix: テンポラリプール振り分け画面のスナップショット並び順をスナップショット一覧に合わせる

### DIFF
--- a/app/controllers/admin/temporary_snapshot_people_controller.rb
+++ b/app/controllers/admin/temporary_snapshot_people_controller.rb
@@ -28,7 +28,7 @@ module Admin
     def assign
       target_unit_id = params[:unit_id].presence || @temporary_snapshot_person.hint_unit_id
       @unit = Unit.kept.find_by(id: target_unit_id)
-      @unit_snapshots = @unit ? @unit.unit_snapshots.chronological : UnitSnapshot.none
+      @unit_snapshots = @unit ? @unit.unit_snapshots.order(:snapshot_index) : UnitSnapshot.none
 
       return unless request.post?
 
@@ -85,7 +85,7 @@ module Admin
     end
 
     def render_assign_errors(messages)
-      @unit_snapshots = @unit.unit_snapshots.chronological
+      @unit_snapshots = @unit.unit_snapshots.order(:snapshot_index)
       flash.now[:alert] = "振り分けに失敗しました: #{messages.join('、')}"
       render :assign, status: :unprocessable_entity
     end

--- a/test/controllers/admin/temporary_snapshot_people_controller_test.rb
+++ b/test/controllers/admin/temporary_snapshot_people_controller_test.rb
@@ -34,6 +34,16 @@ module Admin
       assert_match @unit.name, response.body
     end
 
+    test 'should list assign target snapshots ordered by snapshot_index, matching the snapshot list order' do
+      @snapshot.update!(snapshot_index: 2)
+      @other_snapshot.update!(snapshot_index: 1)
+
+      get assign_admin_temporary_snapshot_person_path(@temporary_snapshot_person)
+      assert_response :success
+      assert_operator response.body.index(@other_snapshot.display_label),
+                      :<, response.body.index(@snapshot.display_label)
+    end
+
     test 'should assign to an existing snapshot and remove from pool' do
       assert_difference('SnapshotPerson.count', 1) do
         assert_difference('TemporarySnapshotPerson.count', -1) do


### PR DESCRIPTION
## Summary
- /admin/temporary_snapshot_people/*/assign の振り分け先スナップショット一覧が `snapshot_date` 昇順（`chronological` スコープ）で表示されていた
- スナップショット一覧画面（/admin/units/:unit_id/unit_snapshots、ドラッグ&ドロップで並び替え可能）は `snapshot_index` 順のため、両者の並び順が一致していなかった
- assign 画面側も `snapshot_index` 順に揃えるよう修正

## Test plan
- [x] `bundle exec rails test test/controllers/admin/temporary_snapshot_people_controller_test.rb` が全件パスすること
- [x] `bundle exec rubocop` で offense なし
- [x] snapshot_index 順で並ぶことを検証するテストを追加

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)