### PR TITLE
feat: Itemの論理削除に対応する

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -66,13 +66,13 @@ module Admin
     def destroy
       @item.discard
       record_update_log(@item, action: 'discard')
-      redirect_to admin_items_path, notice: 'Item deleted successfully.'
+      redirect_to edit_admin_item_path(@item), notice: 'Item deleted successfully.'
     end
 
     def undiscard
       @item.undiscard
       record_update_log(@item, action: 'undiscard')
-      redirect_to admin_items_path, notice: 'Item restored successfully.'
+      redirect_to edit_admin_item_path(@item), notice: 'Item restored successfully.'
     end
 
     def bulk_artist_update

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
 module Admin
-  class ItemsController < Admin::BaseController
+  class ItemsController < Admin::BaseController # rubocop:disable Metrics/ClassLength
     MATCH_TYPES = %w[old_key key name alias].freeze
 
     before_action :require_super_operator, only: %i[new create edit update bulk_artist_update]
-    before_action :require_admin, only: %i[destroy]
-    before_action :set_item, only: %i[edit update destroy]
+    before_action :require_admin, only: %i[destroy undiscard]
+    before_action :set_item, only: %i[edit update destroy undiscard]
 
     def index
       @q = params[:q]
       @match_type = params[:match_type].presence_in(MATCH_TYPES)
       @match_value = params[:match_value].to_s.strip
+      @show_discarded = params[:discarded]
 
-      scope = Item.all.order(release_date: :desc)
+      scope = case @show_discarded
+              when 'only' then Item.discarded
+              when 'all'  then Item.with_discarded
+              else             Item.kept
+              end
+      scope = scope.order(release_date: :desc)
       scope = scope.where('title ILIKE :q OR asin ILIKE :q', q: "%#{@q}%") if @q.present?
       scope = scope.public_send(:"by_artist_#{@match_type}", @match_value) if @match_type.present? && @match_value.present?
       @pagy, @items = pagy(scope)
@@ -58,8 +64,15 @@ module Admin
     end
 
     def destroy
-      @item.destroy
+      @item.discard
+      record_update_log(@item, action: 'discard')
       redirect_to admin_items_path, notice: 'Item deleted successfully.'
+    end
+
+    def undiscard
+      @item.undiscard
+      record_update_log(@item, action: 'undiscard')
+      redirect_to admin_items_path, notice: 'Item restored successfully.'
     end
 
     def bulk_artist_update
@@ -83,7 +96,7 @@ module Admin
     private
 
     def set_item
-      @item = Item.find(params[:id])
+      @item = Item.with_discarded.find(params[:id])
     end
 
     def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@
 
 class ItemsController < ApplicationController
   def show
-    @item = Item.find(params[:id])
+    @item = Item.kept.find(params[:id])
 
     scoped_artists = @item.artists.filter_map { |a| [a, artist_item_scope(a)] if artist_item_scope(a) }
 
@@ -22,7 +22,7 @@ class ItemsController < ApplicationController
   end
 
   def index
-    base_scope = filter_by_artist(Item.all)
+    base_scope = filter_by_artist(Item.kept)
     base_scope = filter_by_query(base_scope)
 
     @year_counts = base_scope.where.not(release_date: nil)
@@ -48,12 +48,12 @@ class ItemsController < ApplicationController
   def artist_item_scope(artist)
     if artist['key'].present? || artist['old_key'].present?
       scopes = [
-        (Item.by_artist_key(artist['key']) if artist['key'].present?),
-        (Item.by_artist_old_key(artist['old_key']) if artist['old_key'].present?)
+        (Item.kept.by_artist_key(artist['key']) if artist['key'].present?),
+        (Item.kept.by_artist_old_key(artist['old_key']) if artist['old_key'].present?)
       ].compact
       scopes.reduce(:or)
     elsif artist['name'].present?
-      Item.by_artist_name(artist['name'])
+      Item.kept.by_artist_name(artist['name'])
     end
   end
 

--- a/app/controllers/legacy_redirects_controller.rb
+++ b/app/controllers/legacy_redirects_controller.rb
@@ -69,7 +69,7 @@ class LegacyRedirectsController < ApplicationController
   end
 
   def item_redirect
-    item = Item.find_by(asin: params[:asin])
+    item = Item.kept.find_by(asin: params[:asin])
     if item
       redirect_to item_url(item), status: :moved_permanently
     else

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -116,8 +116,8 @@ class ProfilesController < ApplicationController
 
   def load_items
     scopes = []
