### PR TITLE
feat: 全ページ共通のmeta descriptionを追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -152,6 +152,16 @@ module ApplicationHelper # rubocop:disable Metrics/ModuleLength
     CGI.unescapeHTML(text.to_s).gsub('&', '&amp;').gsub('<', '&lt;').html_safe
   end
 
+  # meta descriptionはHTML属性値（content="..."）として出力するため、page_title_textと違い
+  # "&"と"<"だけでなく">"や引用符も含めてエスケープする必要がある。
+  # content_for(:description, ...)にプレーン文字列を渡した場合も、page_title_textと同様に
+  # ActionViewの内部バッファ格納時に一度HTMLエスケープされる可能性があるため、
+  # 一度デコードしてから属性値として正しくエスケープし直す。
+  # 検索結果のスニペットとして不自然に途切れないよう、150〜160字程度に切り詰める。
+  def meta_description_text(text)
+    ERB::Util.html_escape(CGI.unescapeHTML(text.to_s).truncate(160, separator: ' '))
+  end
+
   # prioritize_first_image: 本文中最初の画像にfetchpriority="high"を付与するか
   # （LCP対策、issue #1215）。ヘッダー/フッターの短いメッセージや、1ページに複数回
   # 展開されるSection（ユニット/人物ページ）では意図せず複数箇所が高優先度になり得るため、

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html class="motion-safe:scroll-smooth">
   <head>
     <title><%= page_title_text(content_for?(:title) ? "#{yield(:title)} - #{Rails.application.config.site_name}" : Rails.application.config.site_name) %></title>
+    <meta name="description" content="<%= meta_description_text(content_for?(:description) ? yield(:description) : Rails.application.config.site_description) %>">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Vkdby">

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,12 @@ module Vkdby
     # Site name used in page titles
     config.site_name = ENV.fetch('SITE_NAME', 'vkdb.jp')
 
+    # Default meta description for pages that don't set content_for(:description) (issue #1223)
+    config.site_description = ENV.fetch(
+      'SITE_DESCRIPTION',
+      'ヴィジュアル系バンド・アーティストのデータベース。ユニットやメンバーの結成・脱退・改名などの活動履歴、プロフィール、動向、年表を掲載しています。'
+    )
+
     # Base URL for old-key links to the legacy site (issue #946).
     # Only relevant during the migration period; remove once the old site is retired.
     config.old_key_url_base = ENV.fetch('OLD_KEY_URL_BASE', 'https://wiki.vkdb.jp')


### PR DESCRIPTION
## Summary
- layoutに `<meta name="description">` タグを追加し、`content_for(:description)` が未設定のページではデフォルトのサイト説明文（`config.site_description` / `SITE_DESCRIPTION` 環境変数）を出力する
- `ApplicationHelper#meta_description_text` を追加。`page_title_text` と同様に二重エスケープを避けつつ、属性値として `&`/`<`/`>`/引用符を正しくエスケープし、150〜160字程度に切り詰める
- 開発サーバーで `/`・`/units`・`/people`・`/search` を確認し、いずれも正しくmeta descriptionが出力されることを確認済み

なお、Unit/Person詳細・トップページ・動向詳細など、内容が動的に決まるページへの個別description設定（フェーズ2）は #1235 として別issue化した

## Test plan
- [x] `bin/rails test` が全件パスすること（460 runs, 0 failures）
- [x] `bundle exec rubocop` で新規オフェンスなし
- [x] 開発サーバーでトップページ・一覧ページのmeta descriptionをcurlで目視確認

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)