### PR TITLE
fix: アイテム登録後、一覧ではなく編集画面に遷移するようにする

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -38,7 +38,7 @@ module Admin
       @item.artists = build_artists_from_json(params[:item][:artists_json])
 
       if @item.save
-        redirect_to admin_items_path, notice: 'Item created successfully.'
+        redirect_to edit_admin_item_path(@item), notice: 'Item created successfully.'
       else
         render :new, status: :unprocessable_entity
       end

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -49,6 +49,19 @@ module Admin
       assert item.reload.various_artists?
     end
 
+    test 'create redirects to the edit page of the newly created item' do
+      post admin_items_path, params: {
+        item: {
+          title: 'Test Item',
+          release_date: Date.today,
+          link_url: "https://example.com/item-#{SecureRandom.hex(4)}"
+        }
+      }
+
+      item = Item.order(:id).last
+      assert_redirected_to edit_admin_item_path(item)
+    end
+
     test 'new does not auto-confirm an artist passed via query params, even with an artist_key' do
       get new_admin_item_path, params: {
         artist_name: 'シド',


### PR DESCRIPTION
## Summary
- Admin::ItemsController#create の保存成功時のリダイレクト先を、一覧画面（admin_items_path）から編集画面（edit_admin_item_path）に変更
- update アクションと同じ挙動に揃え、登録直後にそのまま続けて編集できるようにする

## Test plan
- [x] `bin/rails test` が全件パスすること
- [x] 新規テスト「create redirects to the edit page of the newly created item」を追加し、リダイレクト先を検証

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)