### PR TITLE
管理画面のスナップショット編集フォームにRELATED（past）チェックボックスを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@
 !/tmp/storage/
 !/tmp/storage/.keep
 
+# Ignore SQLite database files.
+/db/*.sqlite3
+/db/*.sqlite3-*
+
 /public/assets
 
 # Ignore key files for decrypting credentials and more.

--- a/app/controllers/admin/unit_snapshots_controller.rb
+++ b/app/controllers/admin/unit_snapshots_controller.rb
@@ -102,7 +102,7 @@ module Admin
     end
 
     def unit_snapshot_params
-      params.require(:unit_snapshot).permit(:snapshot_date, :label, :current, :active)
+      params.require(:unit_snapshot).permit(:snapshot_date, :label, :current, :active, :past)
     end
 
     def copy_snapshot_to(target_unit)

--- a/app/controllers/admin/unit_snapshots_controller.rb
+++ b/app/controllers/admin/unit_snapshots_controller.rb
@@ -6,8 +6,9 @@ module Admin
     before_action :set_unit_snapshot, only: %i[edit update destroy copy copy_to_unit]
 
     def index
+      # ユニットページ（ProfilesController#load_unit_data）の表示順に合わせる
       @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person)
-                             .order(:snapshot_index)
+                             .order(past: :asc, current: :desc, snapshot_index: :asc)
     end
 
     def new

--- a/app/views/admin/unit_snapshots/_form.html.erb
+++ b/app/views/admin/unit_snapshots/_form.html.erb
@@ -35,6 +35,13 @@
     </label>
   </div>
 
+  <div>
+    <label class="inline-flex items-center">
+      <%= form.check_box :past, class: "form-checkbox text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded dark:bg-gray-700 dark:border-gray-600" %>
+      <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">RELATED（past）</span>
+    </label>
+  </div>
+
   <div class="flex justify-end gap-x-4">
     <%= link_to "Cancel", admin_unit_unit_snapshots_path(unit), class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
     <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>

--- a/app/views/admin/unit_snapshots/index.html.erb
+++ b/app/views/admin/unit_snapshots/index.html.erb
@@ -27,6 +27,7 @@
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">ラベル</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">メンバー</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">現在</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">RELATED</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-200">公開</th>
                 <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
                   <span class="sr-only">操作</span>
@@ -58,6 +59,11 @@
                   <td class="whitespace-nowrap px-3 py-4 text-sm">
                     <% if snapshot.current? %>
                       <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">現在</span>
+                    <% end %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-4 text-sm">
+                    <% if snapshot.past? %>
+                      <span class="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900 dark:text-amber-200">RELATED</span>
                     <% end %>
                   </td>
                   <td class="whitespace-nowrap px-3 py-4 text-sm">

--- a/test/controllers/admin/unit_snapshots_controller_test.rb
+++ b/test/controllers/admin/unit_snapshots_controller_test.rb
@@ -15,6 +15,18 @@ module Admin
       assert_response :success
     end
 
+    test 'should list snapshots ordered to match the unit page and show RELATED badge for past snapshots' do
+      other_snapshot = unit_snapshots(:two)
+      @snapshot.update!(past: true, snapshot_index: 1)
+      other_snapshot.update!(past: false, snapshot_index: 2)
+
+      get admin_unit_unit_snapshots_path(@unit)
+      assert_response :success
+      assert_operator response.body.index(other_snapshot.display_label),
+                      :<, response.body.index(@snapshot.display_label)
+      assert_match 'RELATED', response.body
+    end
+
     test 'should get new' do
       get new_admin_unit_unit_snapshot_path(@unit)
       assert_response :success
@@ -45,11 +57,12 @@ module Admin
 
     test 'should update unit_snapshot' do
       patch admin_unit_unit_snapshot_path(@unit, @snapshot), params: {
-        unit_snapshot: { label: 'Updated Label' }
+        unit_snapshot: { label: 'Updated Label', past: true }
       }
       assert_redirected_to admin_unit_unit_snapshots_path(@unit)
       @snapshot.reload
       assert_equal 'Updated Label', @snapshot.label
+      assert @snapshot.past?
     end
 
     test 'should destroy unit_snapshot' do


### PR DESCRIPTION
## Summary
- Admin::UnitSnapshotsController のスナップショット編集フォームに `past`（RELATED表示フラグ）用チェックボックスを追加し、`unit_snapshot_params` で permit
- スナップショット一覧（admin index）の並び順をユニットページ（ProfilesController#load_unit_data）と同じ `order(past: :asc, current: :desc, snapshot_index: :asc)` に統一
- スナップショット一覧にRELATEDバッジ列を追加
- db配下のSQLiteデータベースファイルを .gitignore に追加

## Test plan
- [x] `bundle exec rails test test/controllers/admin/unit_snapshots_controller_test.rb` が全13件パス
- [x] `bundle exec rails test` フルスイート432件パス（pre-push hookで確認済み）
- [x] Rubocop 問題なし
- [x] 管理画面でスナップショットのRELATED（past）チェックボックスを操作し、ユニットページのラベル表示（RELATED / Members）が切り替わることを確認
- [x] スナップショット一覧の並び順がユニットページの表示順と一致することを確認

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)