### PR TITLE
feat: ユニット・個人ページにcanonicalタグを追加する

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,11 @@
 <% content_for :title, @resource.name_kana.present? ? "#{@resource.name}（#{@resource.name_kana}）" : @resource.name %>
 <% content_for :head do %>
   <style>.page-nav-scroll::-webkit-scrollbar { display: none; }</style>
+  <% if Rails.application.config.canonical_host.present? %>
+    <%# TODO: 本番ドメイン（www.vkdb.jp）への切り替え完了後、この canonical タグ出力と
+        config.canonical_host（CANONICAL_HOST）ごと削除する（issue #1208） %>
+    <%= tag.link rel: "canonical", href: "https://#{Rails.application.config.canonical_host}#{request.path}" %>
+  <% end %>
 <% end %>
 <div class="flex justify-center">
   <div class="bg-white dark:bg-slate-800 shadow-2xl rounded-none md:rounded-3xl md:overflow-hidden w-full min-w-0 max-w-5xl animate-in slide-in-from-bottom-5 duration-700" data-google-adsense-noads>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,13 @@ module Vkdby
     # Only relevant during the migration period; remove once the old site is retired.
     config.old_key_url_base = ENV.fetch('OLD_KEY_URL_BASE', 'https://wiki.vkdb.jp')
 
+    # Canonical host for <link rel="canonical"> on unit/person pages (issue #1208).
+    # Currently running on a pre-production subdomain that differs from the production
+    # domain (www.vkdb.jp); set to prevent the subdomain from being indexed as the
+    # canonical source. TODO: once the production domain switch is complete, remove
+    # this setting and the canonical tag output that references it.
+    config.canonical_host = ENV.fetch('CANONICAL_HOST', nil)
+
     # Google Custom Search Engine ID, offered as a supplementary web-wide search
     # option alongside the internal DB search on error pages (issue #962).
     config.google_cse_id = ENV.fetch('GOOGLE_CSE_ID', '012501366286233936630:nhzl-0aow2y')

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -97,6 +97,20 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, 'inactive section body'
   end
 
+  test 'does not render a canonical tag when canonical_host is not configured' do
+    unit = Unit.create!(name: 'No Canonical Unit', key: 'unit-no-canonical', status: :active)
+    get profile_path(unit.key)
+    assert_response :success
+    assert_not_includes response.body, 'rel="canonical"'
+  end
+
+  test 'renders a canonical tag pointing at the configured canonical host' do
+    unit = Unit.create!(name: 'Canonical Unit', key: 'unit-canonical', status: :active)
+    with_canonical_host('www.vkdb.jp') { get profile_path(unit.key) }
+    assert_response :success
+    assert_includes response.body, "<link rel=\"canonical\" href=\"https://www.vkdb.jp#{profile_path(unit.key)}\">"
+  end
+
   test 'unit trend list shows the recorded name when it differs from the current unit name' do
     unit = Unit.create!(name: 'Renamed Trend Unit', key: 'unit-trend-name-badge', status: :active)
     Trend.create!(title: 'Trend before rename', date: Date.current, publish_start_at: Time.current,
@@ -106,5 +120,15 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, 'Old Trend Unit Name'
+  end
+
+  private
+
+  def with_canonical_host(host)
+    original = Rails.application.config.canonical_host
+    Rails.application.config.canonical_host = host
+    yield
+  ensure
+    Rails.application.config.canonical_host = original
   end
 end


### PR DESCRIPTION
## Summary
- `ProfilesController#show`（ユニット・個人ページ）の `<head>` に `<link rel="canonical" href="...">` を出力する
- canonical のホスト名は `config.canonical_host`（`CANONICAL_HOST` env、デフォルト未設定）で切り替え、未設定時は出力しない
- 本番ドメイン（www.vkdb.jp）切り替え完了後に削除できるようTODOコメントを付与

## Test plan
- [x] `bundle exec rails test` が全件パスすること
- [x] `bundle exec rubocop` がクリーンであること
- [x] `canonical_host` 未設定時にcanonicalタグが出力されないこと（テストで確認）
- [x] `canonical_host` 設定時に正しいhrefでcanonicalタグが出力されること（テストで確認）

Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)