### PR TITLE
fix: markdown画像のwidth/heightキャッシュがnilを永続化する不具合を修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,13 +67,18 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     # メタデータ（width/height）を引く。外部URLの画像や、解析が行われていない
     # （metadataにwidth/heightが記録されていない）blobの場合はnilを返し、
     # 呼び出し側はwidth/height属性を出力しない（ベストエフォート）。
-    # signed_idごとにRails.cacheへ結果をキャッシュする（画像が差し替えられた場合は
-    # blob自体・signed_idが変わるため自然に無効化される。issue #1215）。
+    # 見つかった場合のみsigned_idごとにRails.cacheへ結果をキャッシュする（画像が
+    # 差し替えられた場合はblob自体・signed_idが変わるため自然に無効化される。issue #1215）。
+    # skip_nil: true必須: 解析未完了（width/height無し）の結果までキャッシュしてしまうと、
+    # その後の解析（rakeタスクや新規アップロード時の非同期解析）でメタデータが埋まっても
+    # 「無し」という結果がTTL分（最大7日）居座り続けページに反映されない
+    # （実運用でblobをrakeタスクで解析済みにした後もwidth/heightが出ない事象で発覚）。
     def image_dimensions_for(link)
       match = link.to_s.match(IMAGE_BLOB_URL_PATTERN)
       return nil unless match
 
-      Rails.cache.fetch(['markdown_image_dimensions', match[1]], expires_in: IMAGE_DIMENSIONS_CACHE_TTL) do
+      Rails.cache.fetch(['markdown_image_dimensions', match[1]], expires_in: IMAGE_DIMENSIONS_CACHE_TTL,
+                                                                 skip_nil: true) do
         blob = ActiveStorage::Blob.find_signed(match[1])
         width = blob&.metadata&.[]('width')
         height = blob&.metadata&.[]('height')

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -756,6 +756,22 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_no_match(/height=/, result)
   end
 
+  test '解析未完了(width/height無し)の結果はキャッシュされず、後から解析が完了すれば反映される(issue #1215)' do
+    with_memory_cache_store do
+      blob = create_image_blob(width: nil, height: nil)
+      src = rails_blob_path(blob, only_path: true)
+
+      before = markdown("![alt](#{src})")
+      assert_no_match(/width=/, before)
+
+      # rakeタスク(active_storage:analyze_images)相当: 後からmetadataが埋まるケース
+      blob.update!(metadata: blob.metadata.merge('width' => 400, 'height' => 150))
+
+      after = markdown("![alt](#{src})")
+      assert_match(/<img[^>]+width="400"[^>]+height="150"/, after)
+    end
+  end
+
   test 'prioritize_first_image: true の場合、本文最初の画像のみfetchpriority="high"が付与される(issue #1215)' do
     blob = create_image_blob(width: 400, height: 150)
     src = rails_blob_path(blob, only_path: true)


### PR DESCRIPTION
## Summary
- PR #1225（issue #1215）マージ後、本番で `active_storage:analyze_images` を実行してblobのwidth/heightをmetadataに補完したにもかかわらず、ページ上のwidth/height属性が付与されないままだった不具合を修正
- 原因: `image_dimensions_for` の `Rails.cache.fetch` が、blob解析未完了（width/height無し）の結果もそのままキャッシュしていた（Railsの`fetch`はデフォルトでnilもキャッシュするため）。解析前に一度でもページが描画されると、「無し」という結果が最大7日間キャッシュに残り、後からblobが解析されても反映されなくなっていた
- `skip_nil: true` を指定し、width/heightが見つからなかった場合はキャッシュに書き込まないよう修正

## Test plan
- [x] `bin/rails test` が全件パスすること（460 runs, 0 failures）
- [x] rubocop がクリーンであること
- [x] 新規テストで「未解析時はキャッシュされず、後から解析が完了すれば次回描画で反映される」ことを確認
- [ ] 本番デプロイ後、Redisキャッシュに既に居座っている「無し」の結果をクリアする必要あり（既存のキャッシュエントリはこの修正だけでは解消されないため、`Rails.cache.delete_matched('markdown_image_dimensions*')` 等でクリアするか、TTL失効を待つ）

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)