-    scopes << Item.by_artist_key(@resource.key) if @resource.key.present?
-    scopes << Item.by_artist_old_key(@resource.old_key) if @resource.old_key.present?
+    scopes << Item.kept.by_artist_key(@resource.key) if @resource.key.present?
+    scopes << Item.kept.by_artist_old_key(@resource.old_key) if @resource.old_key.present?
     return if scopes.empty?
 
     query = scopes.reduce(:or)

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -51,8 +51,8 @@ class TrendsController < ApplicationController
                     .find_by(current: true)
 
     scopes = []
-    scopes << Item.by_artist_key(unit.key) if unit.key.present?
-    scopes << Item.by_artist_old_key(unit.old_key) if unit.old_key.present?
+    scopes << Item.kept.by_artist_key(unit.key) if unit.key.present?
+    scopes << Item.kept.by_artist_old_key(unit.old_key) if unit.old_key.present?
     @items = scopes.reduce(:or).order(release_date: :desc).limit(8) if scopes.any?
 
     @unit_trends = Trend.where('units @> ?', [{ unit_id: unit.id }].to_json)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -309,7 +309,7 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     asin = args.strip
     return '' if asin.blank?
 
-    item = Item.find_by(asin: asin)
+    item = Item.kept.find_by(asin: asin)
     return '' unless item
 
     html = plugin_cache_fetch('item', item.cache_key_with_version) do

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@
 #  id              :bigint           not null, primary key
 #  artists         :jsonb            not null
 #  asin            :string
+#  discarded_at    :datetime
 #  image_url       :string
 #  link_url        :string           not null
 #  release_date    :date             not null
@@ -21,12 +22,15 @@
 #  index_items_on_artists       (artists) USING gin
 #  index_items_on_artists_trgm  (((artists)::text) gin_trgm_ops) USING gin
 #  index_items_on_asin          (asin) UNIQUE
+#  index_items_on_discarded_at  (discarded_at)
 #  index_items_on_link_url      (link_url) UNIQUE
 #  index_items_on_release_date  (release_date)
 #  index_items_on_title         (title)
 #  index_items_on_title_trgm    (title) USING gin
 #
 class Item < ApplicationRecord
+  include Discard::Model
+
   validates :title, presence: true
   validates :release_date, presence: true
   validates :link_url, presence: true, uniqueness: true

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -154,7 +154,7 @@
   </div>
 
   <div class="flex justify-end gap-x-4">
-    <%= link_to "Cancel", admin_items_path, class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
-    <%= form.submit class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+    <%= link_to "キャンセル", admin_items_path, class: "px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" %>
+    <%= form.submit item.persisted? ? "更新" : "作成", class: "px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
   </div>
 <% end %>

--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -18,7 +18,7 @@
     </thead>
     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
       <% @items.each do |item| %>
-        <tr>
+        <tr class="<%= item.discarded? ? 'bg-red-50 dark:bg-red-950/40' : '' %>">
           <% if @show_bulk_artist_ui %>
             <% matched_and_unlinked = (item.artists || []).any? { |a| a[@match_type].to_s == @match_value && a['key'].blank? } %>
             <td class="px-4 py-4">
@@ -28,6 +28,9 @@
           <% end %>
           <td class="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
             <%= link_to item.title, item_path(item), class: "text-indigo-600 hover:text-indigo-900 max-w-xs line-clamp-2 block" %>
+            <% if item.discarded? %>
+              <span class="ml-1 text-xs text-red-500">削除済み</span>
+            <% end %>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"><%= item.release_date %></td>
           <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
@@ -71,11 +74,17 @@
             <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 break-words"><%= item.asin %></td>
           <% end %>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-            <% if current_user.super_operator_or_above? %>
