### PR TITLE
feat: 管理画面Item一覧でアーティスト名の部分一致検索に対応

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -20,7 +20,12 @@ module Admin
               else             Item.kept
               end
       scope = scope.order(release_date: :desc)
-      scope = scope.where('title ILIKE :q OR asin ILIKE :q', q: "%#{@q}%") if @q.present?
+      if @q.present?
+        scope = scope.where(
+          'title ILIKE :q OR asin ILIKE :q OR artists::text ILIKE :q',
+          q: "%#{normalize_search_query(@q)}%"
+        )
+      end
       scope = scope.public_send(:"by_artist_#{@match_type}", @match_value) if @match_type.present? && @match_value.present?
       @pagy, @items = pagy(scope)
 

--- a/app/views/admin/items/_items_table.html.erb
+++ b/app/views/admin/items/_items_table.html.erb
@@ -82,7 +82,7 @@
               <% end %>
             <% else %>
               <% if current_user.super_operator_or_above? %>
-                <%= link_to "Edit", edit_admin_item_path(item), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
+                <%= link_to "編集", edit_admin_item_path(item), class: "text-indigo-600 hover:text-indigo-900 mr-4" %>
               <% end %>
               <% if current_user.admin? %>
                 <%= button_to "論理削除", admin_item_path(item), method: :delete,

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -4,7 +4,7 @@
   <div class="flex items-center justify-between mb-4">
     <h1 class="text-2xl font-bold"><%= title %></h1>
     <% if current_user.super_operator_or_above? %>
-      <%= link_to "Add Item", new_admin_item_path, class: "px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700" %>
+      <%= link_to "新規追加", new_admin_item_path, class: "px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700" %>
     <% end %>
   </div>
 
@@ -12,8 +12,8 @@
     <%= f.hidden_field :discarded, value: params[:discarded] %>
     <div class="flex flex-wrap items-end gap-2">
       <div>
-        <%= label_tag :q, "タイトル / ASIN で検索", class: "block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1" %>
-        <%= text_field_tag :q, params[:q], placeholder: "タイトルまたはASIN", class: "rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-base w-64 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
+        <%= label_tag :q, "タイトル / ASIN / アーティスト名で検索", class: "block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1" %>
+        <%= text_field_tag :q, params[:q], placeholder: "タイトル・ASIN・アーティスト名（部分一致）", class: "rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-base w-96 dark:bg-gray-700 dark:border-gray-600 dark:text-white" %>
       </div>
     </div>
 
@@ -31,7 +31,7 @@
       <%= submit_tag "検索", class: "px-4 py-2 bg-white text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 cursor-pointer dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600" %>
     </div>
     <p class="text-xs text-gray-500 dark:text-gray-400">
-      Item に紐づいているアーティストの old_key / key / name / alias（表示名）で絞り込みます。一致した Item にはチェックボックスが表示され、まとめて別の Unit/Person に差し替えられます。
+      Item に紐づいているアーティストの old_key / key / name / alias（表示名）との完全一致で絞り込みます。一致した Item にはチェックボックスが表示され、まとめて別の Unit/Person に差し替えられます。
     </p>
   <% end %>
 

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -133,6 +133,32 @@ module Admin
       assert_not_includes response.body, '論理削除'
     end
 
+    test 'index filters by artist name with q param' do
+      matching = Item.create!(title: 'Matching Item', release_date: Date.today,
+                              link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                              artists: [{ 'name' => 'ムック' }])
+      other = Item.create!(title: 'Other Item', release_date: Date.today,
+                           link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                           artists: [{ 'name' => 'Other Artist' }])
+
+      get admin_items_path(q: 'ムック')
+
+      assert_response :success
+      assert_includes response.body, matching.title
+      assert_not_includes response.body, other.title
+    end
+
+    test 'index filters by artist name with full-width alphanumeric q param' do
+      matching = Item.create!(title: 'Matching Item', release_date: Date.today,
+                              link_url: "https://example.com/item-#{SecureRandom.hex(4)}",
+                              artists: [{ 'name' => 'ABC123' }])
+
+      get admin_items_path(q: 'ＡＢＣ１２３')
+
+      assert_response :success
+      assert_includes response.body, matching.title
+    end
+
     test 'index does not show the bulk artist replace UI without an artist search condition' do
       Item.create!(title: 'Some Item', release_date: Date.today,
                    link_url: "https://example.com/item-#{SecureRandom.hex(4)}")


### PR DESCRIPTION
## Summary
- 管理画面のアイテム一覧 `q` 検索に、公開側と同様のアーティスト名（バンド名等）部分一致検索を追加（`artists::text ILIKE`）
- `normalize_search_query` による全角/半角正規化も合わせて適用
- 既存の `match_type`/`match_value` によるアーティスト完全一致検索（一括差し替え機能向け）とは役割が異なることが分かるよう、検索フォームのラベル・説明文を整備
- 「Add Item」「Edit」ボタンを、他のボタン（復元・論理削除など）と表記を揃えて日本語化（新規追加・編集）

## Test plan
- [x] `bin/rails test` が全件パスすること（454 runs, 0 failures）
- [x] RuboCop クリーン
- [ ] 管理画面アイテム一覧で `q` にアーティスト名（部分一致・全角）を入力して絞り込めることを確認

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)