### PR TITLE
セクションに active フラグを追加し非公開セクションを公開ビューで非表示にする

### DIFF
--- a/app/controllers/admin/sections_controller.rb
+++ b/app/controllers/admin/sections_controller.rb
@@ -97,7 +97,7 @@ module Admin
     end
 
     def section_params
-      params.require(:section).permit(:name, :wiki_text, :markdown, :sort_order)
+      params.require(:section).permit(:name, :wiki_text, :markdown, :sort_order, :active)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -279,7 +279,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
               CustomPage.published.find_by(key: identifier)
             end
 
-    section = owner&.sections&.kept&.find_by(name: section_name)
+    section = owner&.sections&.kept&.publicly_visible&.find_by(name: section_name)
     section&.markdown.presence || section&.wiki_text.presence || ''
   end
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -5,17 +5,21 @@
 # Table name: sections
 #
 #  id               :bigint           not null, primary key
+#  active           :boolean          default(TRUE), not null
+#  discarded_at     :datetime
+#  markdown         :text
 #  name             :string
-#  wiki_text        :text
-#  sort_order       :integer
 #  sectionable_type :string           not null
-#  sectionable_id   :bigint           not null
+#  sort_order       :integer
+#  wiki_text        :text
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  sectionable_id   :bigint           not null
 #
 # Indexes
 #
-#  index_sections_on_sectionable  (sectionable_type,sectionable_id)
+#  index_sections_on_discarded_at  (discarded_at)
+#  index_sections_on_sectionable   (sectionable_type,sectionable_id)
 #
 class Section < ApplicationRecord
   include Discard::Model
@@ -24,6 +28,9 @@ class Section < ApplicationRecord
   has_many_attached :images
 
   validates :name, presence: true
+
+  # 公開ビューに表示してよいセクション（discardとは独立。削除はせず一時的に非公開にしたい場合に使う）
+  scope :publicly_visible, -> { where(active: true) }
 
   after_commit :expire_including_pages_cache, on: %i[create update destroy]
 

--- a/app/views/admin/sections/_form.html.erb
+++ b/app/views/admin/sections/_form.html.erb
@@ -27,14 +27,6 @@
           class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
   </div>
 
-  <div class="flex items-center">
-    <%= form.check_box :active,
-          class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700" %>
-    <%= form.label :active, "公開する",
-          class: "ml-2 block text-sm text-gray-700 dark:text-gray-300" %>
-    <p class="ml-2 text-xs text-gray-500 dark:text-gray-400">オフにすると公開ページには表示されなくなります（管理画面では引き続き編集できます）</p>
-  </div>
-
   <div>
     <div class="flex justify-between items-baseline mb-1">
       <%= form.label :markdown, "Markdown テキスト", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
@@ -94,6 +86,11 @@
             data-action="click->markdown-preview#serverPreview">
       Markdownプレビュー
     </button>
+    <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+      <%= form.check_box :active,
+            class: "form-checkbox text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:bg-gray-700 dark:border-gray-600" %>
+      公開する
+    </label>
     <%= form.submit section.persisted? ? "更新" : "作成",
           class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
   </div>

--- a/app/views/admin/sections/_form.html.erb
+++ b/app/views/admin/sections/_form.html.erb
@@ -27,6 +27,14 @@
           class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
   </div>
 
+  <div class="flex items-center">
+    <%= form.check_box :active,
+          class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700" %>
+    <%= form.label :active, "公開する",
+          class: "ml-2 block text-sm text-gray-700 dark:text-gray-300" %>
+    <p class="ml-2 text-xs text-gray-500 dark:text-gray-400">オフにすると公開ページには表示されなくなります（管理画面では引き続き編集できます）</p>
+  </div>
+
   <div>
     <div class="flex justify-between items-baseline mb-1">
       <%= form.label :markdown, "Markdown テキスト", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>

--- a/app/views/admin/sections/_list.html.erb
+++ b/app/views/admin/sections/_list.html.erb
@@ -36,6 +36,8 @@
                 <%= section.name %>
                 <% if discarded %>
                   <span class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">削除済み</span>
+                <% elsif !section.active? %>
+                  <span class="ml-1 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">非公開</span>
                 <% end %>
               </td>
               <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500 dark:text-gray-400">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -26,7 +26,7 @@
         <% if (@resource.is_a?(Person) && @old_history_items.present?) || (@resource.is_a?(Unit) && @history.present?) %>
           <a href="#history" class="flex items-center py-3 text-xs text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors shrink-0">History</a>
         <% end %>