-              <%= link_to "Edit", edit_admin_item_path(item), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
-            <% end %>
-            <% if current_user.admin? %>
-              <%= link_to "Delete", admin_item_path(item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "text-red-600 hover:text-red-900" %>
+            <% if item.discarded? %>
+              <% if current_user.admin? %>
+                <%= link_to "復元", undiscard_admin_item_path(item), data: { turbo_method: :patch, turbo_confirm: "「#{item.title}」を復元します。よろしいですか？" }, class: "text-green-600 hover:text-green-900" %>
+              <% end %>
+            <% else %>
+              <% if current_user.super_operator_or_above? %>
+                <%= link_to "Edit", edit_admin_item_path(item), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
+              <% end %>
+              <% if current_user.admin? %>
+                <%= link_to "Delete", admin_item_path(item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "text-red-600 hover:text-red-900" %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -76,14 +76,19 @@
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
             <% if item.discarded? %>
               <% if current_user.admin? %>
-                <%= link_to "復元", undiscard_admin_item_path(item), data: { turbo_method: :patch, turbo_confirm: "「#{item.title}」を復元します。よろしいですか？" }, class: "text-green-600 hover:text-green-900" %>
+                <%= button_to "復元", undiscard_admin_item_path(item), method: :patch,
+                      form_class: "inline",
+                      class: "text-green-600 hover:text-green-900 bg-transparent border-0 p-0 cursor-pointer" %>
               <% end %>
             <% else %>
               <% if current_user.super_operator_or_above? %>
                 <%= link_to "Edit", edit_admin_item_path(item), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
               <% end %>
               <% if current_user.admin? %>
-                <%= link_to "論理削除", admin_item_path(item), data: { turbo_method: :delete, turbo_confirm: "「#{item.title}」を論理削除しますか？" }, class: "text-red-600 hover:text-red-900" %>
+                <%= button_to "論理削除", admin_item_path(item), method: :delete,
+                      form_class: "inline",
+                      onclick: "return confirm('「#{item.title}」を論理削除しますか？')",
+                      class: "text-red-600 hover:text-red-900 bg-transparent border-0 p-0 cursor-pointer" %>
               <% end %>
             <% end %>
           </td>

--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -83,7 +83,7 @@
                 <%= link_to "Edit", edit_admin_item_path(item), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
               <% end %>
               <% if current_user.admin? %>
-                <%= link_to "Delete", admin_item_path(item), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "text-red-600 hover:text-red-900" %>
+                <%= link_to "論理削除", admin_item_path(item), data: { turbo_method: :delete, turbo_confirm: "「#{item.title}」を論理削除しますか？" }, class: "text-red-600 hover:text-red-900" %>
               <% end %>
             <% end %>
           </td>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -4,7 +4,10 @@
   <div class="max-w-2xl mx-auto">
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold"><%= title %></h1>
-      <%= link_to "Back to Public Page", item_path(@item), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+      <div class="flex items-center gap-4">
+        <%= link_to "一覧へ戻る", admin_items_path, class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+        <%= link_to "公開ページを見る", item_path(@item), class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300" %>
+      </div>
     </div>
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", item: @item %>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -9,5 +9,21 @@
     <div class="bg-white shadow rounded-lg p-6">
       <%= render "form", item: @item %>
     </div>
+
+    <% if current_user.admin? %>
+      <div class="mt-4 flex justify-end">
+        <% if @item.discarded? %>
+          <%= button_to "復元", undiscard_admin_item_path(@item), method: :patch,
+              form_class: "inline",
+              onclick: "return confirm('「#{@item.title}」を復元しますか？')",
+              class: "px-3 py-1.5 text-sm text-white bg-green-600 hover:bg-green-700 rounded cursor-pointer border-0" %>
+        <% else %>
+          <%= button_to "論理削除", admin_item_path(@item), method: :delete,
+              form_class: "inline",
+              onclick: "return confirm('「#{@item.title}」を論理削除しますか？')",
+              class: "px-3 py-1.5 text-sm text-white bg-red-600 hover:bg-red-700 rounded cursor-pointer border-0" %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -8,7 +8,8 @@
     <% end %>
   </div>
 
-  <%= form_with url: admin_items_path, method: :get, local: true, class: "bg-white dark:bg-gray-800 shadow-sm rounded-lg p-4 mb-6 space-y-4" do %>
+  <%= form_with url: admin_items_path, method: :get, local: true, class: "bg-white dark:bg-gray-800 shadow-sm rounded-lg p-4 mb-6 space-y-4" do |f| %>
+    <%= f.hidden_field :discarded, value: params[:discarded] %>
     <div class="flex flex-wrap items-end gap-2">
       <div>
         <%= label_tag :q, "タイトル / ASIN で検索", class: "block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1" %>
@@ -40,6 +41,15 @@
       <%= link_to "解除", admin_items_path(q: params[:q]), class: "underline hover:no-underline" %>
     </div>
   <% end %>
+
+  <div class="flex space-x-2 mb-4">
+    <%= link_to "通常", admin_items_path(q: params[:q]),
+        class: "px-3 py-1 rounded text-sm #{@show_discarded.blank? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+    <%= link_to "削除済みのみ", admin_items_path(q: params[:q], discarded: "only"),
+        class: "px-3 py-1 rounded text-sm #{@show_discarded == 'only' ? 'bg-red-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+    <%= link_to "全件", admin_items_path(q: params[:q], discarded: "all"),
+        class: "px-3 py-1 rounded text-sm #{@show_discarded == 'all' ? 'bg-gray-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+  </div>
 
   <div class="mb-4">
     <%== pagy_tailwind_nav(@pagy) if @pagy.pages > 1 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       collection do
         patch :bulk_artist_update
       end
+      member do
+        patch :undiscard
+      end
     end
 
     resources :tag_indices, except: %i[index show] do

--- a/db/migrate/20260822140001_add_discarded_at_to_items.rb
+++ b/db/migrate/20260822140001_add_discarded_at_to_items.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDiscardedAtToItems < ActiveRecord::Migration[8.1]
+  def change
+    add_column :items, :discarded_at, :datetime
+    add_index :items, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_22_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_22_140001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -89,6 +89,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_140000) do
     t.jsonb "artists", default: [], null: false
     t.string "asin"
     t.datetime "created_at", null: false
+    t.datetime "discarded_at"
     t.string "image_url"
     t.string "link_url", null: false
     t.integer "old_item_id"
@@ -99,6 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_22_140000) do
     t.index "((artists)::text) gin_trgm_ops", name: "index_items_on_artists_trgm", using: :gin
     t.index ["artists"], name: "index_items_on_artists", using: :gin
     t.index ["asin"], name: "index_items_on_asin", unique: true
