### PR TITLE
unit_snapshots に past を含む複合インデックスを追加

### DIFF
--- a/app/controllers/admin/units_controller.rb
+++ b/app/controllers/admin/units_controller.rb
@@ -54,7 +54,10 @@ module Admin
 
     def edit
       @unit_logs = @unit.unit_logs.order(:log_date)
-      @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(current: :desc, snapshot_index: :asc)
+      # ユニットページ本体・スナップショット一覧（Admin::UnitSnapshotsController#index）の
+      # 表示順に合わせる
+      @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person)
+                             .order(past: :asc, current: :desc, snapshot_index: :asc)
       @unit.links.build # Build an empty link for the form
       @wiki_page_imports = @unit.wiki_page_imports.includes(:wikipage).order(updated_at: :desc)
       @update_logs = UpdateLog.for_unit(@unit)
@@ -84,7 +87,10 @@ module Admin
         redirect_to edit_admin_unit_path(@unit), notice: 'Unit updated successfully.'
       else
         @unit_logs = @unit.unit_logs.order(:log_date)
-        @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person).order(current: :desc, snapshot_index: :asc)
+        # ユニットページ本体・スナップショット一覧（Admin::UnitSnapshotsController#index）の
+        # 表示順に合わせる
+        @unit_snapshots = @unit.unit_snapshots.includes(snapshot_people: :person)
+                               .order(past: :asc, current: :desc, snapshot_index: :asc)
         @unit.links.build if @unit.links.none?(&:new_record?)
         render :edit, status: :unprocessable_entity
       end

--- a/db/migrate/20260822120000_add_past_index_to_unit_snapshots.rb
+++ b/db/migrate/20260822120000_add_past_index_to_unit_snapshots.rb
@@ -2,7 +2,10 @@
 
 class AddPastIndexToUnitSnapshots < ActiveRecord::Migration[8.1]
   def change
+    # past ASC, current DESC, snapshot_index ASC の並び順（ProfilesController#load_unit_data /
+    # Admin::UnitSnapshotsController#index）に完全一致させ、ソート処理を省略できるようにする
     add_index :unit_snapshots, %i[unit_id past current snapshot_index],
+              order: { current: :desc },
               name: 'index_unit_snapshots_on_unit_id_and_past_and_current_and_index'
   end
 end

--- a/db/migrate/20260822120000_add_past_index_to_unit_snapshots.rb
+++ b/db/migrate/20260822120000_add_past_index_to_unit_snapshots.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPastIndexToUnitSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    add_index :unit_snapshots, %i[unit_id past current snapshot_index],
+               name: 'index_unit_snapshots_on_unit_id_and_past_and_current_and_index'
+  end
+end

--- a/db/migrate/20260822120000_add_past_index_to_unit_snapshots.rb
+++ b/db/migrate/20260822120000_add_past_index_to_unit_snapshots.rb
@@ -3,6 +3,6 @@
 class AddPastIndexToUnitSnapshots < ActiveRecord::Migration[8.1]
   def change
     add_index :unit_snapshots, %i[unit_id past current snapshot_index],
-               name: 'index_unit_snapshots_on_unit_id_and_past_and_current_and_index'
+              name: 'index_unit_snapshots_on_unit_id_and_past_and_current_and_index'
   end
 end

--- a/db/migrate/20260822130000_remove_current_index_from_unit_snapshots.rb
+++ b/db/migrate/20260822130000_remove_current_index_from_unit_snapshots.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveCurrentIndexFromUnitSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    # Admin::UnitsController#edit/update の並び順を past を含む形に統一したため、
+    # (unit_id, current, snapshot_index) を使うクエリがなくなり、
+    # index_unit_snapshots_on_unit_id_and_past_and_current_and_index で代替できる
+    remove_index :unit_snapshots, column: %i[unit_id current snapshot_index],
+                                  name: 'index_unit_snapshots_on_unit_id_and_current_and_index'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -359,6 +359,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_120000) do
     t.bigint "unit_id", null: false
     t.datetime "updated_at", null: false
     t.index ["unit_id", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_current_and_index"
+    t.index ["unit_id", "past", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_past_and_current_and_index"
     t.index ["unit_id"], name: "index_unit_snapshots_on_unit_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -358,7 +358,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_120000) do
     t.integer "snapshot_index", default: 0, null: false
     t.bigint "unit_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["unit_id", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_current_and_index"
     t.index ["unit_id", "past", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_past_and_current_and_index", order: { current: :desc }
     t.index ["unit_id"], name: "index_unit_snapshots_on_unit_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -359,7 +359,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_120000) do
     t.bigint "unit_id", null: false
     t.datetime "updated_at", null: false
     t.index ["unit_id", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_current_and_index"
-    t.index ["unit_id", "past", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_past_and_current_and_index"
+    t.index ["unit_id", "past", "current", "snapshot_index"], name: "index_unit_snapshots_on_unit_id_and_past_and_current_and_index", order: { current: :desc }
     t.index ["unit_id"], name: "index_unit_snapshots_on_unit_id"
   end
 

--- a/test/controllers/admin/units_controller_test.rb
+++ b/test/controllers/admin/units_controller_test.rb
@@ -335,6 +335,18 @@ module Admin
       assert_equal positions, positions.sort
     end
 
+    test 'edit shows past snapshots after non-past snapshots' do
+      related = @unit.unit_snapshots.create!(label: 'Snapshot Related', snapshot_date: '2020-01-01',
+                                             snapshot_index: 1, past: true)
+      members = @unit.unit_snapshots.create!(label: 'Snapshot Members', snapshot_date: '2024-01-01',
+                                             snapshot_index: 2, past: false)
+
+      get edit_admin_unit_path(@unit)
+
+      assert_response :success
+      assert_operator response.body.index(members.label), :<, response.body.index(related.label)
+    end
+
     private
 
     def login_as_admin


### PR DESCRIPTION
## Summary
- `unit_snapshots` テーブルに `(unit_id, past, current DESC, snapshot_index)` の複合インデックスを追加するマイグレーションを作成
- ユニットページ本体（ProfilesController#load_unit_data）・管理画面のスナップショット一覧（Admin::UnitSnapshotsController#index）はいずれも `order(past: :asc, current: :desc, snapshot_index: :asc)` でスナップショットを並べているが、既存インデックス `(unit_id, current, snapshot_index)` は `past` を含んでおらず、`current` の向きも合っていなかったため、EXPLAIN で `Incremental Sort` が発生していた
- `order: { current: :desc }` を指定してインデックス自体の向きを揃え、Sortノードなしで完結するようにした
- `Admin::UnitsController#edit`/`update`（ユニット編集画面のスナップショットのミニ一覧）の並び順も `past` を含む形に統一し、旧インデックス `(unit_id, current, snapshot_index)` を使うクエリがなくなったため、そのインデックスを削除するマイグレーションを追加

## Test plan
- [x] `bundle exec rails db:migrate` / `db:rollback` の往復成功、`db/schema.rb` 更新済み
- [x] `EXPLAIN` でSortノードが発生しないことを確認（`order: { current: :desc }` 追加前後で比較）
- [x] `bundle exec rails test test/controllers/admin/unit_snapshots_controller_test.rb test/controllers/admin/units_controller_test.rb test/controllers/profiles_controller_test.rb` 50件パス
- [x] `bundle exec rails test` フルスイート433件パス（pre-push hookで確認済み）
- [x] Rubocop 問題なし
- [ ] 管理画面のユニット編集画面・スナップショット一覧・ユニットページ本体で、それぞれスナップショットの並び順が一致することを確認

Closes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)