-        <% if @resource.sections.kept.exists? %>
+        <% if @resource.sections.kept.publicly_visible.exists? %>
           <a href="#sections" class="flex items-center py-3 text-xs text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors shrink-0">Notes</a>
         <% end %>
         <% if @items.present? %>
@@ -176,9 +176,9 @@
             <% end %>
           <% end %>
 
-          <% if @resource.sections.kept.exists? %>
+          <% if @resource.sections.kept.publicly_visible.exists? %>
             <div id="sections">
-              <%= render SectionComponent.with_collection(@resource.sections.kept.order(:sort_order), admin: defined?(logged_in?) && logged_in?) %>
+              <%= render SectionComponent.with_collection(@resource.sections.kept.publicly_visible.order(:sort_order), admin: defined?(logged_in?) && logged_in?) %>
             </div>
           <% end %>
         </div>

--- a/db/migrate/20260822140000_add_active_to_sections.rb
+++ b/db/migrate/20260822140000_add_active_to_sections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddActiveToSections < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sections, :active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -201,6 +201,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_130000) do
   end
 
   create_table "sections", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "discarded_at"
     t.text "markdown"

--- a/test/controllers/admin/sections_controller_test.rb
+++ b/test/controllers/admin/sections_controller_test.rb
@@ -31,6 +31,31 @@ module Admin
       assert_equal '<p>こんにちは</p>', response.parsed_body['html'].strip
     end
 
+    test 'preview does not expand include plugin for an inactive section' do
+      unit = Unit.create!(name: 'Preview Inactive Include Unit', key: 'sections-preview-inactive-include-unit',
+                          status: :active)
+      unit.sections.create!(name: 'greeting', markdown: 'こんにちは', active: false)
+
+      post preview_admin_sections_path, params: {
+        sectionable_type: 'Unit', sectionable_id: unit.id, body: '{{include ,greeting}}'
+      }
+
+      assert_response :success
+      assert_equal '', response.parsed_body['html'].strip
+    end
+
+    test 'update can toggle active off and on' do
+      unit = Unit.create!(name: 'Toggle Active Unit', key: 'sections-toggle-active-unit', status: :active)
+      section = unit.sections.create!(name: 'about', markdown: '本文')
+
+      patch admin_section_path(section), params: { section: { active: false } }
+      assert_redirected_to edit_admin_unit_path(unit)
+      assert_not section.reload.active?
+
+      patch admin_section_path(section), params: { section: { active: true } }
+      assert section.reload.active?
+    end
+
     test 'edit画面の下部にMarkdownヘルプが表示される' do
       unit = Unit.create!(name: 'Help Display Unit', key: 'sections-help-display-unit', status: :active)
       section = unit.sections.create!(name: 'about', markdown: '本文')

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -85,6 +85,18 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, '諸事情により掲載を停止しております。'
   end
 
+  test 'shows an active section but hides an inactive section' do
+    unit = Unit.create!(name: 'Section Visibility Unit', key: 'unit-section-visibility', status: :active)
+    unit.sections.create!(name: 'Visible Note', markdown: 'active section body')
+    unit.sections.create!(name: 'Hidden Note', markdown: 'inactive section body', active: false)
+
+    get profile_path(unit.key)
+
+    assert_response :success
+    assert_includes response.body, 'active section body'
+    assert_not_includes response.body, 'inactive section body'
+  end
+
   test 'unit trend list shows the recorded name when it differs from the current unit name' do
     unit = Unit.create!(name: 'Renamed Trend Unit', key: 'unit-trend-name-badge', status: :active)
     Trend.create!(title: 'Trend before rename', date: Date.current, publish_start_at: Time.current,


### PR DESCRIPTION
## Summary
- `sections` テーブルに `active` boolean（default: true）を追加
- `Section#publicly_visible` スコープを追加し、公開ビュー（profiles/show, `{{include}}` プラグイン展開）で `active: false` のセクションを除外
- 管理画面の編集フォームに「公開する」チェックボックス、一覧に「非公開」バッジを追加（既存の論理削除機能とは独立）

## Test plan
- [x] `bin/rails test` が全件パスすること（436 runs, 1571 assertions, 0 failures）
- [x] 公開ページで active: false のセクションが表示されないこと（`ProfilesControllerTest`）
- [x] `{{include}}` プラグインが非公開セクションを展開しないこと（`Admin::SectionsControllerTest`）
- [x] 管理画面で active のトグル更新ができること（`Admin::SectionsControllerTest`）

Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)