+    t.index ["discarded_at"], name: "index_items_on_discarded_at"
     t.index ["link_url"], name: "index_items_on_link_url", unique: true
     t.index ["release_date"], name: "index_items_on_release_date"
     t.index ["title"], name: "index_items_on_title"

--- a/docs/admin/permissions.md
+++ b/docs/admin/permissions.md
@@ -53,7 +53,7 @@
 | **画像管理**（`/admin/images`） | index / show / destroy（全アクション） |
 | **画像アップロード**（Section 編集） | upload_image |
 | **画像アップロード**（Custom Page 編集） | upload_image |
-| Items — 削除 | destroy |
+| Items — 削除・復元 | destroy / undiscard |
 | Users 管理 | 全アクション |
 | Operation Logs（ログイン履歴） | index（全アクション） |
 | Wiki Page Imports | 全アクション |

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -322,7 +322,7 @@ module Admin
       assert_nil item.reload.artists.first['key']
     end
 
-    test 'destroy soft-deletes the item instead of destroying the record' do
+    test 'destroy soft-deletes the item and redirects to the edit screen so the item is not lost' do
       delete logout_path
       post login_path, params: { email: users(:admin).email, password: 'password' }
       item = Item.create!(title: 'Target Item', release_date: Date.today,
@@ -330,7 +330,7 @@ module Admin
 
       delete admin_item_path(item)
 
-      assert_redirected_to admin_items_path
+      assert_redirected_to edit_admin_item_path(item)
       assert item.reload.discarded?
       assert Item.with_discarded.exists?(item.id)
     end
@@ -345,7 +345,7 @@ module Admin
       assert_not item.reload.discarded?
     end
 
-    test 'undiscard restores a discarded item' do
+    test 'undiscard restores a discarded item and redirects to the edit screen' do
       delete logout_path
       post login_path, params: { email: users(:admin).email, password: 'password' }
       item = Item.create!(title: 'Target Item', release_date: Date.today,
@@ -354,7 +354,7 @@ module Admin
 
       patch undiscard_admin_item_path(item)
 
-      assert_redirected_to admin_items_path
+      assert_redirected_to edit_admin_item_path(item)
       assert_not item.reload.discarded?
     end
 

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -87,6 +87,16 @@ module Admin
       assert_not_includes response.body, '復元'
     end
 
+    test 'edit shows a link back to the item list' do
+      item = Item.create!(title: 'Test Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+
+      get edit_admin_item_path(item)
+
+      assert_response :success
+      assert_match(%r{<a[^>]*href="#{Regexp.escape(admin_items_path)}"[^>]*>一覧へ戻る</a>}, response.body)
+    end
+
     test 'edit shows a 復元 button for admin on a discarded item' do
       delete logout_path
       post login_path, params: { email: users(:admin).email, password: 'password' }

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -74,6 +74,42 @@ module Admin
       assert_match(/artist-name-hidden[^>]*value="名称のみのアーティスト"/, response.body)
     end
 
+    test 'edit shows a 論理削除 button for admin on a kept item' do
+      delete logout_path
+      post login_path, params: { email: users(:admin).email, password: 'password' }
+      item = Item.create!(title: 'Test Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+
+      get edit_admin_item_path(item)
+
+      assert_response :success
+      assert_includes response.body, '論理削除'
+      assert_not_includes response.body, '復元'
+    end
+
+    test 'edit shows a 復元 button for admin on a discarded item' do
+      delete logout_path
+      post login_path, params: { email: users(:admin).email, password: 'password' }
+      item = Item.create!(title: 'Test Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+      item.discard
+
+      get edit_admin_item_path(item)
+
+      assert_response :success
+      assert_includes response.body, '復元'
+    end
+
+    test 'edit does not show the 論理削除 button for a non-admin' do
+      item = Item.create!(title: 'Test Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+
+      get edit_admin_item_path(item)
+
+      assert_response :success
+      assert_not_includes response.body, '論理削除'
+    end
+
     test 'index does not show the bulk artist replace UI without an artist search condition' do
       Item.create!(title: 'Some Item', release_date: Date.today,
                    link_url: "https://example.com/item-#{SecureRandom.hex(4)}")

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -286,6 +286,70 @@ module Admin
       assert_nil item.reload.artists.first['key']
     end
 
+    test 'destroy soft-deletes the item instead of destroying the record' do
+      delete logout_path
+      post login_path, params: { email: users(:admin).email, password: 'password' }
+      item = Item.create!(title: 'Target Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+
+      delete admin_item_path(item)
+
+      assert_redirected_to admin_items_path
+      assert item.reload.discarded?
+      assert Item.with_discarded.exists?(item.id)
+    end
+
+    test 'destroy requires admin role' do
+      item = Item.create!(title: 'Target Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+
+      delete admin_item_path(item)
+
+      assert_redirected_to root_path
+      assert_not item.reload.discarded?
+    end
+
+    test 'undiscard restores a discarded item' do
+      delete logout_path
+      post login_path, params: { email: users(:admin).email, password: 'password' }
+      item = Item.create!(title: 'Target Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+      item.discard
+
+      patch undiscard_admin_item_path(item)
+
+      assert_redirected_to admin_items_path
+      assert_not item.reload.discarded?
+    end
+
+    test 'index does not show discarded items by default' do
+      kept = Item.create!(title: 'Kept Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+      discarded = Item.create!(title: 'Discarded Item', release_date: Date.today,
+                               link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+      discarded.discard
+
+      get admin_items_path
+
+      assert_response :success
+      assert_includes response.body, kept.title
+      assert_not_includes response.body, discarded.title
+    end
+
+    test 'index with discarded=only shows only discarded items' do
+      kept = Item.create!(title: 'Kept Item', release_date: Date.today,
+                          link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+      discarded = Item.create!(title: 'Discarded Item', release_date: Date.today,
+                               link_url: "https://example.com/item-#{SecureRandom.hex(4)}")
+      discarded.discard
+
+      get admin_items_path(discarded: 'only')
+
+      assert_response :success
+      assert_includes response.body, discarded.title
+      assert_not_includes response.body, kept.title
+    end
+
     test 'bulk_artist_update requires super_operator role' do
       delete logout_path
       operator = User.create!(email: 'operator-bulk-artist-test@example.com', name: 'Operator', password: 'password', role: :operator)

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -167,6 +167,33 @@ class ItemsControllerTest < ActionDispatch::IntegrationTest # rubocop:disable Me
     assert_not_includes response.body, 'オムニバス の全作品を見る'
   end
 
+  test 'index does not list a discarded item' do
+    item = Item.create!(
+      title: "Discarded Item #{SecureRandom.hex(4)}",
+      release_date: '2026-03-01',
+      link_url: "http://example.com/discarded-index-item-#{SecureRandom.hex(4)}"
+    )
+    item.discard
+
+    get items_path(q: item.title)
+
+    assert_response :success
+    assert_not_includes response.body, item_path(item)
+  end
+
+  test 'show returns 404 for a discarded item' do
+    item = Item.create!(
+      title: 'Discarded Show Item',
+      release_date: '2026-03-01',
+      link_url: "http://example.com/discarded-show-item-#{SecureRandom.hex(4)}"
+    )
+    item.discard
+
+    get item_path(item)
+
+    assert_response :not_found
+  end
+
   test 'index filters by artist name with q param' do
     item = Item.create!(
       title: 'Searchable Artist Item',

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -7,6 +7,7 @@
 #  id              :bigint           not null, primary key
 #  artists         :jsonb            not null
 #  asin            :string
+#  discarded_at    :datetime
 #  image_url       :string
 #  link_url        :string           not null
 #  release_date    :date             not null
@@ -21,6 +22,7 @@
 #  index_items_on_artists       (artists) USING gin
 #  index_items_on_artists_trgm  (((artists)::text) gin_trgm_ops) USING gin
 #  index_items_on_asin          (asin) UNIQUE
+#  index_items_on_discarded_at  (discarded_at)
 #  index_items_on_link_url      (link_url) UNIQUE
 #  index_items_on_release_date  (release_date)
 #  index_items_on_title         (title)
@@ -28,7 +30,7 @@
 #
 require 'test_helper'
 
-class ItemTest < ActiveSupport::TestCase
+class ItemTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
   test 'by_artist_old_key finds an item whose artists array contains the old_key' do
     item = Item.create!(title: 'Some Album', release_date: Date.current, link_url: 'https://example.com/item-old-key',
                         artists: [{ 'name' => 'ムック', 'alias' => 'MUCC', 'old_key' => '%A5%E0%A5%C3%A5%AF' }])
@@ -143,5 +145,26 @@ class ItemTest < ActiveSupport::TestCase
     assert_equal false, result
     item.reload
     assert_equal [{ 'name' => 'ムック', 'old_key' => '%A5%E0%A5%C3%A5%AF' }], item.artists
+  end
+
+  test 'discard sets discarded_at and excludes the item from kept, but with_discarded still includes it' do
+    item = Item.create!(title: 'Some Album', release_date: Date.current, link_url: 'https://example.com/item-discard')
+
+    item.discard
+
+    assert item.discarded?
+    assert_not_includes Item.kept, item
+    assert_includes Item.discarded, item
+    assert_includes Item.with_discarded, item
+  end
+
+  test 'undiscard clears discarded_at and returns the item to kept' do
+    item = Item.create!(title: 'Some Album', release_date: Date.current, link_url: 'https://example.com/item-undiscard')
+    item.discard
+
+    item.undiscard
+
+    assert_not item.discarded?
+    assert_includes Item.kept, item
   end
 end


### PR DESCRIPTION
## Summary
- `items.discarded_at` カラムを追加し、`Item` に `Discard::Model` を include
- `Admin::ItemsController#destroy` を物理削除から `discard` に変更し、`undiscard` アクションを追加
- 管理画面の Item 一覧に 通常/削除済みのみ/全件 のフィルタと復元ボタンを追加（Unit/Personと同じパターン）
- 公開側で論理削除済み Item を除外
  - `ItemsController`（一覧・詳細・関連作品）
  - `ProfilesController#load_items`（ユニット/個人ページの作品一覧）
  - `TrendsController`（動向ページの関連作品）
  - `{{item ASIN}}` プラグイン展開（`application_helper.rb`）
  - ASIN経由の旧URLリダイレクト（`legacy_redirects_controller.rb`）
- `docs/admin/permissions.md` を更新（Items — 削除・復元 に undiscard を追記）

物理削除（purge）は今回のスコープ外としています。Unit/Personほど強い削除ブロック要件が現状無いため、必要になれば別issueで対応します。

## Test plan
- [x] `bin/rails test` が全件パスすること（445 runs, 0 failures）
- [x] `bundle exec rubocop` で警告なし
- [ ] 管理画面でItemを削除→一覧から消える→「削除済みのみ」で表示・復元できることを確認
- [ ] 削除したItemが公開側（一覧・詳細・アーティストページの作品一覧・{{item}}プラグイン）に表示されないことを確認

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)